### PR TITLE
feat: add join screen device preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ LowTime is a web-first calling app for people on weak or expensive internet conn
 - Monorepo scaffolding is in place for `apps/web`, `apps/server`, and `packages/shared`.
 - Docker Compose baseline is in place for local development and single-host deployment.
 - CI and linting baseline is in place for pull requests and pushes to `main`.
-- Room creation, share-link generation, public join admission, SFU token handoff, the first basic in-call UI, the network health badge, and the installable PWA shell are in place for the core 1:1 flow.
+- Room creation, share-link generation, public join admission, the join-side device preview, SFU token handoff, the first basic in-call UI, the network health badge, and the installable PWA shell are in place for the core 1:1 flow.
 
 ## Planned Stack
 - Web client: React + TypeScript + PWA shell

--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,7 @@
 | --- | --- | --- | --- |
 | Room creation endpoint and share link | `done` | Issue #4. Added room creation, host secret issuance, room metadata lookup, and a web share-link flow | [docs/05-api-and-realtime-contracts.md](docs/05-api-and-realtime-contracts.md) |
 | Public join flow with display name | `done` | Issue #5. Added open-room admission, lobby waiting responses, and a no-registration join form on the room page | [docs/03-room-and-user-flows.md](docs/03-room-and-user-flows.md) |
