### PR TITLE
feat: add pwa shell and install prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - Purpose: Provide a short project entry point, explain the product, and route contributors to the correct detailed docs.
 - Audience: New engineers, product collaborators, designers, and operators.
 - Status: Baseline
-- Last Updated: 2026-03-24
+- Last Updated: 2026-03-25
 - Related Docs: [Contributing](CONTRIBUTING.md), [Docs Map](docs/00-docs-map.md), [Product Overview](docs/01-product-overview.md), [System Architecture](docs/02-system-architecture.md)
 
 LowTime is a web-first calling app for people on weak or expensive internet connections. It is designed to feel as easy as opening a FaceTime link, but with stronger low-bandwidth behavior, flexible quality controls, and no account requirement.
@@ -20,7 +20,7 @@ LowTime is a web-first calling app for people on weak or expensive internet conn
 - Monorepo scaffolding is in place for `apps/web`, `apps/server`, and `packages/shared`.
 - Docker Compose baseline is in place for local development and single-host deployment.
 - CI and linting baseline is in place for pull requests and pushes to `main`.
-- Room creation, share-link generation, public join admission, SFU token handoff, the first basic in-call UI, and a network health badge are in place for the core 1:1 flow.
+- Room creation, share-link generation, public join admission, SFU token handoff, the first basic in-call UI, the network health badge, and the installable PWA shell are in place for the core 1:1 flow.
 
 ## Planned Stack
 - Web client: React + TypeScript + PWA shell

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 - Purpose: Track implementation progress feature by feature and provide one living checklist that must be updated whenever work lands.
 - Audience: Engineers, reviewers, and release owners.
 - Status: Active
-- Last Updated: 2026-03-24
+- Last Updated: 2026-03-25
 - Related Docs: [README](README.md), [Docs Map](docs/00-docs-map.md), [Roadmap And Release Phases](docs/12-roadmap-and-release-phases.md), [Testing And QA](docs/11-testing-and-qa.md)
 
 ## How To Use This File
@@ -39,7 +39,7 @@
 | SFU integration for 1:1 rooms | `done` | Issue #7. Added LiveKit token issuance, a minimal `/r/:slug/call` handoff, and a web SFU connection flow for direct joins | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Basic in-call UI | `done` | Issue #8. Added a usable call screen with remote tile area, local self-view, and mute/camera/leave controls on the LiveKit path | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
 | Network health badge | `done` | Issue #9. Added a call-header badge that reflects offline, reconnecting, poor, fair, and good network states from browser connectivity heuristics | [docs/10-observability-and-operations.md](docs/10-observability-and-operations.md) |
-| PWA shell and installability | `planned` | Manifest, shell caching, and install prompt behavior | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
+| PWA shell and installability | `done` | Issue #10. Added a manifest, shell caching service worker, app icons, and a landing-page install prompt | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
 
 ## Phase 2: Admission Control And Recovery
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Low-bandwidth video calling with fast, no-registration room links." />
+    <meta name="theme-color" content="#0f172a" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" href="/icons/app-icon.svg" type="image/svg+xml" />
     <title>LowTime</title>
   </head>
   <body>
@@ -10,4 +16,3 @@
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>
-

--- a/apps/web/public/icons/app-icon-maskable.svg
+++ b/apps/web/public/icons/app-icon-maskable.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title">
+  <title>LowTime</title>
+  <rect width="512" height="512" fill="#020617" />
+  <circle cx="256" cy="256" r="184" fill="#0f172a" />
+  <rect x="144" y="168" width="136" height="176" rx="28" fill="#e2e8f0" />
+  <path d="M276 223.2 370.738 168c12.307-7.198 28.262 1.678 28.262 15.925v144.15c0 14.247-15.955 23.123-28.262 15.925L276 288.8v-65.6Z" fill="#38bdf8" />
+  <path d="M187 212h51v26h-25v24h22v26h-22v51h-26v-127Z" fill="#0f172a" />
+  <path d="M248 212h26v127h-26V212Z" fill="#0f172a" />
+</svg>

