### PR TITLE
feat: add network health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ LowTime is a web-first calling app for people on weak or expensive internet conn
 - Monorepo scaffolding is in place for `apps/web`, `apps/server`, and `packages/shared`.
 - Docker Compose baseline is in place for local development and single-host deployment.
 - CI and linting baseline is in place for pull requests and pushes to `main`.
-- Room creation, share-link generation, public join admission, SFU token handoff, and the first basic in-call UI are in place for the core 1:1 flow.
+- Room creation, share-link generation, public join admission, SFU token handoff, the first basic in-call UI, and a network health badge are in place for the core 1:1 flow.
 
 ## Planned Stack
 - Web client: React + TypeScript + PWA shell

--- a/TODO.md
+++ b/TODO.md
@@ -38,7 +38,7 @@
 | Join screen with device preview | `planned` | Includes permission flow and preset selection | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
 | SFU integration for 1:1 rooms | `done` | Issue #7. Added LiveKit token issuance, a minimal `/r/:slug/call` handoff, and a web SFU connection flow for direct joins | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Basic in-call UI | `done` | Issue #8. Added a usable call screen with remote tile area, local self-view, and mute/camera/leave controls on the LiveKit path | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
-| Network health badge | `planned` | Surface degraded connectivity to the user | [docs/10-observability-and-operations.md](docs/10-observability-and-operations.md) |
+| Network health badge | `done` | Issue #9. Added a call-header badge that reflects offline, reconnecting, poor, fair, and good network states from browser connectivity heuristics | [docs/10-observability-and-operations.md](docs/10-observability-and-operations.md) |
 | PWA shell and installability | `planned` | Manifest, shell caching, and install prompt behavior | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
 
 ## Phase 2: Admission Control And Recovery

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -90,9 +90,9 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    const syncNetworkHealth = () => {
-      const connection = getNavigatorConnection();
+    const connection = getNavigatorConnection();
 
+    const syncNetworkHealth = () => {
       setNetworkHealth(
         assessNetworkHealth({
           callStatus,
@@ -105,7 +105,6 @@ export function App() {
 
     syncNetworkHealth();
 
-    const connection = getNavigatorConnection();
     window.addEventListener("online", syncNetworkHealth);
     window.addEventListener("offline", syncNetworkHealth);
     connection?.addEventListener?.("change", syncNetworkHealth);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -17,6 +17,7 @@ import {
   type VideoTrackLike,
 } from "./call-experience.js";
 import { connectToSfu } from "./media-controller.js";
+import { assessNetworkHealth, getNetworkHealthLabel, type NetworkHealth } from "./network-health.js";
 import {
   buildRequestedMedia,
   clearStoredCallSession,
@@ -61,6 +62,12 @@ export function App() {
   const [localVideoTrack, setLocalVideoTrack] = useState<VideoTrackLike | null>(null);
   const [remoteVideoTrack, setRemoteVideoTrack] = useState<VideoTrackLike | null>(null);
   const [remoteParticipantLabel, setRemoteParticipantLabel] = useState<string>("Waiting for someone to join");
+  const [networkHealth, setNetworkHealth] = useState<NetworkHealth>(() =>
+    assessNetworkHealth({
+      callStatus: "idle",
+      isOnline: typeof navigator === "undefined" ? true : navigator.onLine,
+    }),
+  );
 
   const apiBaseUrl = useMemo(
     () => getApiBaseUrl(import.meta.env.VITE_API_BASE_URL, window.location),
@@ -81,6 +88,34 @@ export function App() {
       window.removeEventListener("popstate", handlePopState);
     };
   }, []);
+
+  useEffect(() => {
+    const syncNetworkHealth = () => {
+      const connection = getNavigatorConnection();
+
+      setNetworkHealth(
+        assessNetworkHealth({
+          callStatus,
+          isOnline: typeof navigator === "undefined" ? true : navigator.onLine,
+          effectiveType: connection?.effectiveType,
+          rtt: connection?.rtt,
+        }),
+      );
+    };
+
+    syncNetworkHealth();
+
+    const connection = getNavigatorConnection();
+    window.addEventListener("online", syncNetworkHealth);
+    window.addEventListener("offline", syncNetworkHealth);
+    connection?.addEventListener?.("change", syncNetworkHealth);
+
+    return () => {
+      window.removeEventListener("online", syncNetworkHealth);
+      window.removeEventListener("offline", syncNetworkHealth);
+      connection?.removeEventListener?.("change", syncNetworkHealth);
+    };
+  }, [callStatus]);
 
   useEffect(() => {
     if (viewState.kind === "room") {
@@ -478,8 +513,13 @@ export function App() {
             <h1>LowTime</h1>
             <p style={mutedParagraphStyle}>Room <code>{viewState.slug}</code></p>
           </div>
-          <div style={callStatusBadgeStyle(callStatus)}>
-            {callStatus.replace("_", " ")}
+          <div style={callHeaderBadgeRowStyle}>
+            <div style={networkBadgeStyle(networkHealth)}>
+              {getNetworkHealthLabel(networkHealth)}
+            </div>
+            <div style={callStatusBadgeStyle(callStatus)}>
+              {callStatus.replace("_", " ")}
+            </div>
           </div>
         </section>
         {callSession ? (
@@ -705,6 +745,13 @@ const callHeaderStyle = {
   flexWrap: "wrap",
 } as const;
 
+const callHeaderBadgeRowStyle = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.75rem",
+  flexWrap: "wrap",
+} as const;
+
 const callLayoutStyle = {
   display: "grid",
   gap: "1rem",
@@ -835,4 +882,51 @@ function callStatusBadgeStyle(callStatus: "idle" | "requesting_token" | "connect
     fontWeight: 600,
     textTransform: "capitalize" as const,
   };
+}
+
+function networkBadgeStyle(networkHealth: NetworkHealth) {
+  return {
+    borderRadius: "999px",
+    padding: "0.5rem 0.75rem",
+    background:
+      networkHealth === "good"
+        ? "#dcfce7"
+        : networkHealth === "fair"
+          ? "#fef3c7"
+          : networkHealth === "poor"
+            ? "#fee2e2"
+            : networkHealth === "offline"
+              ? "#e2e8f0"
+              : "#dbeafe",
+    color:
+      networkHealth === "good"
+        ? "#166534"
+        : networkHealth === "fair"
+          ? "#92400e"
+          : networkHealth === "poor"
+            ? "#b91c1c"
+            : networkHealth === "offline"
+              ? "#334155"
+              : "#1d4ed8",
+    fontWeight: 600,
+  };
+}
+
+interface NavigatorConnectionLike extends EventTarget {
+  effectiveType?: string;
+  rtt?: number;
+}
+
+function getNavigatorConnection(): NavigatorConnectionLike | null {
+  if (typeof navigator === "undefined") {
+    return null;
+  }
+
+  const candidate = navigator as Navigator & {
+    connection?: NavigatorConnectionLike;
+    mozConnection?: NavigatorConnectionLike;
+    webkitConnection?: NavigatorConnectionLike;
+  };
+
+  return candidate.connection ?? candidate.mozConnection ?? candidate.webkitConnection ?? null;
 }

--- a/apps/web/src/network-health.test.ts
+++ b/apps/web/src/network-health.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { assessNetworkHealth, getNetworkHealthLabel } from "./network-health.js";
+
+test("assessNetworkHealth returns offline when browser is offline", () => {
+  assert.equal(
+    assessNetworkHealth({
+      callStatus: "connected",
+      isOnline: false,
+    }),
+    "offline",
+  );
+});
+
+test("assessNetworkHealth returns reconnecting before the call is fully connected", () => {
+  assert.equal(
+    assessNetworkHealth({
+      callStatus: "connecting",
+      isOnline: true,
+    }),
+    "reconnecting",
+  );
+});
+
+test("assessNetworkHealth returns poor for weak connection indicators", () => {
+  assert.equal(
+    assessNetworkHealth({
+      callStatus: "connected",
+      isOnline: true,
+      effectiveType: "2g",
+    }),
+    "poor",
+  );
+
+  assert.equal(
+    assessNetworkHealth({
+      callStatus: "connected",
+      isOnline: true,
+      rtt: 900,
+    }),
+    "poor",
+  );
+});
+
+test("assessNetworkHealth returns fair for moderate connection indicators", () => {
+  assert.equal(
+    assessNetworkHealth({
+      callStatus: "connected",
+      isOnline: true,
+      effectiveType: "3g",
+    }),
+    "fair",
+  );
+
+  assert.equal(
+    assessNetworkHealth({
+      callStatus: "connected",
+      isOnline: true,
+      rtt: 300,
+    }),
+    "fair",
+  );
+});
+
+test("assessNetworkHealth returns good for healthy connected state", () => {
+  assert.equal(
+    assessNetworkHealth({
+      callStatus: "connected",
+      isOnline: true,
+      effectiveType: "4g",
+      rtt: 100,
+    }),
+    "good",
+  );
+});
+
+test("getNetworkHealthLabel maps statuses to user-facing copy", () => {
+  assert.equal(getNetworkHealthLabel("good"), "Good network");
+  assert.equal(getNetworkHealthLabel("fair"), "Fair network");
+  assert.equal(getNetworkHealthLabel("poor"), "Poor network");
+  assert.equal(getNetworkHealthLabel("reconnecting"), "Reconnecting");
+  assert.equal(getNetworkHealthLabel("offline"), "Offline");
+});

--- a/apps/web/src/network-health.ts
+++ b/apps/web/src/network-health.ts
@@ -1,0 +1,48 @@
+export type NetworkHealth = "offline" | "reconnecting" | "poor" | "fair" | "good";
+
+export interface NetworkAssessmentInput {
+  callStatus: "idle" | "requesting_token" | "connecting" | "connected";
+  isOnline: boolean;
+  effectiveType?: string;
+  rtt?: number;
+}
+
+export function assessNetworkHealth(input: NetworkAssessmentInput): NetworkHealth {
+  if (!input.isOnline) {
+    return "offline";
+  }
+
+  if (input.callStatus !== "connected") {
+    return "reconnecting";
+  }
+
+  const effectiveType = input.effectiveType?.toLowerCase();
+  const rtt = input.rtt;
+
+  if (effectiveType === "slow-2g" || effectiveType === "2g" || (rtt != null && rtt >= 600)) {
+    return "poor";
+  }
+
+  if (effectiveType === "3g" || (rtt != null && rtt >= 250)) {
+    return "fair";
+  }
+
+  return "good";
+}
+
+export function getNetworkHealthLabel(networkHealth: NetworkHealth): string {
+  switch (networkHealth) {
+    case "offline":
+      return "Offline";
+    case "reconnecting":
+      return "Reconnecting";
+    case "poor":
+      return "Poor network";
+    case "fair":
+      return "Fair network";
+    case "good":
+      return "Good network";
+    default:
+      return "Network unknown";
+  }
+}

--- a/docs/07-frontend-architecture.md
+++ b/docs/07-frontend-architecture.md
@@ -93,4 +93,4 @@ The frontend is a React + TypeScript PWA optimized for mobile browsers first. It
 - Keep contract types in a shared package consumed by the client.
 - Build the media controller as a dedicated subsystem rather than mixing it into UI components.
 - Treat PWA support as shell enhancement, not as offline call support.
-- Current implementation supports room creation, display-name join on `/r/:slug`, and a basic `/r/:slug/call` route with local self-view, remote tile area, and mute/camera/leave controls on top of LiveKit.
+- Current implementation supports room creation, display-name join on `/r/:slug`, and a basic `/r/:slug/call` route with local self-view, remote tile area, mute/camera/leave controls, and a lightweight network health badge on top of LiveKit.

--- a/docs/10-observability-and-operations.md
+++ b/docs/10-observability-and-operations.md
@@ -85,3 +85,4 @@ B --> K
 - Tag metrics by browser, device class, transport, and preset where possible.
 - Redact secrets in logs, traces, and error reporting by default.
 - Keep dashboard ownership clear once the team grows.
+- Current implementation exposes a client-side network health badge in the call header using browser online state plus lightweight connection heuristics; deeper transport-quality metrics are still future work.


### PR DESCRIPTION
## Summary
- add a call-header network health badge that reflects offline, reconnecting, poor, fair, and good states from browser connectivity heuristics
- add focused network health helper tests and wire the badge into the existing call experience
- update the README, frontend architecture doc, observability doc, and implementation tracker for the shipped badge behavior

## Verification
```bash
npm run test --workspace @lowtime/web
npm run typecheck --workspace @lowtime/web
npm run build --workspace @lowtime/web
```

Closes #9