-| Join screen with device preview | `planned` | Includes permission flow and preset selection | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
+| Join screen with device preview | `done` | Issue #6. Added join-side camera/mic preview, media toggles, and quality preset selection before room admission | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
 | SFU integration for 1:1 rooms | `done` | Issue #7. Added LiveKit token issuance, a minimal `/r/:slug/call` handoff, and a web SFU connection flow for direct joins | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Basic in-call UI | `done` | Issue #8. Added a usable call screen with remote tile area, local self-view, and mute/camera/leave controls on the LiveKit path | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
 | Network health badge | `done` | Issue #9. Added a call-header badge that reflects offline, reconnecting, poor, fair, and good network states from browser connectivity heuristics | [docs/10-observability-and-operations.md](docs/10-observability-and-operations.md) |

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -19,6 +19,13 @@ import {
 import { connectToSfu } from "./media-controller.js";
 import { assessNetworkHealth, getNetworkHealthLabel, type NetworkHealth } from "./network-health.js";
 import {
+  buildPreviewConstraints,
+  getPreviewStateMessage,
+  getQualityPresetLabel,
+  stopMediaStream,
+  type PreviewState,
+} from "./device-preview.js";
+import {
   attachInstallPromptListeners,
   isPwaInstalled,
   promptForInstallation,
@@ -52,6 +59,11 @@ export function App() {
   const [isLoadingRoom, setIsLoadingRoom] = useState(false);
 
   const [displayName, setDisplayName] = useState("");
+  const [selectedQualityPreset, setSelectedQualityPreset] = useState<QualityPreset>(DEFAULT_QUALITY_PRESET);
+  const [previewAudioEnabled, setPreviewAudioEnabled] = useState(DEFAULT_REQUESTED_MEDIA.audio);
+  const [previewVideoEnabled, setPreviewVideoEnabled] = useState(DEFAULT_REQUESTED_MEDIA.video);
+  const [previewState, setPreviewState] = useState<PreviewState>("idle");
+  const [previewError, setPreviewError] = useState<string | null>(null);
   const [joinError, setJoinError] = useState<string | null>(null);
   const [joinResult, setJoinResult] = useState<JoinRoomResponse | null>(null);
   const [isJoining, setIsJoining] = useState(false);
@@ -85,6 +97,8 @@ export function App() {
   );
 
   const callRoomRef = useRef<Awaited<ReturnType<typeof connectToSfu>> | null>(null);
+  const previewStreamRef = useRef<MediaStream | null>(null);
+  const previewVideoRef = useRef<HTMLVideoElement | null>(null);
   const localVideoRef = useRef<HTMLVideoElement | null>(null);
   const remoteVideoRef = useRef<HTMLVideoElement | null>(null);
 
@@ -153,8 +167,32 @@ export function App() {
     setJoinError(null);
     setJoinResult(null);
     setDisplayName("");
+    setSelectedQualityPreset(DEFAULT_QUALITY_PRESET);
+    setPreviewAudioEnabled(DEFAULT_REQUESTED_MEDIA.audio);
+    setPreviewVideoEnabled(DEFAULT_REQUESTED_MEDIA.video);
+    setPreviewState("idle");
+    setPreviewError(null);
     setIsLoadingRoom(false);
+    stopMediaStream(previewStreamRef.current);
+    previewStreamRef.current = null;
   }, [viewState]);
+
+  useEffect(() => {
+    const videoElement = previewVideoRef.current;
+    const stream = previewStreamRef.current;
+
+    if (videoElement == null) {
+      return;
+    }
+
+    videoElement.srcObject = stream;
+
+    return () => {
+      if (videoElement.srcObject === stream) {
+        videoElement.srcObject = null;
+      }
+    };
+  }, [previewState, previewVideoEnabled]);
 
   useEffect(() => {
     if (viewState.kind !== "room") {
@@ -465,8 +503,8 @@ export function App() {
         },
         body: JSON.stringify({
           displayName,
-          qualityPreset: DEFAULT_QUALITY_PRESET,
-          requestedMedia: DEFAULT_REQUESTED_MEDIA,
+          qualityPreset: selectedQualityPreset,
+          requestedMedia: buildRequestedMedia(previewAudioEnabled, previewVideoEnabled),
         }),
       });
 
@@ -482,11 +520,13 @@ export function App() {
         saveStoredCallSession(window.sessionStorage, viewState.slug, {
           sessionId: payload.sessionId,
           displayName: displayName.trim(),
-          qualityPreset: DEFAULT_QUALITY_PRESET,
+          qualityPreset: selectedQualityPreset,
           transportPreference: payload.transportPreference,
-          requestedMedia: buildRequestedMedia(DEFAULT_REQUESTED_MEDIA.audio, DEFAULT_REQUESTED_MEDIA.video),
+          requestedMedia: buildRequestedMedia(previewAudioEnabled, previewVideoEnabled),
         });
 
+        stopMediaStream(previewStreamRef.current);
+        previewStreamRef.current = null;
         window.history.pushState({}, "", getCallRoute(viewState.slug));
         setViewState(getViewState(window.location.pathname));
       }
@@ -548,6 +588,37 @@ export function App() {
       setCallError(error instanceof Error ? error.message : "Unable to update camera state");
     } finally {
       setIsTogglingCamera(false);
+    }
+  }
+
+  async function handleStartPreview() {
+    if (typeof navigator === "undefined" || navigator.mediaDevices?.getUserMedia == null) {
+      setPreviewState("error");
+      setPreviewError("This browser does not support live device preview.");
+      return;
+    }
+
+    setPreviewState("requesting");
+    setPreviewError(null);
+
+    try {
+      const requestedMedia = buildRequestedMedia(previewAudioEnabled, previewVideoEnabled);
+      const stream = await navigator.mediaDevices.getUserMedia(buildPreviewConstraints(requestedMedia));
+      stopMediaStream(previewStreamRef.current);
+      previewStreamRef.current = stream;
+      setPreviewState("ready");
+    } catch (error) {
+      stopMediaStream(previewStreamRef.current);
+      previewStreamRef.current = null;
+
+      const name = error instanceof DOMException ? error.name : "";
+      if (name === "NotAllowedError" || name === "SecurityError") {
+        setPreviewState("blocked");
+        setPreviewError("Camera or microphone access was blocked. Adjust browser permissions to preview devices.");
+      } else {
+        setPreviewState("error");
+        setPreviewError(error instanceof Error ? error.message : "Unable to start device preview.");
+      }
     }
   }
 
@@ -708,6 +779,60 @@ export function App() {
             </section>
             <section>
               <h2>Join Room</h2>
+              <div style={joinPreviewGridStyle}>
+                <section style={previewCardStyle}>
+                  <div style={tileHeaderStyle}>
+                    <h3 style={tileHeadingStyle}>Device Preview</h3>
+                    <span>{getQualityPresetLabel(selectedQualityPreset)}</span>
+                  </div>
+                  {previewState === "ready" && previewVideoEnabled ? (
+                    <video
+                      ref={previewVideoRef}
+                      autoPlay
+                      muted
+                      playsInline
+                      style={previewVideoStyle}
+                    />
+                  ) : (
+                    <div style={previewPlaceholderStyle}>
+                      <strong>{previewVideoEnabled ? "Preview ready when you are" : "Audio-only join selected"}</strong>
+                      <p style={mutedParagraphStyle}>{getPreviewStateMessage(previewState, previewError)}</p>
+                    </div>
+                  )}
+                  <div style={previewOptionsStyle}>
+                    <label style={toggleOptionStyle}>
+                      <input
+                        type="checkbox"
+                        checked={previewAudioEnabled}
+                        onChange={(event) => setPreviewAudioEnabled(event.target.checked)}
+                      />
+                      Start with microphone
+                    </label>
+                    <label style={toggleOptionStyle}>
+                      <input
+                        type="checkbox"
+                        checked={previewVideoEnabled}
+                        onChange={(event) => setPreviewVideoEnabled(event.target.checked)}
+                      />
+                      Start with camera
+                    </label>
+                    <label style={toggleOptionStyle}>
+                      Quality preset
+                      <select
+                        value={selectedQualityPreset}
+                        onChange={(event) => setSelectedQualityPreset(event.target.value as QualityPreset)}
+                      >
+                        <option value="data_saver">Data Saver</option>
+                        <option value="balanced">Balanced</option>
+                        <option value="best_quality">Best Quality</option>
+                      </select>
+                    </label>
+                  </div>
+                  <button type="button" onClick={() => void handleStartPreview()} disabled={previewState === "requesting"}>
+                    {previewState === "requesting" ? "Starting Preview..." : "Start Device Preview"}
+                  </button>
+                </section>
+              </div>
               <label>
                 Display name
                 <input
@@ -831,6 +956,49 @@ const callHeaderBadgeRowStyle = {
 const callLayoutStyle = {
   display: "grid",
   gap: "1rem",
+} as const;
+
+const joinPreviewGridStyle = {
+  display: "grid",
+  gap: "1rem",
+  marginBottom: "1rem",
+} as const;
+
+const previewCardStyle = {
+  display: "grid",
+  gap: "1rem",
+  padding: "1rem",
+  borderRadius: "1rem",
+  background: "#e2e8f0",
+} as const;
+
+const previewPlaceholderStyle = {
+  minHeight: "14rem",
+  display: "grid",
+  placeItems: "center",
+  textAlign: "center",
+  background: "#cbd5e1",
+  borderRadius: "0.75rem",
+  padding: "1rem",
+} as const;
+
+const previewVideoStyle = {
+  width: "100%",
+  maxWidth: "24rem",
+  aspectRatio: "16 / 10",
+  objectFit: "cover",
+  borderRadius: "0.75rem",
+  background: "#0f172a",
+} as const;
+
+const previewOptionsStyle = {
+  display: "grid",
+  gap: "0.75rem",
+} as const;
+
+const toggleOptionStyle = {
+  display: "grid",
+  gap: "0.35rem",
 } as const;
 
 const remoteTileStyle = {

--- a/apps/web/src/device-preview.test.ts
+++ b/apps/web/src/device-preview.test.ts
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildPreviewConstraints,
+  getPreviewStateMessage,
+  getQualityPresetLabel,
+} from "./device-preview.js";
+
+test("buildPreviewConstraints disables camera constraints when video is off", () => {
+  assert.deepEqual(buildPreviewConstraints({ audio: true, video: false }), {
+    audio: true,
+    video: false,
+  });
+});
+
+test("buildPreviewConstraints returns conservative mobile-friendly video defaults", () => {
+  assert.deepEqual(buildPreviewConstraints({ audio: true, video: true }), {
+    audio: true,
+    video: {
+      width: { ideal: 640, max: 1280 },
+      height: { ideal: 360, max: 720 },
+      frameRate: { ideal: 15, max: 24 },
+      facingMode: "user",
+    },
+  });
+});
+
+test("getQualityPresetLabel maps presets to readable names", () => {
+  assert.equal(getQualityPresetLabel("data_saver"), "Data Saver");
+  assert.equal(getQualityPresetLabel("balanced"), "Balanced");
+  assert.equal(getQualityPresetLabel("best_quality"), "Best Quality");
+});
+
+test("getPreviewStateMessage prefers explicit errors and covers preview states", () => {
+  assert.equal(
+    getPreviewStateMessage("idle", null),
+    "Start a device preview to check your camera and microphone before joining.",
+  );
+  assert.equal(
+    getPreviewStateMessage("ready", null),
+    "Preview is ready. Review your camera and mic choices before joining.",
+  );
+  assert.equal(
+    getPreviewStateMessage("blocked", null),
+    "Camera or microphone access is blocked. You can still join with your current media settings.",
+  );
+  assert.equal(
+    getPreviewStateMessage("error", "Camera missing"),
+    "Camera missing",
+  );
+});

--- a/apps/web/src/device-preview.ts
+++ b/apps/web/src/device-preview.ts
@@ -1,0 +1,53 @@
+import type { QualityPreset, RequestedMedia } from "@lowtime/shared";
+
+export type PreviewState = "idle" | "requesting" | "ready" | "blocked" | "error";
+
+export function buildPreviewConstraints(requestedMedia: RequestedMedia): MediaStreamConstraints {
+  return {
+    audio: requestedMedia.audio,
+    video: requestedMedia.video
+      ? {
+          width: { ideal: 640, max: 1280 },
+          height: { ideal: 360, max: 720 },
+          frameRate: { ideal: 15, max: 24 },
+          facingMode: "user",
+        }
+      : false,
+  };
+}
+
+export function getQualityPresetLabel(qualityPreset: QualityPreset): string {
+  switch (qualityPreset) {
+    case "data_saver":
+      return "Data Saver";
+    case "best_quality":
+      return "Best Quality";
+    default:
+      return "Balanced";
+  }
+}
+
+export function getPreviewStateMessage(previewState: PreviewState, previewError: string | null): string {
+  if (previewError != null && previewError.trim() !== "") {
+    return previewError;
+  }
+
+  switch (previewState) {
+    case "requesting":
+      return "Requesting camera and microphone access...";
+    case "ready":
+      return "Preview is ready. Review your camera and mic choices before joining.";
+    case "blocked":
+      return "Camera or microphone access is blocked. You can still join with your current media settings.";
+    case "error":
+      return "Preview could not start. Check your browser permissions or device availability.";
+    default:
+      return "Start a device preview to check your camera and microphone before joining.";
+  }
+}
+
+export function stopMediaStream(stream: MediaStream | null) {
+  stream?.getTracks().forEach((track) => {
+    track.stop();
+  });
+}

--- a/docs/07-frontend-architecture.md
+++ b/docs/07-frontend-architecture.md
@@ -93,4 +93,4 @@ The frontend is a React + TypeScript PWA optimized for mobile browsers first. It
 - Keep contract types in a shared package consumed by the client.
 - Build the media controller as a dedicated subsystem rather than mixing it into UI components.
 - Treat PWA support as shell enhancement, not as offline call support.
-- Current implementation supports room creation, display-name join on `/r/:slug`, and a basic `/r/:slug/call` route with local self-view, remote tile area, mute/camera/leave controls, a lightweight network health badge, and an installable PWA shell with manifest, service-worker registration, and landing-page install prompt behavior on top of LiveKit.
+- Current implementation supports room creation, display-name join on `/r/:slug`, a join-side device preview with media toggles and quality preset selection, and a basic `/r/:slug/call` route with local self-view, remote tile area, mute/camera/leave controls, a lightweight network health badge, and an installable PWA shell with manifest, service-worker registration, and landing-page install prompt behavior on top of LiveKit.


### PR DESCRIPTION
## Summary
- add a join-side device preview with camera and microphone toggles before admission
- add quality preset selection and persist the chosen media settings into the stored call session
- update the tracker and frontend docs to mark issue #6 as implemented

## Verification
```bash
npm run test --workspace @lowtime/web
npm run typecheck --workspace @lowtime/web
npm run build --workspace @lowtime/web
```