### PR TITLE
docs: update architecture after refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,16 @@
 - The repository workflow first checks whether the `codex` reviewer request succeeds and skips the `@codex review` comment when Codex reviewer access or review usage is unavailable.
 - Follow the full issue -> branch -> pull request process in [docs/13-issue-branch-pr-workflow.md](docs/13-issue-branch-pr-workflow.md).
 
+## Code Organization
+- Keep frontend route rendering and navigation helpers in `apps/web/src/app/`.
+- Keep frontend feature-specific UI and effects in `apps/web/src/features/<area>/`.
+- Keep frontend shared pure helpers in top-level web modules only when they are used across multiple features.
+- Keep backend HTTP handlers in `apps/server/src/routes/`.
+- Keep backend policy, room state, and validation logic in `apps/server/src/domain/`.
+- Keep backend runtime wiring helpers in `apps/server/src/server-support.ts` unless they become domain logic.
+- Keep server tests split by route area instead of rebuilding a single catch-all integration file.
+- When a file starts accumulating multiple unrelated responsibilities, prefer extracting a focused module beside the owning feature or domain before adding more logic.
+
 ## Required Documentation Updates
 - Update [TODO.md](TODO.md) whenever a tracked feature changes status.
 - Update the relevant file in `docs/` whenever you change:

--- a/TODO.md
+++ b/TODO.md
@@ -93,6 +93,22 @@
 | Metrics, logs, and dashboards | `planned` | Product, media, and abuse visibility | [docs/10-observability-and-operations.md](docs/10-observability-and-operations.md) |
 | Abuse and rate-limit controls | `planned` | Protect room creation and join paths | [docs/09-security-and-abuse.md](docs/09-security-and-abuse.md) |
 
+## Refactor Program
+
+| Feature | Status | Notes | Source |
+| --- | --- | --- | --- |
+| Web route-level page extraction | `done` | Issue #52. Extracted route-level pages and reduced `App.tsx` size materially | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
+| Web styles extraction from `App.tsx` | `planned` | Issue #53. Shared page styles already moved once; deeper style-module cleanup is still open | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
+| Room and waiting feature-module split | `done` | Issue #54. Room and waiting effects/actions live in feature modules | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
+| Call feature-module split | `done` | Issue #55. Call connection and media sync moved into `features/call/call-effects.ts` | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
+| Preview and install feature-module split | `done` | Issue #56. Install and preview behavior moved into dedicated feature hooks | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
+| Web route helpers and app shell | `done` | Issue #57. Added `app/routes.ts` and `app/app-shell.tsx` | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
+| Server route registration split | `done` | Issue #58. Fastify route modules now own health, rooms, lobby, and media endpoints | [docs/08-backend-architecture.md](docs/08-backend-architecture.md) |
+| Server room validation and status domain split | `done` | Issue #59. Validation and room status logic now live in domain modules | [docs/08-backend-architecture.md](docs/08-backend-architecture.md) |
+| Server room-store domain split | `done` | Issue #60. In-memory store and lobby/session mutations moved into `domain/room-store.ts` | [docs/08-backend-architecture.md](docs/08-backend-architecture.md) |
+| Server integration test split | `done` | Issue #61. Split route coverage into `rooms`, `lobby`, and `media` test files | [docs/08-backend-architecture.md](docs/08-backend-architecture.md) |
+| Architecture docs for refactored structure | `done` | Issue #62. Updated frontend/backend architecture docs and contributor guidance to match the shipped layout | [docs/08-backend-architecture.md](docs/08-backend-architecture.md) |
+
 ## Update Rule For Every PR
 - If a feature changes status, update this file.
 - If a feature is done, verify the matching source doc still describes the shipped behavior.

--- a/docs/07-frontend-architecture.md
+++ b/docs/07-frontend-architecture.md
@@ -9,12 +9,42 @@
 ## Overview
 The frontend is a React + TypeScript PWA optimized for mobile browsers first. It owns room creation, join flow, device preview, in-call controls, reconnect UX, and local media adaptation. Server-side policy remains authoritative; the client reflects and requests changes but does not invent policy.
 
+## Source Layout
+- `apps/web/src/App.tsx`
+  - top-level state orchestration only
+- `apps/web/src/app/routes.ts`
+  - route parsing, route path helpers, and push-state helpers
+- `apps/web/src/app/app-shell.tsx`
+  - route-based page selection
+- `apps/web/src/features/home/`
+  - landing page UI and install-prompt behavior
+- `apps/web/src/features/room/`
+  - join page UI, room loading, join actions, and device preview behavior
+- `apps/web/src/features/waiting/`
+  - waiting-room polling and waiting-page UI
+- `apps/web/src/features/call/`
+  - call-page UI and call connection/media lifecycle
+- `apps/web/src/features/page-styles.ts`
+  - shared inline style objects used by the current UI
+- `apps/web/src/room-entry.ts`
+  - stored-session helpers, URL-derived view state, and route-adjacent persistence helpers
+- `apps/web/src/media-controller.ts`
+  - LiveKit connection bridge for the web client
+- `apps/web/src/call-experience.ts`
+  - participant/track selection helpers used by the call flow
+- `apps/web/src/network-health.ts`
+  - network badge heuristics
+- `apps/web/src/device-preview.ts`
+  - pure preview constraint and preview message helpers
+- `apps/web/src/pwa.ts`
+  - service-worker and install prompt helper functions
+
 ## Route Structure
 - `/`
   - landing page with create-room CTA and join-by-link helper
 - `/r/:slug`
   - join screen, room status, device preview, access validation