--- a/apps/web/public/icons/app-icon.svg
+++ b/apps/web/public/icons/app-icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title">
+  <title>LowTime</title>
+  <rect width="256" height="256" rx="56" fill="#0f172a" />
+  <path d="M64 88c0-13.255 10.745-24 24-24h56c13.255 0 24 10.745 24 24v80c0 13.255-10.745 24-24 24H88c-13.255 0-24-10.745-24-24V88Z" fill="#e2e8f0" />
+  <path d="M146 112.8 195.238 84c6.4-3.745 14.762.873 14.762 8.287v71.426c0 7.414-8.362 12.032-14.762 8.287L146 143.2v-30.4Z" fill="#38bdf8" />
+  <path d="M94 108h27.5v14H108v13h12v14h-12v27H94v-68Z" fill="#0f172a" />
+  <path d="M132 108h14v68h-14v-68Z" fill="#0f172a" />
+</svg>

--- a/apps/web/public/manifest.webmanifest
+++ b/apps/web/public/manifest.webmanifest
@@ -1,0 +1,24 @@
+{
+  "name": "LowTime",
+  "short_name": "LowTime",
+  "description": "Low-bandwidth video calling with fast, no-registration room links.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#020617",
+  "theme_color": "#0f172a",
+  "icons": [
+    {
+      "src": "/icons/app-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/app-icon-maskable.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/apps/web/public/service-worker.js
+++ b/apps/web/public/service-worker.js
@@ -1,0 +1,53 @@
+const CACHE_NAME = "lowtime-shell-v1";
+const SHELL_ASSETS = [
+  "/",
+  "/manifest.webmanifest",
+  "/icons/app-icon.svg",
+  "/icons/app-icon-maskable.svg",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(SHELL_ASSETS)),
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) =>
+      Promise.all(
+        cacheNames
+          .filter((cacheName) => cacheName !== CACHE_NAME)
+          .map((cacheName) => caches.delete(cacheName)),
+      ),
+    ),
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") {
+    return;
+  }
+
+  const requestUrl = new URL(event.request.url);
+
+  if (requestUrl.origin !== self.location.origin || requestUrl.pathname.startsWith("/api/")) {
+    return;
+  }
+
+  if (event.request.mode === "navigate") {
+    event.respondWith(
+      fetch(event.request).catch(async () => {
+        const cache = await caches.open(CACHE_NAME);
+        return (await cache.match("/")) ?? Response.error();
+      }),
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => cachedResponse ?? fetch(event.request)),
+  );
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -19,6 +19,12 @@ import {
 import { connectToSfu } from "./media-controller.js";
 import { assessNetworkHealth, getNetworkHealthLabel, type NetworkHealth } from "./network-health.js";
 import {
+  attachInstallPromptListeners,
+  isPwaInstalled,
+  promptForInstallation,
+  type BeforeInstallPromptEvent,
+} from "./pwa.js";
+import {
   buildRequestedMedia,
   clearStoredCallSession,
   getApiBaseUrl,
@@ -68,6 +74,10 @@ export function App() {
       isOnline: typeof navigator === "undefined" ? true : navigator.onLine,
     }),
   );