-- `/r/:slug/waiting`
+- `/r/:slug/waiting/:requestId`
   - lobby waiting state when admission requires approval
 - `/r/:slug/call`
   - in-call screen with media, host controls, chat, settings, and reconnect banners
@@ -38,7 +68,7 @@ The frontend is a React + TypeScript PWA optimized for mobile browsers first. It
 
 ## State Boundaries
 - `App state`
-  - routing, install prompts, theme, service-worker state
+  - view-state routing, room create flow, shared cross-route form state, network badge state
 - `Room state`
   - room settings, participant roster, host privileges, lobby state
 - `Media state`
@@ -47,6 +77,15 @@ The frontend is a React + TypeScript PWA optimized for mobile browsers first. It
   - available cameras, microphones, speakers, permissions, hardware errors
 - `UI state`
   - which drawer or modal is open, pending toasts, banners
+
+Current implementation boundary:
+- `App.tsx` owns routing, create-room flow, shared join inputs, and cross-feature coordination.
+- Feature hooks own route-specific effects:
+  - `useRoomPageData`
+  - `useWaitingRoomState`
+  - `useCallFlow`
+  - `useDevicePreview`
+  - `useInstallPrompt`
 
 ## Media Controller Responsibilities
 - Acquire and release local tracks
@@ -67,17 +106,27 @@ The frontend is a React + TypeScript PWA optimized for mobile browsers first. It
 
 ## Component Ownership
 - `app-shell`
-  - router, providers, PWA hooks
-- `room-entry`
-  - create, join, preview, waiting
-- `call-experience`
-  - participant layout, transport state, reconnect UX
-- `host-controls`
-  - access mode, quality cap, room size, moderation actions
-- `chat`
-  - ephemeral room chat drawer
-- `settings`
-  - presets and advanced controls
+  - route rendering only
+- `routes`
+  - pathname parsing and navigation helpers
+- `home-page`
+  - create-room landing experience
+- `room-page`
+  - join form, room summary, device preview, and host lobby queue
+- `waiting-page`
+  - waiting-room status and back-to-join action
+- `call-page`
+  - connected call UI and control surface
+- `call-effects`
+  - token request, LiveKit room connection, participant sync, and call control handlers
+- `room-effects`
+  - room summary loading and host lobby queue refresh
+- `waiting-effects`
+  - waiting-room polling and approval transition handling
+- `preview-effects`
+  - preview media stream lifecycle and preview state
+- `install-effects`
+  - install prompt lifecycle and install status messaging
 
 ## Edge Cases
 - Browser denies media permissions after the user has already joined.
@@ -94,3 +143,7 @@ The frontend is a React + TypeScript PWA optimized for mobile browsers first. It
 - Build the media controller as a dedicated subsystem rather than mixing it into UI components.
 - Treat PWA support as shell enhancement, not as offline call support.
 - Current implementation supports room creation, display-name join on `/r/:slug`, a join-side device preview with media toggles and quality preset selection, a `/r/:slug/waiting/:requestId` polling flow for lobby rooms, host-side pending-request controls on the room page, and a basic `/r/:slug/call` route with local self-view, remote tile area, mute/camera/leave controls, a lightweight network health badge, and an installable PWA shell with manifest, service-worker registration, and landing-page install prompt behavior on top of LiveKit.
+- The current refactor direction is feature-slice oriented on the frontend:
+  - page UI stays under `features/<area>/`
+  - route-specific effects live beside the page they support
+  - generic helpers remain in top-level utility modules until a shared-lib layer becomes necessary

--- a/docs/08-backend-architecture.md
+++ b/docs/08-backend-architecture.md
@@ -3,34 +3,59 @@
 - Purpose: Describe the server-side services, policy engine, signaling behavior, and failure handling for LowTime.
 - Audience: Backend and platform engineers.
 - Status: Baseline
-- Last Updated: 2026-03-24
+- Last Updated: 2026-03-25
 - Related Docs: [System Architecture](02-system-architecture.md), [API And Realtime Contracts](05-api-and-realtime-contracts.md), [Data Model And Lifecycle](06-data-model-and-lifecycle.md), [Security And Abuse](09-security-and-abuse.md)
 
 ## Overview
 The backend is a Fastify application exposing REST endpoints and a WebSocket signaling channel. It is responsible for room creation, admission checks, host validation, lobby handling, reconnect rules, media token issuance, and quality-cap enforcement.
 