+  const [deferredInstallPrompt, setDeferredInstallPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [installMessage, setInstallMessage] = useState<string | null>(null);
+  const [isInstallingApp, setIsInstallingApp] = useState(false);
+  const [isStandaloneApp, setIsStandaloneApp] = useState(() => getStandaloneAppState());
 
   const apiBaseUrl = useMemo(
     () => getApiBaseUrl(import.meta.env.VITE_API_BASE_URL, window.location),
@@ -87,6 +97,23 @@ export function App() {
     return () => {
       window.removeEventListener("popstate", handlePopState);
     };
+  }, []);
+
+  useEffect(() => {
+    setIsStandaloneApp(getStandaloneAppState());
+
+    return attachInstallPromptListeners(window, {
+      onPromptAvailable: (event) => {
+        setDeferredInstallPrompt(event);
+        setInstallMessage("Install LowTime for faster access from your home screen.");
+      },
+      onInstalled: () => {
+        setDeferredInstallPrompt(null);
+        setIsInstallingApp(false);
+        setIsStandaloneApp(true);
+        setInstallMessage("LowTime is installed and ready to launch like an app.");
+      },
+    });
   }, []);
 
   useEffect(() => {
@@ -390,6 +417,26 @@ export function App() {
     }
 
     await navigator.clipboard.writeText(toAbsoluteJoinUrl(createResult.joinUrl));
+  }
+
+  async function handleInstallApp() {
+    if (deferredInstallPrompt == null) {
+      return;
+    }
+
+    setIsInstallingApp(true);
+
+    try {
+      const outcome = await promptForInstallation(deferredInstallPrompt);
+      setDeferredInstallPrompt(null);
+      setInstallMessage(
+        outcome === "accepted"
+          ? "Install accepted. Your browser will finish adding LowTime."
+          : "Install dismissed. You can still add LowTime from your browser menu later.",
+      );
+    } finally {
+      setIsInstallingApp(false);
+    }
   }
 
   function handleOpenRoom() {
@@ -697,6 +744,21 @@ export function App() {
     <main>
       <h1>LowTime</h1>
       <p>Create a room fast, share the link, and move directly into the SFU-backed join flow.</p>
+      {isStandaloneApp || deferredInstallPrompt || installMessage ? (
+        <section style={installCardStyle}>
+          <h2 style={installHeadingStyle}>App Access</h2>
+          <p style={mutedParagraphStyle}>
+            {isStandaloneApp
+              ? "LowTime is already installed on this device."
+              : installMessage ?? "Add LowTime to your home screen for faster repeat joins."}
+          </p>
+          {!isStandaloneApp && deferredInstallPrompt ? (
+            <button type="button" onClick={() => void handleInstallApp()} disabled={isInstallingApp}>
+              {isInstallingApp ? "Opening Install Prompt..." : "Install LowTime"}
+            </button>
+          ) : null}
+        </section>
+      ) : null}
       <button type="button" onClick={() => void handleCreateRoom()} disabled={isCreating}>
         {isCreating ? "Creating..." : "Start Call"}
       </button>
@@ -734,6 +796,21 @@ const callPageStyle = {
   padding: "1rem",
   maxWidth: "72rem",
   margin: "0 auto",
+} as const;
+
+const installCardStyle = {
+  display: "grid",
+  gap: "0.75rem",
+  background: "#e0f2fe",
+  border: "1px solid #7dd3fc",
+  borderRadius: "1rem",
+  padding: "1rem",
+  marginBottom: "1rem",
+  maxWidth: "32rem",
+} as const;
+
+const installHeadingStyle = {
+  margin: 0,
 } as const;
 
 const callHeaderStyle = {
@@ -928,4 +1005,11 @@ function getNavigatorConnection(): NavigatorConnectionLike | null {
   };
 
   return candidate.connection ?? candidate.mozConnection ?? candidate.webkitConnection ?? null;
+}
+
+function getStandaloneAppState(): boolean {
+  return isPwaInstalled({
+    matchMedia: typeof window.matchMedia === "function" ? window.matchMedia.bind(window) : undefined,
+    navigator,
+  });
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
+import { registerServiceWorker } from "./pwa";
+
+registerServiceWorker(import.meta.env, window);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
 );
-

--- a/apps/web/src/pwa.test.ts
+++ b/apps/web/src/pwa.test.ts
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  attachInstallPromptListeners,
+  isPwaInstalled,
+  promptForInstallation,
+  shouldRegisterServiceWorker,
+  type BeforeInstallPromptEvent,
+} from "./pwa.js";
+
+test("isPwaInstalled returns true for standalone display mode", () => {
+  assert.equal(
+    isPwaInstalled({
+      matchMedia: () => ({ matches: true }),
+    }),
+    true,
+  );
+});
+
+test("isPwaInstalled returns true for iOS standalone navigator flag", () => {
+  assert.equal(
+    isPwaInstalled({
+      navigator: { standalone: true } as Navigator & { standalone?: boolean },
+    }),
+    true,
+  );
+});
+
+test("isPwaInstalled returns false when app is not installed", () => {
+  assert.equal(
+    isPwaInstalled({
+      matchMedia: () => ({ matches: false }),
+      navigator: { standalone: false } as Navigator & { standalone?: boolean },
+    }),
+    false,
+  );
+});
+
+test("attachInstallPromptListeners captures the deferred install event", () => {
+  const target = new EventTarget();
+  let promptEvent: BeforeInstallPromptEvent | null = null;
+  let installedCount = 0;
+
+  const cleanup = attachInstallPromptListeners(target, {
+    onPromptAvailable: (event) => {
+      promptEvent = event;
+    },
+    onInstalled: () => {
+      installedCount += 1;
+    },
+  });
+
+  const beforeInstallPromptEvent = createBeforeInstallPromptEvent();
+  target.dispatchEvent(beforeInstallPromptEvent);
+  target.dispatchEvent(new Event("appinstalled"));
+  cleanup();
+
+  assert.equal(promptEvent, beforeInstallPromptEvent);
+  assert.equal(beforeInstallPromptEvent.defaultPrevented, true);
+  assert.equal(installedCount, 1);
+});
+
+test("promptForInstallation returns the browser choice outcome", async () => {
+  const deferredPrompt = createBeforeInstallPromptEvent("accepted");
+  assert.equal(await promptForInstallation(deferredPrompt), "accepted");
+});
+
+test("shouldRegisterServiceWorker only enables production browser registration", () => {
+  assert.equal(shouldRegisterServiceWorker({ PROD: true }, {} as Navigator["serviceWorker"]), true);
+  assert.equal(shouldRegisterServiceWorker({ PROD: false }, {} as Navigator["serviceWorker"]), false);
+  assert.equal(shouldRegisterServiceWorker({ PROD: true }, undefined), false);
+});
+
+function createBeforeInstallPromptEvent(
+  outcome: "accepted" | "dismissed" = "dismissed",
+): BeforeInstallPromptEvent {
+  const event = new Event("beforeinstallprompt", { cancelable: true }) as BeforeInstallPromptEvent;
+
+  Object.defineProperties(event, {
+    prompt: {
+      value: async () => {},
+    },
+    userChoice: {
+      value: Promise.resolve({ outcome, platform: "web" }),
+    },
+  });
+
+  return event;
+}

--- a/apps/web/src/pwa.ts
+++ b/apps/web/src/pwa.ts
@@ -1,0 +1,96 @@
+export interface BeforeInstallPromptEvent extends Event {
+  readonly platforms?: string[];
+  readonly userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+  prompt(): Promise<void>;
+}
+
+interface InstallPromptBindings {
+  onPromptAvailable: (event: BeforeInstallPromptEvent) => void;
+  onInstalled: () => void;
+}
+
+interface InstallPromptTarget {
+  addEventListener(type: string, listener: EventListener): void;
+  removeEventListener(type: string, listener: EventListener): void;
+}
+
+interface StandaloneEnvironment {
+  matchMedia?: (query: string) => { matches: boolean };
+  navigator?: Navigator & { standalone?: boolean };
+}
+
+interface ServiceWorkerEnvironment {
+  PROD: boolean;
+}
+
+export function isPwaInstalled(environment: StandaloneEnvironment = {}): boolean {
+  const matchesStandalone = environment.matchMedia?.("(display-mode: standalone)").matches ?? false;
+  const navigatorStandalone = environment.navigator?.standalone === true;
+
+  return matchesStandalone || navigatorStandalone;
+}
+
+export function attachInstallPromptListeners(
+  target: InstallPromptTarget,
+  bindings: InstallPromptBindings,
+): () => void {
+  const handleBeforeInstallPrompt: EventListener = (event) => {
+    if (!isBeforeInstallPromptEvent(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    bindings.onPromptAvailable(event);
+  };
+
+  const handleInstalled: EventListener = () => {
+    bindings.onInstalled();
+  };
+
+  target.addEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+  target.addEventListener("appinstalled", handleInstalled);
+
+  return () => {
+    target.removeEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
+    target.removeEventListener("appinstalled", handleInstalled);
+  };
+}
+
+export async function promptForInstallation(
+  deferredPrompt: BeforeInstallPromptEvent,
+): Promise<"accepted" | "dismissed"> {
+  await deferredPrompt.prompt();
+  const result = await deferredPrompt.userChoice;
+  return result.outcome;
+}
+
+export function shouldRegisterServiceWorker(
+  environment: ServiceWorkerEnvironment,
+  serviceWorker: Navigator["serviceWorker"] | undefined,
+): boolean {
+  return environment.PROD && serviceWorker != null;
+}
+
+export function registerServiceWorker(
+  environment: ServiceWorkerEnvironment,
+  target: Window,
+): void {
+  if (!shouldRegisterServiceWorker(environment, target.navigator.serviceWorker)) {
+    return;
+  }
+
+  const register = () => {
+    void target.navigator.serviceWorker?.register("/service-worker.js");
+  };
+
+  if (target.document.readyState === "complete") {
+    register();
+    return;
+  }
+
+  target.addEventListener("load", register, { once: true });
+}
+
+function isBeforeInstallPromptEvent(event: Event): event is BeforeInstallPromptEvent {
+  return typeof (event as Partial<BeforeInstallPromptEvent>).prompt === "function";
+}

--- a/docs/07-frontend-architecture.md
+++ b/docs/07-frontend-architecture.md
@@ -3,7 +3,7 @@
 - Purpose: Describe the route structure, UI ownership, state boundaries, and client-side responsibilities for the LowTime web app.
 - Audience: Frontend engineers and designers.
 - Status: Baseline
-- Last Updated: 2026-03-24
+- Last Updated: 2026-03-25
 - Related Docs: [Product Overview](01-product-overview.md), [Room And User Flows](03-room-and-user-flows.md), [Media And Quality](04-media-and-quality.md), [ADR-003](adr/ADR-003-pwa-first.md)
 
 ## Overview
@@ -93,4 +93,4 @@ The frontend is a React + TypeScript PWA optimized for mobile browsers first. It
 - Keep contract types in a shared package consumed by the client.
 - Build the media controller as a dedicated subsystem rather than mixing it into UI components.
 - Treat PWA support as shell enhancement, not as offline call support.
-- Current implementation supports room creation, display-name join on `/r/:slug`, and a basic `/r/:slug/call` route with local self-view, remote tile area, mute/camera/leave controls, and a lightweight network health badge on top of LiveKit.
+- Current implementation supports room creation, display-name join on `/r/:slug`, and a basic `/r/:slug/call` route with local self-view, remote tile area, mute/camera/leave controls, a lightweight network health badge, and an installable PWA shell with manifest, service-worker registration, and landing-page install prompt behavior on top of LiveKit.

--- a/docs/10-observability-and-operations.md
+++ b/docs/10-observability-and-operations.md
@@ -3,7 +3,7 @@
 - Purpose: Define what LowTime measures, how it is monitored, and what operators should do when reliability degrades.
 - Audience: Backend, platform, and on-call engineers.
 - Status: Baseline
-- Last Updated: 2026-03-24
+- Last Updated: 2026-03-25
 - Related Docs: [System Architecture](02-system-architecture.md), [Backend Architecture](08-backend-architecture.md), [Testing And QA](11-testing-and-qa.md)
 
 ## Overview
@@ -85,4 +85,4 @@ B --> K
 - Tag metrics by browser, device class, transport, and preset where possible.
 - Redact secrets in logs, traces, and error reporting by default.
 - Keep dashboard ownership clear once the team grows.
-- Current implementation exposes a client-side network health badge in the call header using browser online state plus lightweight connection heuristics; deeper transport-quality metrics are still future work.
+- Current implementation exposes a client-side network health badge in the call header using browser online state plus lightweight connection heuristics; deeper transport-quality metrics are still future work. The PWA shell caches only static app assets, so room state and live call state should still be treated as network-dependent.


### PR DESCRIPTION
## Summary
- add a real PWA shell for the web app with a manifest, icons, and service-worker registration
- add landing-page install prompt handling and standalone detection in the app shell
- update the tracker and frontend/operations docs to mark issue #10 as implemented

## Verification
```bash
npm run test --workspace @lowtime/web
npm run typecheck --workspace @lowtime/web
npm run build --workspace @lowtime/web
```