+## Source Layout
+- `apps/server/src/index.ts`
+  - process entrypoint and server listen startup
+- `apps/server/src/app.ts`
+  - Fastify bootstrap, CORS registration, and route-module registration
+- `apps/server/src/routes/health.ts`
+  - healthcheck endpoint
+- `apps/server/src/routes/rooms.ts`
+  - room creation, room lookup, and join admission endpoints
+- `apps/server/src/routes/lobby.ts`
+  - lobby list, status, approve, and deny endpoints
+- `apps/server/src/routes/media.ts`
+  - media token issuance endpoint
+- `apps/server/src/domain/room-validation.ts`
+  - create/join/token request validation rules
+- `apps/server/src/domain/room-status.ts`
+  - room status calculation and public room summary projection
+- `apps/server/src/domain/room-store.ts`
+  - in-memory room store, session creation, and lobby request mutation logic
+- `apps/server/src/server-support.ts`
+  - route-context creation, runtime wiring, expiry helper, and host-secret validation
+- `apps/server/src/livekit.ts`
+  - LiveKit config loading and token signing
+- `apps/server/src/rooms.test.ts`
+  - room and join endpoint coverage
+- `apps/server/src/lobby.test.ts`
+  - lobby endpoint coverage
+- `apps/server/src/media.test.ts`
+  - media token endpoint coverage
+
 ## Service Responsibilities
-- `Room service`
+- `Route layer`
+  - translate HTTP requests into domain operations
+  - return stable API responses and error messages
+- `Room validation domain`
+  - enforce create, join, and token input rules
+- `Room status domain`
+  - decide whether a room is `created`, `active`, `expired`, or `closed`
+  - shape public room summaries
+- `Room store domain`
   - create rooms
-  - load room metadata
-  - update `last_activity_at`
-  - expire inactive rooms
-- `Access policy service`
-  - enforce open, lobby, and passcode rules
-  - enforce room size limits
-  - validate host secret
+  - create admitted sessions
+  - create, approve, deny, and list lobby requests
 - `Media token service`
-  - request signed LiveKit tokens
-  - prepare P2P fallback session state
-  - return ICE server configuration
-- `Signaling gateway`
-  - handle live room connection
-  - broadcast participant, chat, and settings events
-  - relay P2P SDP and ICE in fallback mode
-- `Reconnect service`
-  - manage recovery window and session restoration
-- `Cleanup worker`
-  - expire rooms and transient state
+  - sign LiveKit access tokens for admitted sessions
+- `App bootstrap layer`
+  - compose Fastify with shared runtime context and route modules
 
 ## Containerization Notes
 - The backend should ship as a Docker image and read all runtime configuration from environment variables.
@@ -65,9 +90,12 @@ A-->>C: room.snapshot
 - Host quality-cap changes are broadcast through signaling and applied live.
 
 ## Lobby Handling
-- Join requests to a lobby room create a Redis-backed waiting record.
-- Host receives `lobby.requested` through signaling.
-- Approval or denial removes the waiting record and emits the resulting event to the guest session.
+- Current implementation:
+  - join requests to a lobby room create an in-memory waiting record in the room store
+  - host polls lobby list/status over REST
+  - approval or denial updates that in-memory waiting record and surfaces the result through the status endpoint
+- Planned evolution:
+  - move waiting records into Redis-backed transient state when signaling and reconnect flows land
 
 ## Failure Handling
 - If Redis is unavailable, reject new joins and room setting changes cleanly rather than risking inconsistent live state.
@@ -86,8 +114,8 @@ A-->>C: room.snapshot
 - Host secret validation passes for an expired room unless expiry is checked first.
 
 ## Implementation Notes
-- Use Redis transactions or equivalent guards for participant-capacity races.
-- Separate room policy code from raw transport integration code to keep rules testable.
+- Current implementation keeps route modules separate from domain helpers so policy rules remain testable without route-level boilerplate.
+- The in-memory room store is intentionally isolated behind `RoomStore` so it can be swapped for Redis/PostgreSQL-backed implementations later.
 - Keep startup and healthcheck behavior container-friendly for Compose and later orchestration.
-- Record host actions as audit events for debugging and abuse review.
+- Record host actions as audit events for debugging and abuse review when persistent storage is introduced.
 - Current implementation signs LiveKit room tokens directly in the Fastify service for admitted sessions and returns them through `POST /api/rooms/:slug/token`.


### PR DESCRIPTION
## Summary
- update the frontend architecture doc to describe the new app-shell and feature-slice layout
- update the backend architecture doc to describe route modules, domain modules, and split test ownership
- add contributor guidance and tracker rows so the refactor program matches the current codebase

## Verification
```bash
sed -n "1,260p" docs/07-frontend-architecture.md
sed -n "1,260p" docs/08-backend-architecture.md
sed -n "1,220p" CONTRIBUTING.md
sed -n "1,320p" TODO.md
```