### PR TITLE
feat: add passcode-protected rooms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ coverage/
 .env.*
 !.env.example
 
+.vscode/
+.kiro/

--- a/TODO.md
+++ b/TODO.md
@@ -46,7 +46,7 @@
 | Feature | Status | Notes | Source |
 | --- | --- | --- | --- |
 | Lobby mode | `done` | Issue #11. Added pending lobby requests, host approval and denial endpoints, a waiting route, and host-side queue controls in the room screen | [docs/03-room-and-user-flows.md](docs/03-room-and-user-flows.md) |
-| Passcode-protected rooms | `planned` | Validate before token issuance | [docs/09-security-and-abuse.md](docs/09-security-and-abuse.md) |
+| Passcode-protected rooms | `done` | Issue #12. Added Argon2id hash storage, join-time verification, `(IP, slug)` rate limiter, host-only settings endpoint for rotation, and access-mode + passcode UI on create and join screens | [docs/09-security-and-abuse.md](docs/09-security-and-abuse.md) |
 | Host reclaim after refresh | `planned` | Restore host role from host secret | [docs/03-room-and-user-flows.md](docs/03-room-and-user-flows.md) |
 | Reconnect window and session recovery | `planned` | Preserve identity during short disconnects | [docs/06-data-model-and-lifecycle.md](docs/06-data-model-and-lifecycle.md) |
 | Room expiry and cleanup jobs | `planned` | Expire inactive rooms and trim transient state | [docs/06-data-model-and-lifecycle.md](docs/06-data-model-and-lifecycle.md) |

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,12 +13,14 @@
   },
   "dependencies": {
     "@fastify/cors": "^11.1.0",
-    "fastify": "^5.2.1",
     "@lowtime/shared": "^0.1.0",
+    "@node-rs/argon2": "^2.0.2",
+    "fastify": "^5.2.1",
     "livekit-server-sdk": "^2.13.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.30",
+    "fast-check": "^4.7.0",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3"
   }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -5,6 +5,7 @@ import { registerHealthRoutes } from "./routes/health.js";
 import { registerLobbyRoutes } from "./routes/lobby.js";
 import { registerMediaRoutes } from "./routes/media.js";
 import { registerRoomRoutes } from "./routes/rooms.js";
+import { registerSettingsRoutes } from "./routes/settings.js";
 import { createInMemoryRoomStore, type RoomStore } from "./domain/room-store.js";
 import {
   createRouteContext,
@@ -13,7 +14,7 @@ import {
 
 export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   const app = Fastify({
-    logger: true,
+    logger: options.logger ?? true,
   });
 
   const context = createRouteContext(options);
@@ -27,6 +28,7 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   registerRoomRoutes(app, context);
   registerLobbyRoutes(app, context);
   registerMediaRoutes(app, context);
+  registerSettingsRoutes(app, context);
 
   return app;
 }

--- a/apps/server/src/domain/passcode-rate-limiter.ts
+++ b/apps/server/src/domain/passcode-rate-limiter.ts
@@ -1,0 +1,150 @@
+import type { RoomSlug } from "@lowtime/shared";
+
+/**
+ * Identifies a single rate-limit bucket. Keyed by the pair `(clientIp, slug)`
+ * so that one noisy client against one room does not lock out unrelated
+ * clients or unrelated rooms (Requirement 6.4).
+ */
+export interface RateLimitKey {
+  clientIp: string;
+  slug: RoomSlug;
+}
+
+/** Inspectable state, used by tests and by Property 6 assertions. */
+export interface PasscodeRateLimiterState {
+  failuresInWindow: number;
+  cooldownUntil: number | null;
+}
+
+export interface PasscodeRateLimiter {
+  /**
+   * Returns `true` if a passcode check may proceed for the given key,
+   * `false` if the key is currently in cooldown. Does not mutate state.
+   */
+  shouldAllow(key: RateLimitKey): boolean;
+  /** Records a failed passcode attempt for the key. */
+  recordFailure(key: RateLimitKey): void;
+  /** Records a successful passcode verification, clearing counters. */
+  recordSuccess(key: RateLimitKey): void;
+  /**
+   * Clears every bucket whose key matches the given slug. Used on passcode
+   * rotation and access-mode changes (Requirements 8.1 and 8.3).
+   */
+  clear(slug: RoomSlug): void;
+  /** Test-only helper that exposes the current bucket state. */
+  getState(key: RateLimitKey): PasscodeRateLimiterState;
+}
+
+export interface CreatePasscodeRateLimiterOptions {
+  /** Sliding window duration in milliseconds. Default 5 minutes. */
+  windowMs?: number;
+  /** Failure count that triggers cooldown. Default 5. */
+  threshold?: number;
+  /** Cooldown duration in milliseconds. Default 60 seconds. */
+  cooldownMs?: number;
+  /** Injected clock for deterministic tests. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+interface Bucket {
+  failures: number[];
+  cooldownUntil: number | null;
+}
+
+const DEFAULT_WINDOW_MS = 5 * 60_000;
+const DEFAULT_THRESHOLD = 5;
+const DEFAULT_COOLDOWN_MS = 60_000;
+
+// Use a non-printable delimiter for the internal key so that a slug containing
+// "|" or similar characters cannot accidentally collide with another
+// (clientIp, slug) pair. Room slugs are base58; client IPs are dotted quads or
+// bracketed IPv6. Neither contains U+0001.
+const INTERNAL_KEY_DELIMITER = "\u0001";
+
+function keyFor(key: RateLimitKey): string {
+  return `${key.clientIp}${INTERNAL_KEY_DELIMITER}${key.slug}`;
+}
+
+export function createInMemoryPasscodeRateLimiter(
+  options: CreatePasscodeRateLimiterOptions = {},
+): PasscodeRateLimiter {
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+  const cooldownMs = options.cooldownMs ?? DEFAULT_COOLDOWN_MS;
+  const now = options.now ?? (() => Date.now());
+
+  const buckets = new Map<string, Bucket>();
+
+  function getBucket(internalKey: string): Bucket {
+    let bucket = buckets.get(internalKey);
+    if (bucket == null) {
+      bucket = { failures: [], cooldownUntil: null };
+      buckets.set(internalKey, bucket);
+    }
+    return bucket;
+  }
+
+  function prune(bucket: Bucket, current: number): void {
+    const cutoff = current - windowMs;
+    while (bucket.failures.length > 0 && bucket.failures[0] < cutoff) {
+      bucket.failures.shift();
+    }
+    if (bucket.cooldownUntil != null && current >= bucket.cooldownUntil) {
+      bucket.cooldownUntil = null;
+      // Recovery after cooldown resets the failure ring so one overdue check
+      // does not immediately re-trip the limiter (Requirement 6.3).
+      bucket.failures.length = 0;
+    }
+  }
+
+  return {
+    shouldAllow(key) {
+      const current = now();
+      const bucket = getBucket(keyFor(key));
+      prune(bucket, current);
+      return bucket.cooldownUntil === null;
+    },
+    recordFailure(key) {
+      const current = now();
+      const bucket = getBucket(keyFor(key));
+      prune(bucket, current);
+
+      // If a cooldown is already active, additional failures do not extend it
+      // and are not appended to the ring; the handler should have short-
+      // circuited via `shouldAllow` before reaching this code path.
+      if (bucket.cooldownUntil !== null) {
+        return;
+      }
+
+      bucket.failures.push(current);
+      if (bucket.failures.length >= threshold) {
+        bucket.cooldownUntil = current + cooldownMs;
+      }
+    },
+    recordSuccess(key) {
+      const bucket = buckets.get(keyFor(key));
+      if (bucket == null) {
+        return;
+      }
+      bucket.failures.length = 0;
+      bucket.cooldownUntil = null;
+    },
+    clear(slug) {
+      const suffix = `${INTERNAL_KEY_DELIMITER}${slug}`;
+      for (const internalKey of [...buckets.keys()]) {
+        if (internalKey.endsWith(suffix)) {
+          buckets.delete(internalKey);
+        }
+      }
+    },
+    getState(key) {
+      const current = now();
+      const bucket = getBucket(keyFor(key));
+      prune(bucket, current);
+      return {
+        failuresInWindow: bucket.failures.length,
+        cooldownUntil: bucket.cooldownUntil,
+      };
+    },
+  };
+}

--- a/apps/server/src/domain/passcode-verifier.ts
+++ b/apps/server/src/domain/passcode-verifier.ts
@@ -1,0 +1,59 @@
+import { Algorithm, hash as argon2Hash, verify as argon2Verify } from "@node-rs/argon2";
+
+/**
+ * Argon2id-backed passcode hashing and verification. Used by the server to
+ * store only the encoded hash of a room's passcode (Requirement 2.1) and to
+ * check submitted passcodes on join without leaking timing information
+ * (Requirement 4.3).
+ *
+ * The interface exists so tests can substitute a deterministic fake.
+ */
+export interface PasscodeVerifier {
+  /** Produce an Argon2id encoded hash of `plaintext`. Each call uses a new salt. */
+  hash(plaintext: string): Promise<string>;
+  /**
+   * Constant-time verify of `plaintext` against a previously produced encoded
+   * hash. Returns `true` on match, `false` on mismatch.
+   */
+  verify(encodedHash: string, plaintext: string): Promise<boolean>;
+}
+
+export interface CreatePasscodeVerifierOptions {
+  /** Memory cost in KiB. Defaults to OWASP 2024 baseline of 19 MiB. */
+  memoryCost?: number;
+  /** Iteration count. Defaults to OWASP 2024 baseline of 2. */
+  timeCost?: number;
+  /** Parallelism degree. Defaults to 1. */
+  parallelism?: number;
+}
+
+// OWASP 2024 baseline tuning for Argon2id with a short secret input.
+// See docs/09-security-and-abuse.md for the rationale.
+const DEFAULT_MEMORY_COST = 19 * 1024; // 19 MiB
+const DEFAULT_TIME_COST = 2;
+const DEFAULT_PARALLELISM = 1;
+
+export function createArgon2idPasscodeVerifier(
+  options: CreatePasscodeVerifierOptions = {},
+): PasscodeVerifier {
+  const memoryCost = options.memoryCost ?? DEFAULT_MEMORY_COST;
+  const timeCost = options.timeCost ?? DEFAULT_TIME_COST;
+  const parallelism = options.parallelism ?? DEFAULT_PARALLELISM;
+
+  return {
+    async hash(plaintext: string): Promise<string> {
+      return argon2Hash(plaintext, {
+        algorithm: Algorithm.Argon2id,
+        memoryCost,
+        timeCost,
+        parallelism,
+      });
+    },
+    async verify(encodedHash: string, plaintext: string): Promise<boolean> {
+      // `@node-rs/argon2`'s verify reads the embedded parameters and does a
+      // constant-time comparison on the derived digest, so mismatches do not
+      // short-circuit earlier than matches.
+      return argon2Verify(encodedHash, plaintext);
+    },
+  };
+}

--- a/apps/server/src/domain/room-store.ts
+++ b/apps/server/src/domain/room-store.ts
@@ -10,6 +10,7 @@ import type {
 
 export interface StoredRoom extends RoomSummary {
   hostSecret: string;
+  passcodeHash: string | null;
   sessions: StoredSession[];
   lobbyRequests: StoredLobbyRequest[];
 }
@@ -20,6 +21,7 @@ export interface CreateStoredRoomInput {
   qualityCap: QualityCap;
   allowScreenShare: boolean;
   expiresAt: string;
+  passcodeHash?: string;
 }
 
 export interface StoredSession {
@@ -40,6 +42,8 @@ export interface StoredLobbyRequest {
 export interface RoomStore {
   createRoom(input: CreateStoredRoomInput): StoredRoom;
   getRoom(slug: RoomSlug): StoredRoom | undefined;
+  setPasscodeHash(slug: RoomSlug, hash: string): boolean;
+  clearPasscodeHash(slug: RoomSlug): boolean;
   createSession(roomSlug: RoomSlug, displayName: string): StoredSession | undefined;
   createLobbyRequest(roomSlug: RoomSlug, displayName: string, createdAt: string): StoredLobbyRequest | undefined;
   listLobbyRequests(roomSlug: RoomSlug): StoredLobbyRequest[];
@@ -68,6 +72,7 @@ export function createInMemoryRoomStore(): RoomStore {
         status: "created",
         expiresAt: input.expiresAt,
         hostSecret: createHostSecret(),
+        passcodeHash: input.passcodeHash ?? null,
         sessions: [],
         lobbyRequests: [],
       };
@@ -78,6 +83,22 @@ export function createInMemoryRoomStore(): RoomStore {
     },
     getRoom(slug) {
       return rooms.get(slug);
+    },
+    setPasscodeHash(slug, hash) {
+      const room = rooms.get(slug);
+      if (room == null) {
+        return false;
+      }
+      room.passcodeHash = hash;
+      return true;
+    },
+    clearPasscodeHash(slug) {
+      const room = rooms.get(slug);
+      if (room == null) {
+        return false;
+      }
+      room.passcodeHash = null;
+      return true;
     },
     createSession(roomSlug, displayName) {
       const room = rooms.get(roomSlug);

--- a/apps/server/src/domain/room-validation.ts
+++ b/apps/server/src/domain/room-validation.ts
@@ -5,6 +5,7 @@ import type {
   MediaTokenRequest,
   QualityCap,
   TransportPreference,
+  UpdateRoomSettingsRequest,
 } from "@lowtime/shared";
 
 import type { CreateStoredRoomInput } from "./room-store.js";
@@ -17,9 +18,58 @@ const DEFAULT_ALLOW_SCREEN_SHARE = true;
 const ACCESS_MODES: AccessMode[] = ["open", "lobby", "passcode"];
 const QUALITY_CAPS: QualityCap[] = ["low", "balanced", "high"];
 
+const PASSCODE_MIN_LENGTH = 4;
+const PASSCODE_MAX_LENGTH = 64;
+const CONTROL_CHAR_PATTERN = /\p{Cc}/u;
+
+/**
+ * Validates a raw passcode value against the rules in Requirements 1.3, 1.4,
+ * and 8.2: 4 to 64 UTF-8 code points, no control characters, no leading or
+ * trailing whitespace.
+ *
+ * The function is deliberately idempotent on valid input: the returned `value`
+ * is the same string that was submitted (no silent trimming). Failure messages
+ * state the rule without echoing the submitted value, which keeps passcodes
+ * out of response bodies and logs (Requirement 7.3).
+ */
+export function validatePasscode(
+  input: unknown,
+): { ok: true; value: string } | { ok: false; message: string } {
+  if (typeof input !== "string") {
+    return {
+      ok: false,
+      message: "passcode must be a string",
+    };
+  }
+
+  if (input !== input.trim()) {
+    return {
+      ok: false,
+      message: "passcode must not contain leading or trailing whitespace",
+    };
+  }
+
+  if (CONTROL_CHAR_PATTERN.test(input)) {
+    return {
+      ok: false,
+      message: "passcode must not contain control characters",
+    };
+  }
+
+  const codePointLength = [...input].length;
+  if (codePointLength < PASSCODE_MIN_LENGTH || codePointLength > PASSCODE_MAX_LENGTH) {
+    return {
+      ok: false,
+      message: `passcode must be ${PASSCODE_MIN_LENGTH} to ${PASSCODE_MAX_LENGTH} characters`,
+    };
+  }
+
+  return { ok: true, value: input };
+}
+
 export function validateCreateRoomRequest(input: CreateRoomRequest): {
   ok: true;
-  value: Omit<CreateStoredRoomInput, "expiresAt">;
+  value: Omit<CreateStoredRoomInput, "expiresAt"> & { passcode?: string };
 } | {
   ok: false;
   message: string;
@@ -57,6 +107,33 @@ export function validateCreateRoomRequest(input: CreateRoomRequest): {
     };
   }
 
+  if (accessMode === "passcode") {
+    if (input.passcode == null || input.passcode === "") {
+      return {
+        ok: false,
+        message: "passcode is required for passcode rooms",
+      };
+    }
+
+    const passcodeResult = validatePasscode(input.passcode);
+    if (!passcodeResult.ok) {
+      return { ok: false, message: passcodeResult.message };
+    }
+
+    return {
+      ok: true,
+      value: {
+        accessMode,
+        maxParticipants,
+        qualityCap,
+        allowScreenShare,
+        passcode: passcodeResult.value,
+      },
+    };
+  }
+
+  // Stray `passcode` fields on non-passcode rooms are silently ignored
+  // (Requirement 1.5). They are never hashed or stored.
   return {
     ok: true,
     value: {
@@ -65,6 +142,66 @@ export function validateCreateRoomRequest(input: CreateRoomRequest): {
       qualityCap,
       allowScreenShare,
     },
+  };
+}
+
+export function validateUpdateSettingsRequest(input: UpdateRoomSettingsRequest): {
+  ok: true;
+  value:
+    | { kind: "rotate"; passcode: string }
+    | { kind: "set-passcode"; passcode: string }
+    | { kind: "clear-passcode"; accessMode: Exclude<AccessMode, "passcode"> };
+} | {
+  ok: false;
+  message: string;
+} {
+  const hasAccessMode = input.accessMode !== undefined;
+  const hasPasscode = input.passcode !== undefined;
+
+  if (!hasAccessMode && !hasPasscode) {
+    return {
+      ok: false,
+      message: "settings update must change accessMode or passcode",
+    };
+  }
+
+  if (hasAccessMode && !ACCESS_MODES.includes(input.accessMode as AccessMode)) {
+    return {
+      ok: false,
+      message: "accessMode must be one of open, lobby, or passcode",
+    };
+  }
+
+  if (hasAccessMode && input.accessMode !== "passcode") {
+    return {
+      ok: true,
+      value: {
+        kind: "clear-passcode",
+        accessMode: input.accessMode as Exclude<AccessMode, "passcode">,
+      },
+    };
+  }
+
+  if (input.passcode == null || input.passcode === "") {
+    return {
+      ok: false,
+      message: "passcode is required for passcode rooms",
+    };
+  }
+
+  const passcodeResult = validatePasscode(input.passcode);
+  if (!passcodeResult.ok) {
+    return { ok: false, message: passcodeResult.message };
+  }
+
+  // If accessMode is explicitly passcode the caller is setting mode + passcode;
+  // if it is omitted the caller is rotating the passcode on an already-passcode
+  // room. The route layer enforces that the room is actually in passcode mode.
+  return {
+    ok: true,
+    value: hasAccessMode
+      ? { kind: "set-passcode", passcode: passcodeResult.value }
+      : { kind: "rotate", passcode: passcodeResult.value },
   };
 }
 

--- a/apps/server/src/passcode.test.ts
+++ b/apps/server/src/passcode.test.ts
@@ -1,0 +1,1509 @@
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+
+import fc from "fast-check";
+
+import { validatePasscode } from "./domain/room-validation.js";
+
+/*
+ * Tests for the passcode-protected-rooms feature.
+ *
+ * Sections (built up across tasks in .kiro/specs/passcode-protected-rooms/tasks.md):
+ *   - Validator unit tests (task 2.1) + Property 2 (task 2.2)
+ *   - Verifier unit tests (task 3.1) + Property 1 (task 3.2)
+ *   - Rate limiter unit tests (task 4.1) + Properties 3 and 4 (tasks 4.2, 4.3)
+ *   - HTTP integration for create, join, and settings (tasks 8, 9, 10) + Properties 5, 6, 7
+ */
+
+describe("Validator: validatePasscode", () => {
+  test("accepts a typical 8-character passcode unchanged (idempotent)", () => {
+    const result = validatePasscode("blueFalc");
+    assert.deepEqual(result, { ok: true, value: "blueFalc" });
+  });
+
+  test("accepts exactly the minimum length of 4", () => {
+    const result = validatePasscode("abcd");
+    assert.deepEqual(result, { ok: true, value: "abcd" });
+  });
+
+  test("accepts exactly the maximum length of 64", () => {
+    const value = "a".repeat(64);
+    const result = validatePasscode(value);
+    assert.deepEqual(result, { ok: true, value });
+  });
+
+  test("accepts non-ASCII code points within the length bounds", () => {
+    const value = "pâté-café";
+    assert.equal([...value].length, 9);
+    const result = validatePasscode(value);
+    assert.deepEqual(result, { ok: true, value });
+  });
+
+  test("rejects a string shorter than 4 code points", () => {
+    const result = validatePasscode("abc");
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.ok === false && /4/.test(result.message),
+      "error message should reference the 4-character minimum",
+    );
+  });
+
+  test("rejects an empty string", () => {
+    const result = validatePasscode("");
+    assert.equal(result.ok, false);
+  });
+
+  test("rejects a string longer than 64 code points", () => {
+    const value = "a".repeat(65);
+    const result = validatePasscode(value);
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.ok === false && /64/.test(result.message),
+      "error message should reference the 64-character maximum",
+    );
+  });
+
+  test("rejects input with leading whitespace", () => {
+    const result = validatePasscode(" leadingSpace");
+    assert.equal(result.ok, false);
+  });
+
+  test("rejects input with trailing whitespace", () => {
+    const result = validatePasscode("trailingSpace ");
+    assert.equal(result.ok, false);
+  });
+
+  test("rejects input with embedded control characters", () => {
+    const result = validatePasscode("abc\u0001def");
+    assert.equal(result.ok, false);
+  });
+
+  test("rejects input with a newline character", () => {
+    const result = validatePasscode("abc\ndef");
+    assert.equal(result.ok, false);
+  });
+
+  test("rejects non-string input", () => {
+    // The function accepts unknown; non-string inputs should be rejected without throwing.
+    const result = validatePasscode(42 as unknown as string);
+    assert.equal(result.ok, false);
+  });
+
+  test("failure messages never include the rejected passcode value", () => {
+    const secret = "rejected-secret-xyz";
+    const result = validatePasscode(` ${secret} `);
+    assert.equal(result.ok, false);
+    if (result.ok === false) {
+      assert.ok(
+        !result.message.includes(secret),
+        "validator must not echo the submitted value in the failure message",
+      );
+    }
+  });
+});
+
+describe("Validator: validatePasscode (Property 2)", () => {
+  /*
+   * Feature: passcode-protected-rooms, Property 2: Passcode validator idempotence and rejection
+   * Validates: Requirements 1.3, 1.4, 8.2
+   */
+
+  // Code points allowed inside a valid passcode: printable characters excluding
+  // any control character and excluding outer whitespace. The generator is
+  // constrained to the "visible" ASCII range plus a sampling of non-ASCII
+  // letters so tests exercise code-point length behavior.
+  const validInternalCharArb = fc.oneof(
+    fc.integer({ min: 0x21, max: 0x7e }).map((code) => String.fromCodePoint(code)),
+    fc.constantFrom("é", "ñ", "ü", "Ω", "日", "中", "ñ"),
+  );
+
+  const validPasscodeArb = fc
+    .array(validInternalCharArb, { minLength: 4, maxLength: 64 })
+    .map((chars) => chars.join(""))
+    .filter((value) => {
+      // Guard against generated sequences whose total code-point length exceeds
+      // the bounds (array length and code-point length match for the alphabet
+      // above, but keep the invariant explicit).
+      const cpLength = [...value].length;
+      return cpLength >= 4 && cpLength <= 64;
+    });
+
+  const controlCharArb = fc
+    .integer({ min: 0, max: 0x1f })
+    .map((code) => String.fromCodePoint(code));
+
+  test("any valid passcode returns { ok: true, value: s } (idempotence)", () => {
+    fc.assert(
+      fc.property(validPasscodeArb, (value) => {
+        const result = validatePasscode(value);
+        assert.deepEqual(result, { ok: true, value });
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test("any string shorter than 4 code points is rejected", () => {
+    const shortArb = fc
+      .array(validInternalCharArb, { minLength: 0, maxLength: 3 })
+      .map((chars) => chars.join(""));
+
+    fc.assert(
+      fc.property(shortArb, (value) => {
+        const result = validatePasscode(value);
+        assert.equal(result.ok, false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test("any string longer than 64 code points is rejected", () => {
+    const longArb = fc
+      .array(validInternalCharArb, { minLength: 65, maxLength: 100 })
+      .map((chars) => chars.join(""));
+
+    fc.assert(
+      fc.property(longArb, (value) => {
+        const result = validatePasscode(value);
+        assert.equal(result.ok, false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test("any string containing a control character is rejected", () => {
+    fc.assert(
+      fc.property(validPasscodeArb, controlCharArb, fc.nat(), (base, control, seed) => {
+        // Inject the control character at an arbitrary position within the base.
+        const position = [...base].length === 0 ? 0 : seed % [...base].length;
+        const chars = [...base];
+        chars.splice(position, 0, control);
+        const value = chars.join("");
+
+        const result = validatePasscode(value);
+        assert.equal(result.ok, false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test("any string wrapped in whitespace is rejected", () => {
+    fc.assert(
+      fc.property(validPasscodeArb, fc.constantFrom(" ", "\t"), (base, ws) => {
+        // Only run when wrapping keeps the body under the 64-char ceiling
+        // (otherwise we would be testing length rejection, not whitespace).
+        fc.pre([...base].length + 2 <= 64);
+
+        const wrappedLeading = `${ws}${base}`;
+        const wrappedTrailing = `${base}${ws}`;
+
+        assert.equal(validatePasscode(wrappedLeading).ok, false);
+        assert.equal(validatePasscode(wrappedTrailing).ok, false);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});
+
+
+describe("Verifier: createArgon2idPasscodeVerifier", async () => {
+  // Import dynamically so the test file can be loaded even before the module
+  // exists (lets us author failing-first tests in a single editor session).
+  const { createArgon2idPasscodeVerifier } = await import("./domain/passcode-verifier.js");
+
+  // Use reduced-cost Argon2id parameters so example tests stay fast. The
+  // production factory uses OWASP 2024 baseline defaults; reduced params are
+  // still real Argon2id encoded hashes that exercise the same code path.
+  const testOptions = { memoryCost: 1024, timeCost: 1, parallelism: 1 };
+
+  test("hash returns an Argon2id encoded string", async () => {
+    const verifier = createArgon2idPasscodeVerifier(testOptions);
+    const encoded = await verifier.hash("blueFalc");
+    assert.ok(typeof encoded === "string" && encoded.length > 0);
+    assert.ok(
+      encoded.startsWith("$argon2id$"),
+      "hash should return an argon2id-prefixed encoded string",
+    );
+  });
+
+  test("verify returns true for the same plaintext", async () => {
+    const verifier = createArgon2idPasscodeVerifier(testOptions);
+    const encoded = await verifier.hash("correct-horse");
+    const match = await verifier.verify(encoded, "correct-horse");
+    assert.equal(match, true);
+  });
+
+  test("verify returns false for a different plaintext", async () => {
+    const verifier = createArgon2idPasscodeVerifier(testOptions);
+    const encoded = await verifier.hash("correct-horse");
+    const match = await verifier.verify(encoded, "battery-staple");
+    assert.equal(match, false);
+  });
+
+  test("two hashes of the same plaintext produce distinct encodings (random salt)", async () => {
+    const verifier = createArgon2idPasscodeVerifier(testOptions);
+    const first = await verifier.hash("same-input");
+    const second = await verifier.hash("same-input");
+    assert.notEqual(first, second);
+    // Both must still verify against the original plaintext.
+    assert.equal(await verifier.verify(first, "same-input"), true);
+    assert.equal(await verifier.verify(second, "same-input"), true);
+  });
+});
+
+describe("Verifier: round-trip (Property 1)", async () => {
+  /*
+   * Feature: passcode-protected-rooms, Property 1: Argon2id hash/verify round-trip
+   * Validates: Requirements 2.1, 4.1, 5.1
+   */
+  const { createArgon2idPasscodeVerifier } = await import("./domain/passcode-verifier.js");
+
+  const validInternalCharArb = fc.oneof(
+    fc.integer({ min: 0x21, max: 0x7e }).map((code) => String.fromCodePoint(code)),
+    fc.constantFrom("é", "ñ", "ü", "Ω", "日"),
+  );
+
+  const validPasscodeArb = fc
+    .array(validInternalCharArb, { minLength: 4, maxLength: 32 })
+    .map((chars) => chars.join(""))
+    .filter((value) => {
+      const cpLength = [...value].length;
+      return cpLength >= 4 && cpLength <= 64;
+    });
+
+  test("hash(a) verifies a and not b for any distinct a != b (reduced-cost Argon2id)", async () => {
+    const verifier = createArgon2idPasscodeVerifier({
+      memoryCost: 1024,
+      timeCost: 1,
+      parallelism: 1,
+    });
+
+    await fc.assert(
+      fc.asyncProperty(validPasscodeArb, validPasscodeArb, async (a, b) => {
+        fc.pre(a !== b);
+        const encodedA = await verifier.hash(a);
+        assert.equal(await verifier.verify(encodedA, a), true);
+        assert.equal(await verifier.verify(encodedA, b), false);
+        const encodedA2 = await verifier.hash(a);
+        assert.notEqual(encodedA, encodedA2);
+      }),
+      // 100 iterations with reduced-cost params; stays well under the test-file
+      // runtime budget.
+      { numRuns: 100 },
+    );
+  });
+
+  test("hash/verify round-trip holds under production-baseline Argon2id (25 runs)", async () => {
+    const verifier = createArgon2idPasscodeVerifier();
+
+    await fc.assert(
+      fc.asyncProperty(validPasscodeArb, validPasscodeArb, async (a, b) => {
+        fc.pre(a !== b);
+        const encoded = await verifier.hash(a);
+        assert.equal(await verifier.verify(encoded, a), true);
+        assert.equal(await verifier.verify(encoded, b), false);
+      }),
+      // Production parameters cost ~20-30 ms per hash; 25 runs stays inside
+      // the per-file runtime budget for CI.
+      { numRuns: 25 },
+    );
+  });
+});
+
+
+describe("Rate Limiter: createInMemoryPasscodeRateLimiter", async () => {
+  const { createInMemoryPasscodeRateLimiter } = await import(
+    "./domain/passcode-rate-limiter.js"
+  );
+
+  function createStubClock(start = 0): { now: () => number; advance: (ms: number) => void } {
+    let current = start;
+    return {
+      now: () => current,
+      advance: (ms: number) => {
+        current += ms;
+      },
+    };
+  }
+
+  const keyA = { clientIp: "10.0.0.1", slug: "room-a" };
+  const keyB = { clientIp: "10.0.0.2", slug: "room-a" };
+  const keyC = { clientIp: "10.0.0.1", slug: "room-b" };
+
+  test("initial state allows requests with no failures", () => {
+    const clock = createStubClock();
+    const limiter = createInMemoryPasscodeRateLimiter({ now: clock.now });
+
+    assert.equal(limiter.shouldAllow(keyA), true);
+    const state = limiter.getState(keyA);
+    assert.equal(state.failuresInWindow, 0);
+    assert.equal(state.cooldownUntil, null);
+  });
+
+  test("threshold is reached after 5 failures within the window", () => {
+    const clock = createStubClock();
+    const limiter = createInMemoryPasscodeRateLimiter({ now: clock.now });
+
+    for (let i = 0; i < 4; i += 1) {
+      limiter.recordFailure(keyA);
+      assert.equal(limiter.shouldAllow(keyA), true);
+    }
+
+    // 5th failure opens the cooldown.
+    limiter.recordFailure(keyA);
+    assert.equal(limiter.shouldAllow(keyA), false);
+    const state = limiter.getState(keyA);
+    assert.equal(state.cooldownUntil !== null, true);
+  });
+
+  test("cooldown denies for 60 seconds by default", () => {
+    const clock = createStubClock(1_000_000);
+    const limiter = createInMemoryPasscodeRateLimiter({ now: clock.now });
+
+    for (let i = 0; i < 5; i += 1) {
+      limiter.recordFailure(keyA);
+    }
+
+    // Inside the cooldown: deny.
+    clock.advance(30_000);
+    assert.equal(limiter.shouldAllow(keyA), false);
+
+    // Exactly at the boundary: still denies because cooldownUntil is exclusive
+    // of the equal instant - we only re-allow once the clock has moved past.
+    clock.advance(30_000 - 1);
+    assert.equal(limiter.shouldAllow(keyA), false);
+
+    // Just past the cooldown: allow again.
+    clock.advance(2);
+    assert.equal(limiter.shouldAllow(keyA), true);
+  });
+
+  test("recordSuccess clears both the failure ring and any active cooldown", () => {
+    const clock = createStubClock();
+    const limiter = createInMemoryPasscodeRateLimiter({ now: clock.now });
+
+    for (let i = 0; i < 5; i += 1) {
+      limiter.recordFailure(keyA);
+    }
+    assert.equal(limiter.shouldAllow(keyA), false);
+
+    limiter.recordSuccess(keyA);
+    const state = limiter.getState(keyA);
+    assert.equal(state.failuresInWindow, 0);
+    assert.equal(state.cooldownUntil, null);
+    assert.equal(limiter.shouldAllow(keyA), true);
+  });
+
+  test("failures older than the window are pruned", () => {
+    const clock = createStubClock(0);
+    const limiter = createInMemoryPasscodeRateLimiter({
+      now: clock.now,
+      windowMs: 5 * 60_000,
+    });
+
+    for (let i = 0; i < 4; i += 1) {
+      limiter.recordFailure(keyA);
+    }
+    assert.equal(limiter.getState(keyA).failuresInWindow, 4);
+
+    // Advance just past the sliding window. Older failures should drop out.
+    clock.advance(5 * 60_000 + 1);
+    assert.equal(limiter.getState(keyA).failuresInWindow, 0);
+    assert.equal(limiter.shouldAllow(keyA), true);
+  });
+
+  test("keys are isolated by (clientIp, slug)", () => {
+    const clock = createStubClock();
+    const limiter = createInMemoryPasscodeRateLimiter({ now: clock.now });
+
+    for (let i = 0; i < 5; i += 1) {
+      limiter.recordFailure(keyA);
+    }
+
+    assert.equal(limiter.shouldAllow(keyA), false);
+    assert.equal(limiter.shouldAllow(keyB), true); // different IP, same slug
+    assert.equal(limiter.shouldAllow(keyC), true); // same IP, different slug
+  });
+
+  test("clear(slug) wipes every key that matches the slug", () => {
+    const clock = createStubClock();
+    const limiter = createInMemoryPasscodeRateLimiter({ now: clock.now });
+
+    for (let i = 0; i < 5; i += 1) {
+      limiter.recordFailure(keyA);
+      limiter.recordFailure(keyB);
+      limiter.recordFailure(keyC);
+    }
+
+    limiter.clear("room-a");
+
+    assert.equal(limiter.shouldAllow(keyA), true);
+    assert.equal(limiter.shouldAllow(keyB), true);
+    // Different slug - should still be in cooldown.
+    assert.equal(limiter.shouldAllow(keyC), false);
+  });
+
+  test("clientIp and slug are interpolated safely even when slug contains separators", () => {
+    // Internal key shape uses `${ip}|${slug}` for locking. The public API takes
+    // a tuple so the route layer never hand-crafts the string; this test just
+    // asserts that two similar-looking keys do not collide.
+    const clock = createStubClock();
+    const limiter = createInMemoryPasscodeRateLimiter({ now: clock.now });
+
+    const clash1 = { clientIp: "1.2.3.4", slug: "5|slug" };
+    const clash2 = { clientIp: "1.2.3.4|5", slug: "slug" };
+
+    for (let i = 0; i < 5; i += 1) {
+      limiter.recordFailure(clash1);
+    }
+
+    assert.equal(limiter.shouldAllow(clash1), false);
+    assert.equal(limiter.shouldAllow(clash2), true);
+  });
+});
+
+describe("Rate Limiter: safety under repeated failures (Property 3)", async () => {
+  /*
+   * Feature: passcode-protected-rooms, Property 3: Rate limiter safety under repeated failures
+   * Validates: Requirements 3.2, 4.2, 6.1, 6.2, 6.4
+   */
+  const { createInMemoryPasscodeRateLimiter } = await import(
+    "./domain/passcode-rate-limiter.js"
+  );
+
+  type Event =
+    | { kind: "failure"; dt: number }
+    | { kind: "allow-check"; dt: number }
+    | { kind: "passcode-required"; dt: number };
+
+  const eventArb: fc.Arbitrary<Event> = fc.oneof(
+    fc.record({
+      kind: fc.constant<"failure">("failure"),
+      dt: fc.integer({ min: 0, max: 10_000 }),
+    }),
+    fc.record({
+      kind: fc.constant<"allow-check">("allow-check"),
+      dt: fc.integer({ min: 0, max: 10_000 }),
+    }),
+    fc.record({
+      kind: fc.constant<"passcode-required">("passcode-required"),
+      dt: fc.integer({ min: 0, max: 10_000 }),
+    }),
+  );
+
+  test("once threshold is reached inside the window, every allow-check in the cooldown denies", () => {
+    const windowMs = 5 * 60_000;
+    const cooldownMs = 60_000;
+    const threshold = 5;
+
+    fc.assert(
+      fc.property(fc.array(eventArb, { minLength: 5, maxLength: 40 }), (events) => {
+        let current = 0;
+        const limiter = createInMemoryPasscodeRateLimiter({
+          now: () => current,
+          windowMs,
+          cooldownMs,
+          threshold,
+        });
+        const key = { clientIp: "10.0.0.1", slug: "room-a" };
+
+        for (const event of events) {
+          current += event.dt;
+
+          if (event.kind === "failure") {
+            limiter.recordFailure(key);
+            continue;
+          }
+
+          // For allow-checks we test the invariant: if the ring currently
+          // contains >= threshold failures within the window and a cooldown is
+          // active, shouldAllow must be false. The passcode-required branch
+          // never touches the limiter; nothing to verify there directly.
+          if (event.kind === "passcode-required") {
+            // Property 3 says passcode-required must not affect cooldown
+            // state. We snapshot before/after and compare.
+            const before = limiter.getState(key);
+            // No limiter call; the route layer would return denied without
+            // invoking the limiter. Simulate that by NOT calling anything.
+            const after = limiter.getState(key);
+            assert.deepEqual(after, before);
+            continue;
+          }
+
+          const state = limiter.getState(key);
+          const cooldownActive = state.cooldownUntil !== null && current < state.cooldownUntil;
+          const allow = limiter.shouldAllow(key);
+          if (cooldownActive) {
+            assert.equal(allow, false);
+          }
+        }
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test("failures on one key do not affect shouldAllow on another key", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 5, max: 20 }), (failureCount) => {
+        let current = 0;
+        const limiter = createInMemoryPasscodeRateLimiter({
+          now: () => current,
+          threshold: 5,
+        });
+        const keyA = { clientIp: "1.2.3.4", slug: "room-a" };
+        const keyB = { clientIp: "5.6.7.8", slug: "room-a" };
+
+        for (let i = 0; i < failureCount; i += 1) {
+          limiter.recordFailure(keyA);
+          current += 100;
+        }
+
+        assert.equal(limiter.shouldAllow(keyA), false);
+        assert.equal(limiter.shouldAllow(keyB), true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});
+
+describe("Rate Limiter: recovery (Property 4)", async () => {
+  /*
+   * Feature: passcode-protected-rooms, Property 4: Rate limiter recovery
+   * Validates: Requirements 5.3, 6.3
+   */
+  const { createInMemoryPasscodeRateLimiter } = await import(
+    "./domain/passcode-rate-limiter.js"
+  );
+
+  test("recordSuccess at any time clears all failures and cooldown", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 20 }), (failureCount) => {
+        let current = 0;
+        const limiter = createInMemoryPasscodeRateLimiter({
+          now: () => current,
+          threshold: 5,
+        });
+        const key = { clientIp: "10.0.0.1", slug: "room-a" };
+
+        for (let i = 0; i < failureCount; i += 1) {
+          limiter.recordFailure(key);
+          current += 1_000;
+        }
+
+        limiter.recordSuccess(key);
+        const state = limiter.getState(key);
+        assert.equal(state.failuresInWindow, 0);
+        assert.equal(state.cooldownUntil, null);
+        assert.equal(limiter.shouldAllow(key), true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test("advancing the clock past cooldownMs re-allows", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 5, max: 20 }), (failureCount) => {
+        let current = 0;
+        const cooldownMs = 60_000;
+        const limiter = createInMemoryPasscodeRateLimiter({
+          now: () => current,
+          threshold: 5,
+          cooldownMs,
+        });
+        const key = { clientIp: "10.0.0.1", slug: "room-a" };
+
+        for (let i = 0; i < failureCount; i += 1) {
+          limiter.recordFailure(key);
+        }
+        // Cooldown is active after threshold failures.
+        assert.equal(limiter.shouldAllow(key), false);
+
+        // Advance past the cooldown; limiter should re-allow.
+        current += cooldownMs + 1;
+        assert.equal(limiter.shouldAllow(key), true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});
+
+
+describe("Room store: passcode hash storage", async () => {
+  const { createInMemoryRoomStore } = await import("./domain/room-store.js");
+
+  function baseInput() {
+    return {
+      accessMode: "passcode" as const,
+      maxParticipants: 2,
+      qualityCap: "balanced" as const,
+      allowScreenShare: true,
+      expiresAt: new Date("2026-03-24T18:00:00Z").toISOString(),
+    };
+  }
+
+  test("createRoom stores the passcodeHash when provided", () => {
+    const store = createInMemoryRoomStore();
+    const room = store.createRoom({ ...baseInput(), passcodeHash: "$argon2id$stub" });
+    assert.equal(room.passcodeHash, "$argon2id$stub");
+
+    const fetched = store.getRoom(room.slug);
+    assert.equal(fetched?.passcodeHash, "$argon2id$stub");
+  });
+
+  test("createRoom leaves passcodeHash null when not provided", () => {
+    const store = createInMemoryRoomStore();
+    const room = store.createRoom({ ...baseInput(), accessMode: "open" });
+    assert.equal(room.passcodeHash, null);
+  });
+
+  test("setPasscodeHash replaces the stored hash and returns true", () => {
+    const store = createInMemoryRoomStore();
+    const room = store.createRoom({ ...baseInput(), passcodeHash: "$argon2id$old" });
+
+    const ok = store.setPasscodeHash(room.slug, "$argon2id$new");
+    assert.equal(ok, true);
+    assert.equal(store.getRoom(room.slug)?.passcodeHash, "$argon2id$new");
+  });
+
+  test("setPasscodeHash returns false for unknown slug", () => {
+    const store = createInMemoryRoomStore();
+    assert.equal(store.setPasscodeHash("not-a-room", "$argon2id$new"), false);
+  });
+
+  test("clearPasscodeHash nulls the stored hash and returns true", () => {
+    const store = createInMemoryRoomStore();
+    const room = store.createRoom({ ...baseInput(), passcodeHash: "$argon2id$stub" });
+
+    const ok = store.clearPasscodeHash(room.slug);
+    assert.equal(ok, true);
+    assert.equal(store.getRoom(room.slug)?.passcodeHash, null);
+  });
+
+  test("clearPasscodeHash returns false for unknown slug", () => {
+    const store = createInMemoryRoomStore();
+    assert.equal(store.clearPasscodeHash("not-a-room"), false);
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// HTTP integration helpers. Tests in the sections below build a Fastify
+// instance with stubbed verifier and rate limiter so assertions run fast and
+// stay deterministic.
+// ---------------------------------------------------------------------------
+
+import { buildApp } from "./app.js";
+import { createInMemoryRoomStore } from "./domain/room-store.js";
+import { TEST_LIVEKIT_CONFIG, createMemoryLogger, joinOutputs } from "./test-helpers.js";
+import type { PasscodeVerifier } from "./domain/passcode-verifier.js";
+import type { PasscodeRateLimiter } from "./domain/passcode-rate-limiter.js";
+
+function createFakeVerifier(): PasscodeVerifier & {
+  calls: { hash: number; verify: number };
+} {
+  const calls = { hash: 0, verify: 0 };
+  return {
+    calls,
+    async hash(plaintext) {
+      calls.hash += 1;
+      // Use a recognizable prefix so tests can assert the stored value is an
+      // encoded hash rather than the plaintext.
+      return `$fake$${plaintext}`;
+    },
+    async verify(encodedHash, plaintext) {
+      calls.verify += 1;
+      return encodedHash === `$fake$${plaintext}`;
+    },
+  };
+}
+
+// Simpler rate limiter stub: synchronous in-memory implementation so HTTP
+// tests can interleave failures and allow-checks without promise races.
+async function createSyncRateLimiter(options?: {
+  threshold?: number;
+  cooldownMs?: number;
+  windowMs?: number;
+}) {
+  const mod = await import("./domain/passcode-rate-limiter.js");
+  let now = 1_700_000_000_000;
+  const limiter = mod.createInMemoryPasscodeRateLimiter({
+    now: () => now,
+    threshold: options?.threshold ?? 5,
+    cooldownMs: options?.cooldownMs ?? 60_000,
+    windowMs: options?.windowMs ?? 5 * 60_000,
+  });
+  return {
+    limiter,
+    advanceClock: (ms: number) => {
+      now += ms;
+    },
+    setClock: (value: number) => {
+      now = value;
+    },
+  };
+}
+
+describe("HTTP: create passcode room", () => {
+  test("rejects create with accessMode=passcode and missing passcode", async () => {
+    const app = buildApp({
+      logger: false,
+      liveKitConfig: TEST_LIVEKIT_CONFIG,
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/rooms",
+      payload: { accessMode: "passcode" },
+    });
+
+    assert.equal(response.statusCode, 400);
+    const body = response.json() as { message: string };
+    assert.ok(/passcode is required/i.test(body.message));
+    await app.close();
+  });
+
+  test("rejects create with a passcode that is too short", async () => {
+    const app = buildApp({ logger: false, liveKitConfig: TEST_LIVEKIT_CONFIG });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/rooms",
+      payload: { accessMode: "passcode", passcode: "abc" },
+    });
+
+    assert.equal(response.statusCode, 400);
+    const body = response.json() as { message: string };
+    assert.ok(/4 to 64/.test(body.message));
+    await app.close();
+  });
+
+  test("accepts create with a valid passcode and echoes plaintext exactly once", async () => {
+    const verifier = createFakeVerifier();
+    const app = buildApp({
+      logger: false,
+      liveKitConfig: TEST_LIVEKIT_CONFIG,
+      passcodeVerifier: verifier,
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/rooms",
+      payload: { accessMode: "passcode", passcode: "blueFalcon42" },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as {
+      passcode?: string;
+      room: { accessMode: string };
+    };
+    assert.equal(body.passcode, "blueFalcon42");
+    assert.equal(body.room.accessMode, "passcode");
+    // Plaintext must not appear nested inside the room summary.
+    assert.equal((body.room as Record<string, unknown>).passcode, undefined);
+    // `room` summary never carries a hash either.
+    assert.equal((body.room as Record<string, unknown>).passcodeHash, undefined);
+    // Verifier.hash was called once.
+    assert.equal(verifier.calls.hash, 1);
+    await app.close();
+  });
+
+  test("stores passcodeHash on the StoredRoom (not plaintext)", async () => {
+    const store = createInMemoryRoomStore();
+    const verifier = createFakeVerifier();
+    const app = buildApp({
+      logger: false,
+      liveKitConfig: TEST_LIVEKIT_CONFIG,
+      passcodeVerifier: verifier,
+      roomStore: store,
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/rooms",
+      payload: { accessMode: "passcode", passcode: "blueFalcon42" },
+    });
+
+    const body = response.json() as { roomSlug: string };
+    const stored = store.getRoom(body.roomSlug);
+    assert.ok(stored != null);
+    assert.equal(stored.accessMode, "passcode");
+    assert.equal(stored.passcodeHash, "$fake$blueFalcon42");
+    await app.close();
+  });
+
+  test("open-mode create with stray passcode field succeeds and stores no hash (Property 6 partial)", async () => {
+    const store = createInMemoryRoomStore();
+    const verifier = createFakeVerifier();
+    const app = buildApp({
+      logger: false,
+      liveKitConfig: TEST_LIVEKIT_CONFIG,
+      passcodeVerifier: verifier,
+      roomStore: store,
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/rooms",
+      payload: { accessMode: "open", passcode: "ignored-value" },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as { roomSlug: string; passcode?: string };
+    assert.equal(body.passcode, undefined);
+
+    const stored = store.getRoom(body.roomSlug);
+    assert.equal(stored?.passcodeHash, null);
+    // Verifier must not have been invoked for a non-passcode room.
+    assert.equal(verifier.calls.hash, 0);
+    await app.close();
+  });
+});
+
+describe("HTTP: join passcode room", () => {
+  async function setupRoom(verifier: PasscodeVerifier, limiter: PasscodeRateLimiter) {
+    const store = createInMemoryRoomStore();
+    const app = buildApp({
+      logger: false,
+      liveKitConfig: TEST_LIVEKIT_CONFIG,
+      passcodeVerifier: verifier,
+      passcodeRateLimiter: limiter,
+      roomStore: store,
+    });
+
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/rooms",
+      payload: { accessMode: "passcode", passcode: "correct-horse-42" },
+    });
+    const { roomSlug } = createResponse.json() as { roomSlug: string };
+    return { app, store, slug: roomSlug };
+  }
+
+  test("join without a passcode returns passcode_required without invoking verifier", async () => {
+    const verifier = createFakeVerifier();
+    const { limiter } = await createSyncRateLimiter();
+    const { app, slug } = await setupRoom(verifier, limiter);
+
+    const hashCountBefore = verifier.calls.hash; // set to 1 after create
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/join`,
+      payload: { displayName: "Sam" },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as { joinState: string; reason: string };
+    assert.equal(body.joinState, "denied");
+    assert.equal(body.reason, "passcode_required");
+    // Verifier must not have been called for passcode_required.
+    assert.equal(verifier.calls.verify, 0);
+    // The only hash call is the one from create.
+    assert.equal(verifier.calls.hash, hashCountBefore);
+    await app.close();
+  });
+
+  test("join with wrong passcode returns invalid_passcode and records a failure", async () => {
+    const verifier = createFakeVerifier();
+    const { limiter } = await createSyncRateLimiter();
+    const { app, slug } = await setupRoom(verifier, limiter);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/join`,
+      payload: { displayName: "Sam", passcode: "wrong" },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as { joinState: string; reason: string };
+    assert.equal(body.joinState, "denied");
+    assert.equal(body.reason, "invalid_passcode");
+    assert.equal(verifier.calls.verify, 1);
+
+    const state = limiter.getState({ clientIp: "127.0.0.1", slug });
+    assert.equal(state.failuresInWindow, 1);
+    await app.close();
+  });
+
+  test("join with correct passcode returns direct and clears any failures", async () => {
+    const verifier = createFakeVerifier();
+    const { limiter } = await createSyncRateLimiter();
+    const { app, slug } = await setupRoom(verifier, limiter);
+
+    // Prime one failure so we can observe that success clears it.
+    await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/join`,
+      payload: { displayName: "Sam", passcode: "wrong" },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/join`,
+      payload: { displayName: "Sam", passcode: "correct-horse-42" },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as {
+      joinState: string;
+      sessionId?: string;
+      transportPreference?: string;
+    };
+    assert.equal(body.joinState, "direct");
+    assert.ok(body.sessionId && body.sessionId.length > 0);
+    assert.equal(body.transportPreference, "sfu");
+
+    const state = limiter.getState({ clientIp: "127.0.0.1", slug });
+    assert.equal(state.failuresInWindow, 0);
+    assert.equal(state.cooldownUntil, null);
+    await app.close();
+  });
+
+  test("after 5 failures the next attempt is denied without invoking the verifier", async () => {
+    const verifier = createFakeVerifier();
+    const { limiter } = await createSyncRateLimiter();
+    const { app, slug } = await setupRoom(verifier, limiter);
+
+    for (let i = 0; i < 5; i += 1) {
+      await app.inject({
+        method: "POST",
+        url: `/api/rooms/${slug}/join`,
+        payload: { displayName: "Sam", passcode: "wrong" },
+      });
+    }
+    const verifyCountAfterFailures = verifier.calls.verify;
+
+    // Cooldown is now active. Next attempt - even with the correct passcode -
+    // must be denied and must not invoke the verifier again.
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/join`,
+      payload: { displayName: "Sam", passcode: "correct-horse-42" },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as { joinState: string; reason: string };
+    assert.equal(body.joinState, "denied");
+    assert.equal(body.reason, "invalid_passcode");
+    assert.equal(verifier.calls.verify, verifyCountAfterFailures);
+    await app.close();
+  });
+
+  test("room_expired precedence over passcode check", async () => {
+    // Build with an artificial clock that jumps far forward after room create.
+    let simulated = new Date("2026-03-24T18:00:00Z");
+    const store = createInMemoryRoomStore();
+    const verifier = createFakeVerifier();
+    const { limiter } = await createSyncRateLimiter();
+    const app = buildApp({
+      logger: false,
+      liveKitConfig: TEST_LIVEKIT_CONFIG,
+      passcodeVerifier: verifier,
+      passcodeRateLimiter: limiter,
+      roomStore: store,
+      now: () => simulated,
+    });
+
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/rooms",
+      payload: { accessMode: "passcode", passcode: "correct-horse-42" },
+    });
+    const { roomSlug } = createResponse.json() as { roomSlug: string };
+
+    // Jump far past the 2-hour default TTL.
+    simulated = new Date(simulated.getTime() + 10 * 60 * 60 * 1000);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/join`,
+      payload: { displayName: "Sam", passcode: "correct-horse-42" },
+    });
+
+    const body = response.json() as { joinState: string; reason: string };
+    assert.equal(body.joinState, "denied");
+    assert.equal(body.reason, "room_expired");
+    // Verifier not invoked when the room is already expired.
+    assert.equal(verifier.calls.verify, 0);
+    await app.close();
+  });
+
+  test("room_full precedence over passcode check", async () => {
+    const verifier = createFakeVerifier();
+    const { limiter } = await createSyncRateLimiter();
+    const store = createInMemoryRoomStore();
+    const app = buildApp({
+      logger: false,
+      liveKitConfig: TEST_LIVEKIT_CONFIG,
+      passcodeVerifier: verifier,
+      passcodeRateLimiter: limiter,
+      roomStore: store,
+    });
+
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/rooms",
+      payload: {
+        accessMode: "passcode",
+        passcode: "correct-horse-42",
+        maxParticipants: 2,
+      },
+    });
+    const { roomSlug } = createResponse.json() as { roomSlug: string };
+
+    // Fill the room with two direct sessions via the correct passcode.
+    await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/join`,
+      payload: { displayName: "A", passcode: "correct-horse-42" },
+    });
+    await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/join`,
+      payload: { displayName: "B", passcode: "correct-horse-42" },
+    });
+
+    const verifyCallsBefore = verifier.calls.verify;
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/join`,
+      payload: { displayName: "C", passcode: "correct-horse-42" },
+    });
+
+    const body = response.json() as { joinState: string; reason: string };
+    assert.equal(body.joinState, "denied");
+    assert.equal(body.reason, "room_full");
+    // Verifier must not be consulted when the room is already full.
+    assert.equal(verifier.calls.verify, verifyCallsBefore);
+    await app.close();
+  });
+});
+
+
+describe("HTTP: settings endpoint", () => {
+  async function setup() {
+    const store = createInMemoryRoomStore();
+    const verifier = createFakeVerifier();
+    const { limiter } = await createSyncRateLimiter();
+    const app = buildApp({
+      logger: false,
+      liveKitConfig: TEST_LIVEKIT_CONFIG,
+      passcodeVerifier: verifier,
+      passcodeRateLimiter: limiter,
+      roomStore: store,
+    });
+
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/rooms",
+      payload: { accessMode: "passcode", passcode: "original-passcode" },
+    });
+    const { roomSlug, hostSecret } = createResponse.json() as {
+      roomSlug: string;
+      hostSecret: string;
+    };
+    return { app, store, slug: roomSlug, hostSecret, verifier, limiter };
+  }
+
+  test("403 when host secret is missing", async () => {
+    const { app, slug } = await setup();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/settings`,
+      payload: { accessMode: "open" },
+    });
+
+    assert.equal(response.statusCode, 403);
+    await app.close();
+  });
+
+  test("400 when body has neither accessMode nor passcode", async () => {
+    const { app, slug, hostSecret } = await setup();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/settings`,
+      headers: { "x-host-secret": hostSecret },
+      payload: {},
+    });
+
+    assert.equal(response.statusCode, 400);
+    await app.close();
+  });
+
+  test("rotating the passcode replaces the hash and clears the rate limiter", async () => {
+    const { app, store, slug, hostSecret, limiter } = await setup();
+
+    // Prime a failure so we can watch the limiter get cleared on rotation.
+    await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/join`,
+      payload: { displayName: "Sam", passcode: "wrong" },
+    });
+    assert.equal(limiter.getState({ clientIp: "127.0.0.1", slug }).failuresInWindow, 1);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/settings`,
+      headers: { "x-host-secret": hostSecret },
+      payload: { passcode: "new-passcode-value" },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as Record<string, unknown>;
+    // Response must never echo the plaintext.
+    assert.equal(body.passcode, undefined);
+    assert.equal((body.room as { accessMode: string }).accessMode, "passcode");
+
+    assert.equal(store.getRoom(slug)?.passcodeHash, "$fake$new-passcode-value");
+    assert.equal(limiter.getState({ clientIp: "127.0.0.1", slug }).failuresInWindow, 0);
+
+    // Old passcode should now fail.
+    const oldAttempt = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/join`,
+      payload: { displayName: "Sam", passcode: "original-passcode" },
+    });
+    const oldBody = oldAttempt.json() as { reason: string };
+    assert.equal(oldBody.reason, "invalid_passcode");
+
+    // New passcode admits.
+    const newAttempt = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/join`,
+      payload: { displayName: "Sam", passcode: "new-passcode-value" },
+    });
+    const newBody = newAttempt.json() as { joinState: string };
+    assert.equal(newBody.joinState, "direct");
+    await app.close();
+  });
+
+  test("changing accessMode away from passcode clears the hash and admits directly", async () => {
+    const { app, store, slug, hostSecret, limiter } = await setup();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/settings`,
+      headers: { "x-host-secret": hostSecret },
+      payload: { accessMode: "open" },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(store.getRoom(slug)?.passcodeHash, null);
+    assert.equal(store.getRoom(slug)?.accessMode, "open");
+    assert.equal(limiter.getState({ clientIp: "127.0.0.1", slug }).failuresInWindow, 0);
+
+    // Previously-failed passcode attempts no longer apply: any join with or
+    // without a passcode follows the open path.
+    const admit = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/join`,
+      payload: { displayName: "Sam", passcode: "ignored-anyway" },
+    });
+    const admitBody = admit.json() as { joinState: string };
+    assert.equal(admitBody.joinState, "direct");
+    await app.close();
+  });
+
+  test("rotation fails when the room is not in passcode mode", async () => {
+    const { app, slug, hostSecret } = await setup();
+
+    // First switch the room away from passcode mode.
+    await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/settings`,
+      headers: { "x-host-secret": hostSecret },
+      payload: { accessMode: "open" },
+    });
+
+    // Rotate call should now fail because the room is no longer passcode mode.
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/settings`,
+      headers: { "x-host-secret": hostSecret },
+      payload: { passcode: "another-one" },
+    });
+
+    assert.equal(response.statusCode, 400);
+    await app.close();
+  });
+
+  test("transitioning to passcode mode requires a valid passcode payload", async () => {
+    const { app, slug, hostSecret } = await setup();
+
+    // First switch away from passcode.
+    await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/settings`,
+      headers: { "x-host-secret": hostSecret },
+      payload: { accessMode: "open" },
+    });
+
+    // Now try to switch back to passcode without supplying a passcode body.
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${slug}/settings`,
+      headers: { "x-host-secret": hostSecret },
+      payload: { accessMode: "passcode" },
+    });
+
+    assert.equal(response.statusCode, 400);
+    await app.close();
+  });
+});
+
+describe("HTTP: Property 5 (no echo of passcode plaintext or hash)", () => {
+  /*
+   * Feature: passcode-protected-rooms, Property 5: No echo of passcode plaintext or hash
+   * Validates: Requirements 2.2, 2.3, 2.4, 7.1, 7.2, 7.3, 9.2
+   *
+   * Uses a real Argon2id verifier with reduced parameters so the stored hash
+   * is a realistic encoded string. Captures log output through the memory
+   * logger helper and scans every response body except the single sanctioned
+   * create-response echo.
+   */
+
+  const passcodeCharArb = fc
+    .array(fc.integer({ min: 0x21, max: 0x7e }).map((c) => String.fromCodePoint(c)), {
+      minLength: 8,
+      maxLength: 24,
+    })
+    .map((chars) => chars.join(""));
+
+  test("plaintext and hash never appear outside the sanctioned create echo", async () => {
+    const { createArgon2idPasscodeVerifier } = await import("./domain/passcode-verifier.js");
+
+    await fc.assert(
+      fc.asyncProperty(passcodeCharArb, async (plaintext) => {
+        fc.pre(plaintext.trim() === plaintext);
+        fc.pre(!/\p{Cc}/u.test(plaintext));
+
+        const verifier = createArgon2idPasscodeVerifier({
+          memoryCost: 1024,
+          timeCost: 1,
+          parallelism: 1,
+        });
+        const store = createInMemoryRoomStore();
+        const memLogger = createMemoryLogger();
+        const app = buildApp({
+          logger: memLogger.loggerOption,
+          liveKitConfig: TEST_LIVEKIT_CONFIG,
+          passcodeVerifier: verifier,
+          roomStore: store,
+        });
+
+        const nonCreateBodies: string[] = [];
+
+        const createResponse = await app.inject({
+          method: "POST",
+          url: "/api/rooms",
+          payload: { accessMode: "passcode", passcode: plaintext },
+        });
+        const { roomSlug } = createResponse.json() as { roomSlug: string };
+        const storedHash = store.getRoom(roomSlug)?.passcodeHash ?? "";
+
+        // Wrong passcode attempt.
+        const wrong = await app.inject({
+          method: "POST",
+          url: `/api/rooms/${roomSlug}/join`,
+          payload: { displayName: "Sam", passcode: `${plaintext}-nope` },
+        });
+        nonCreateBodies.push(wrong.body);
+
+        // Correct passcode attempt.
+        const right = await app.inject({
+          method: "POST",
+          url: `/api/rooms/${roomSlug}/join`,
+          payload: { displayName: "Sam", passcode: plaintext },
+        });
+        nonCreateBodies.push(right.body);
+
+        // Room metadata GET must not carry plaintext or hash.
+        const meta = await app.inject({
+          method: "GET",
+          url: `/api/rooms/${roomSlug}`,
+        });
+        nonCreateBodies.push(meta.body);
+
+        await app.close();
+
+        const combined = joinOutputs(nonCreateBodies, memLogger.readCapturedLogs());
+
+        assert.equal(
+          combined.includes(plaintext),
+          false,
+          `plaintext leaked in response or log output`,
+        );
+        assert.equal(
+          combined.includes(storedHash),
+          false,
+          `passcode hash leaked in response or log output`,
+        );
+      }),
+      { numRuns: 20 },
+    );
+  });
+});
+
+describe("HTTP: Property 6 (access-mode gating)", () => {
+  /*
+   * Feature: passcode-protected-rooms, Property 6: Access-mode gating
+   * Validates: Requirements 1.5, 4.3 (negative half)
+   *
+   * For any room created with accessMode in {open, lobby}, the verifier must
+   * not be invoked on any create or join call regardless of stray passcode
+   * fields, and the rate limiter must show zero failures.
+   */
+
+  const anyPasscodeArb = fc.option(
+    fc.string({ minLength: 1, maxLength: 30 }),
+    { nil: undefined },
+  );
+
+  test("verifier is not invoked for non-passcode rooms, regardless of stray passcode fields", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.constantFrom("open" as const, "lobby" as const),
+        anyPasscodeArb,
+        anyPasscodeArb,
+        async (accessMode, createPasscode, joinPasscode) => {
+          const verifier = createFakeVerifier();
+          const { limiter } = await createSyncRateLimiter();
+          const store = createInMemoryRoomStore();
+          const app = buildApp({
+            logger: false,
+            liveKitConfig: TEST_LIVEKIT_CONFIG,
+            passcodeVerifier: verifier,
+            passcodeRateLimiter: limiter,
+            roomStore: store,
+          });
+
+          const createResponse = await app.inject({
+            method: "POST",
+            url: "/api/rooms",
+            payload: { accessMode, passcode: createPasscode },
+          });
+
+          // Skip runs where validation rejected the create call (e.g. when
+          // accessMode is somehow rejected by other validation rules). The
+          // property only applies to successfully created rooms.
+          if (createResponse.statusCode !== 200) {
+            await app.close();
+            return;
+          }
+
+          const { roomSlug } = createResponse.json() as { roomSlug: string };
+          assert.equal(store.getRoom(roomSlug)?.passcodeHash, null);
+
+          const joinResponse = await app.inject({
+            method: "POST",
+            url: `/api/rooms/${roomSlug}/join`,
+            payload: { displayName: "Sam", passcode: joinPasscode },
+          });
+
+          // For open rooms the join path should return direct or room_full;
+          // for lobby rooms it should return waiting. Neither path should have
+          // consulted the verifier or the rate limiter.
+          const body = joinResponse.json() as { joinState: string };
+          assert.ok(["direct", "waiting", "denied"].includes(body.joinState));
+
+          assert.equal(verifier.calls.verify, 0);
+          assert.equal(
+            limiter.getState({ clientIp: "127.0.0.1", slug: roomSlug }).failuresInWindow,
+            0,
+          );
+
+          await app.close();
+        },
+      ),
+      { numRuns: 50 },
+    );
+  });
+});
+
+describe("HTTP: Property 7 (rotation safety)", () => {
+  /*
+   * Feature: passcode-protected-rooms, Property 7: Rotation safety
+   * Validates: Requirements 8.1, 8.3
+   */
+
+  const passcodeArb = fc
+    .array(
+      fc.integer({ min: 0x21, max: 0x7e }).map((c) => String.fromCodePoint(c)),
+      { minLength: 8, maxLength: 20 },
+    )
+    .map((chars) => chars.join(""));
+
+  test("after rotation, the old passcode fails and the new one admits (even with pre-rotation cooldown)", async () => {
+    await fc.assert(
+      fc.asyncProperty(passcodeArb, passcodeArb, async (oldP, newP) => {
+        fc.pre(oldP !== newP);
+
+        const verifier = createFakeVerifier();
+        const { limiter } = await createSyncRateLimiter();
+        const store = createInMemoryRoomStore();
+        const app = buildApp({
+          logger: false,
+          liveKitConfig: TEST_LIVEKIT_CONFIG,
+          passcodeVerifier: verifier,
+          passcodeRateLimiter: limiter,
+          roomStore: store,
+        });
+
+        const createResponse = await app.inject({
+          method: "POST",
+          url: "/api/rooms",
+          payload: { accessMode: "passcode", passcode: oldP },
+        });
+        const { roomSlug, hostSecret } = createResponse.json() as {
+          roomSlug: string;
+          hostSecret: string;
+        };
+
+        // Burn the rate limiter by submitting five wrong attempts.
+        for (let i = 0; i < 5; i += 1) {
+          await app.inject({
+            method: "POST",
+            url: `/api/rooms/${roomSlug}/join`,
+            payload: { displayName: "Sam", passcode: `${oldP}-wrong` },
+          });
+        }
+
+        // Rotate.
+        const rotate = await app.inject({
+          method: "POST",
+          url: `/api/rooms/${roomSlug}/settings`,
+          headers: { "x-host-secret": hostSecret },
+          payload: { passcode: newP },
+        });
+        assert.equal(rotate.statusCode, 200);
+
+        // Old passcode fails.
+        const oldAttempt = await app.inject({
+          method: "POST",
+          url: `/api/rooms/${roomSlug}/join`,
+          payload: { displayName: "Sam", passcode: oldP },
+        });
+        const oldBody = oldAttempt.json() as { reason: string };
+        assert.equal(oldBody.reason, "invalid_passcode");
+
+        // New passcode admits.
+        const newAttempt = await app.inject({
+          method: "POST",
+          url: `/api/rooms/${roomSlug}/join`,
+          payload: { displayName: "Sam", passcode: newP },
+        });
+        const newBody = newAttempt.json() as { joinState: string };
+        assert.equal(newBody.joinState, "direct");
+
+        // Rate limiter state for this slug should be zero across any key.
+        const state = limiter.getState({ clientIp: "127.0.0.1", slug: roomSlug });
+        assert.equal(state.failuresInWindow, 0);
+        assert.equal(state.cooldownUntil, null);
+
+        await app.close();
+      }),
+      { numRuns: 25 },
+    );
+  });
+});

--- a/apps/server/src/rooms.test.ts
+++ b/apps/server/src/rooms.test.ts
@@ -260,3 +260,25 @@ test("POST /api/rooms/:slug/join denies when the room TTL has already expired", 
 
   await app.close();
 });
+
+
+test("POST /api/rooms ignores a stray passcode field for non-passcode rooms", async () => {
+  const app = buildApp();
+
+  for (const accessMode of ["open", "lobby"] as const) {
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/rooms",
+      payload: { accessMode, passcode: "ignored-value" },
+    });
+
+    assert.equal(response.statusCode, 200, `expected 200 for ${accessMode}`);
+    const payload = response.json();
+    assert.equal(payload.passcode, undefined, `expected no echoed passcode for ${accessMode}`);
+    assert.equal(payload.room.accessMode, accessMode);
+    // `room` summary never carries a hash field for any mode.
+    assert.equal(payload.room.passcodeHash, undefined);
+  }
+
+  await app.close();
+});

--- a/apps/server/src/routes/rooms.ts
+++ b/apps/server/src/routes/rooms.ts
@@ -1,5 +1,11 @@
 import type { FastifyInstance } from "fastify";
-import type { CreateRoomRequest, CreateRoomResponse, JoinRoomRequest, JoinRoomResponse, RoomSummary } from "@lowtime/shared";
+import type {
+  CreateRoomRequest,
+  CreateRoomResponse,
+  JoinRoomRequest,
+  JoinRoomResponse,
+  RoomSummary,
+} from "@lowtime/shared";
 
 import { toRoomSummary, getRoomStatus } from "../domain/room-status.js";
 import { validateCreateRoomRequest, validateJoinRoomRequest } from "../domain/room-validation.js";
@@ -22,18 +28,29 @@ export function registerRoomRoutes(app: FastifyInstance, context: RouteContext) 
         };
       }
 
+      const { passcode: plainPasscode, ...storeInput } = validation.value;
+      const passcodeHash =
+        plainPasscode != null ? await context.passcodeVerifier.hash(plainPasscode) : undefined;
+
       const room = context.roomStore.createRoom({
-        ...validation.value,
+        ...storeInput,
         expiresAt: createRoomExpiry(context.now()),
+        passcodeHash,
       });
 
-      return {
+      const responseBody: CreateRoomResponse = {
         roomSlug: room.slug,
         joinUrl: `/r/${room.slug}`,
         hostSecret: room.hostSecret,
         expiresAt: room.expiresAt,
         room: toRoomSummary(room, context.now()),
       };
+
+      if (plainPasscode != null) {
+        responseBody.passcode = plainPasscode;
+      }
+
+      return responseBody;
     },
   );
 
@@ -91,14 +108,45 @@ export function registerRoomRoutes(app: FastifyInstance, context: RouteContext) 
       }
 
       if (room.accessMode === "passcode") {
-        return {
-          joinState: "denied",
-          reason: validation.value.passcode == null ? "passcode_required" : "invalid_passcode",
-        };
+        const submittedPasscode = validation.value.passcode;
+        if (submittedPasscode == null || submittedPasscode === "") {
+          return {
+            joinState: "denied",
+            reason: "passcode_required",
+          };
+        }
+
+        const key = { clientIp: request.ip, slug: room.slug };
+
+        if (!context.passcodeRateLimiter.shouldAllow(key)) {
+          return {
+            joinState: "denied",
+            reason: "invalid_passcode",
+          };
+        }
+
+        const match =
+          room.passcodeHash != null &&
+          (await context.passcodeVerifier.verify(room.passcodeHash, submittedPasscode));
+
+        if (!match) {
+          context.passcodeRateLimiter.recordFailure(key);
+          return {
+            joinState: "denied",
+            reason: "invalid_passcode",
+          };
+        }
+
+        context.passcodeRateLimiter.recordSuccess(key);
+        // Fall through to the direct-session admission path below.
       }
 
       if (room.accessMode === "lobby") {
-        const lobbyRequest = context.roomStore.createLobbyRequest(room.slug, validation.value.displayName, context.now().toISOString());
+        const lobbyRequest = context.roomStore.createLobbyRequest(
+          room.slug,
+          validation.value.displayName,
+          context.now().toISOString(),
+        );
 
         if (lobbyRequest == null) {
           return {

--- a/apps/server/src/routes/settings.ts
+++ b/apps/server/src/routes/settings.ts
@@ -1,0 +1,80 @@
+import type { FastifyInstance } from "fastify";
+import type {
+  UpdateRoomSettingsRequest,
+  UpdateRoomSettingsResponse,
+} from "@lowtime/shared";
+
+import { toRoomSummary } from "../domain/room-status.js";
+import { validateUpdateSettingsRequest } from "../domain/room-validation.js";
+import {
+  hasValidHostSecret,
+  type RouteContext,
+} from "../server-support.js";
+
+/**
+ * Host-only settings endpoint. Currently supports two transitions:
+ *   - rotating the passcode on a passcode room
+ *   - changing the access mode between open, lobby, and passcode
+ *
+ * Both transitions clear the rate limiter for the room so a freshly-rotated
+ * passcode is not locked out by residual cooldown state (Requirement 8.1).
+ *
+ * The endpoint never echoes the new plaintext passcode in its response
+ * (Requirement 9.3): the host is expected to remember what they just sent.
+ */
+export function registerSettingsRoutes(app: FastifyInstance, context: RouteContext) {
+  app.post<{
+    Params: { slug: string };
+    Body: UpdateRoomSettingsRequest;
+    Headers: { "x-host-secret"?: string };
+    Reply: UpdateRoomSettingsResponse | { message: string };
+  }>("/api/rooms/:slug/settings", async (request, reply) => {
+    const room = context.roomStore.getRoom(request.params.slug);
+
+    if (room == null) {
+      reply.code(404);
+      return { message: "Room not found" };
+    }
+
+    if (!hasValidHostSecret(room, request.headers["x-host-secret"])) {
+      reply.code(403);
+      return { message: "Host secret is required" };
+    }
+
+    const body = request.body ?? {};
+    const validation = validateUpdateSettingsRequest(body);
+
+    if (!validation.ok) {
+      reply.code(400);
+      return { message: validation.message };
+    }
+
+    const decision = validation.value;
+
+    if (decision.kind === "clear-passcode") {
+      room.accessMode = decision.accessMode;
+      context.roomStore.clearPasscodeHash(room.slug);
+      context.passcodeRateLimiter.clear(room.slug);
+      return { room: toRoomSummary(room, context.now()) };
+    }
+
+    if (decision.kind === "rotate") {
+      // Rotation only makes sense when the room is already in passcode mode.
+      if (room.accessMode !== "passcode") {
+        reply.code(400);
+        return { message: "passcode rotation requires passcode access mode" };
+      }
+    }
+
+    // Both "rotate" and "set-passcode" hash the new plaintext and replace the
+    // stored hash. We never touch the plaintext beyond the hashing step.
+    const encodedHash = await context.passcodeVerifier.hash(decision.passcode);
+    context.roomStore.setPasscodeHash(room.slug, encodedHash);
+    if (decision.kind === "set-passcode") {
+      room.accessMode = "passcode";
+    }
+    context.passcodeRateLimiter.clear(room.slug);
+
+    return { room: toRoomSummary(room, context.now()) };
+  });
+}

--- a/apps/server/src/server-support.ts
+++ b/apps/server/src/server-support.ts
@@ -1,4 +1,14 @@
+import type { FastifyServerOptions } from "fastify";
+
 import { getLiveKitConfig, type LiveKitConfig } from "./livekit.js";
+import {
+  createArgon2idPasscodeVerifier,
+  type PasscodeVerifier,
+} from "./domain/passcode-verifier.js";
+import {
+  createInMemoryPasscodeRateLimiter,
+  type PasscodeRateLimiter,
+} from "./domain/passcode-rate-limiter.js";
 import {
   createInMemoryRoomStore,
   type RoomStore,
@@ -11,12 +21,22 @@ export interface BuildAppOptions {
   now?: () => Date;
   roomStore?: RoomStore;
   liveKitConfig?: LiveKitConfig | null;
+  passcodeVerifier?: PasscodeVerifier;
+  passcodeRateLimiter?: PasscodeRateLimiter;
+  /**
+   * Overrides the Fastify logger option used by `buildApp`. Primarily used by
+   * tests that capture log output into an in-memory buffer. When omitted the
+   * default `true` is used.
+   */
+  logger?: FastifyServerOptions["logger"];
 }
 
 export interface RouteContext {
   liveKitConfig: LiveKitConfig | null;
   now: () => Date;
   roomStore: RoomStore;
+  passcodeVerifier: PasscodeVerifier;
+  passcodeRateLimiter: PasscodeRateLimiter;
 }
 
 export function createRouteContext(options: BuildAppOptions = {}): RouteContext {
@@ -24,6 +44,8 @@ export function createRouteContext(options: BuildAppOptions = {}): RouteContext 
     liveKitConfig: options.liveKitConfig === undefined ? getLiveKitConfig() : options.liveKitConfig,
     now: options.now ?? (() => new Date()),
     roomStore: options.roomStore ?? createInMemoryRoomStore(),
+    passcodeVerifier: options.passcodeVerifier ?? createArgon2idPasscodeVerifier(),
+    passcodeRateLimiter: options.passcodeRateLimiter ?? createInMemoryPasscodeRateLimiter(),
   };
 }
 

--- a/apps/server/src/test-helpers.test.ts
+++ b/apps/server/src/test-helpers.test.ts
@@ -1,0 +1,44 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import {
+  createMemoryLogger,
+  joinOutputs,
+  TEST_LIVEKIT_CONFIG,
+} from "./test-helpers.js";
+
+test("TEST_LIVEKIT_CONFIG exposes dev defaults for integration tests", () => {
+  assert.equal(TEST_LIVEKIT_CONFIG.url, "ws://localhost:7880");
+  assert.equal(TEST_LIVEKIT_CONFIG.apiKey, "devkey");
+  assert.equal(TEST_LIVEKIT_CONFIG.apiSecret, "secret");
+});
+
+test("createMemoryLogger captures writes made to its stream", () => {
+  const logger = createMemoryLogger();
+
+  logger.loggerOption.stream.write("hello\n");
+  logger.loggerOption.stream.write("world");
+
+  const captured = logger.readCapturedLogs();
+  assert.ok(captured.includes("hello"));
+  assert.ok(captured.includes("world"));
+});
+
+test("createMemoryLogger returns isolated buffers per helper", () => {
+  const first = createMemoryLogger();
+  const second = createMemoryLogger();
+
+  first.loggerOption.stream.write("only-first");
+
+  assert.ok(first.readCapturedLogs().includes("only-first"));
+  assert.equal(second.readCapturedLogs().includes("only-first"), false);
+});
+
+test("joinOutputs concatenates response bodies with log output", () => {
+  const combined = joinOutputs(['{"ok":true}', "body-two"], "log-line-a\nlog-line-b");
+
+  assert.ok(combined.includes('{"ok":true}'));
+  assert.ok(combined.includes("body-two"));
+  assert.ok(combined.includes("log-line-a"));
+  assert.ok(combined.includes("log-line-b"));
+});

--- a/apps/server/src/test-helpers.ts
+++ b/apps/server/src/test-helpers.ts
@@ -1,3 +1,5 @@
+import { Writable } from "node:stream";
+
 import type { LiveKitConfig } from "./livekit.js";
 
 export const TEST_LIVEKIT_CONFIG: LiveKitConfig = {
@@ -5,3 +7,47 @@ export const TEST_LIVEKIT_CONFIG: LiveKitConfig = {
   apiKey: "devkey",
   apiSecret: "secret",
 };
+
+export interface MemoryLogger {
+  /**
+   * The value to pass to Fastify's `logger` option so captured logs flow into
+   * this helper. Fastify and Pino both accept a `{ stream }` option to route
+   * output into a custom writable stream.
+   */
+  loggerOption: { stream: Writable };
+  /**
+   * Returns the raw log content captured so far, joined by newline separators
+   * that Pino inserts between records. Used by Property 5 to scan for accidental
+   * passcode leaks.
+   */
+  readCapturedLogs: () => string;
+}
+
+/**
+ * Creates a Fastify-compatible logger option backed by an in-memory buffer.
+ * Tests that need to assert about log output capture it without touching real
+ * stdout, which keeps the default `node --test` reporter output readable.
+ */
+export function createMemoryLogger(): MemoryLogger {
+  const chunks: string[] = [];
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk.toString("utf8"));
+      callback();
+    },
+  });
+
+  return {
+    loggerOption: { stream },
+    readCapturedLogs: () => chunks.join(""),
+  };
+}
+
+/**
+ * Concatenates response bodies and captured log lines into a single string so
+ * substring scans can check that a sensitive value never appears in any
+ * observable output. Used by Property 5 (no echo).
+ */
+export function joinOutputs(bodies: readonly string[], logs: string): string {
+  return `${bodies.join("\n")}\n${logs}`;
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "lint": "eslint src --ext .ts,.tsx --max-warnings=0",
-    "test": "node --import tsx --test 'src/**/*.test.ts'",
+    "test": "node --import tsx --test src/*.test.ts src/features/*/*.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "build": "tsc --noEmit -p tsconfig.json && vite build",
     "preview": "vite preview"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "lint": "eslint src --ext .ts,.tsx --max-warnings=0",
-    "test": "node --import tsx --test src/*.test.ts",
+    "test": "node --import tsx --test 'src/**/*.test.ts'",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "build": "tsc --noEmit -p tsconfig.json && vite build",
     "preview": "vite preview"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import type {
+  AccessMode,
+  CreateRoomRequest,
   CreateRoomResponse,
   JoinRoomResponse,
   LobbyRequestStatusResponse,
@@ -34,14 +36,18 @@ import {
 } from "./room-entry.js";
 
 const DEFAULT_QUALITY_PRESET: QualityPreset = "balanced";
+const DEFAULT_ACCESS_MODE: AccessMode = "open";
 export function App() {
   const [viewState, setViewState] = useState(() => readViewState(window.location));
   const [createResult, setCreateResult] = useState<CreateRoomResponse | null>(null);
   const [createError, setCreateError] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
+  const [selectedAccessMode, setSelectedAccessMode] = useState<AccessMode>(DEFAULT_ACCESS_MODE);
+  const [createPasscodeInput, setCreatePasscodeInput] = useState("");
 
   const [displayName, setDisplayName] = useState("");
   const [selectedQualityPreset, setSelectedQualityPreset] = useState<QualityPreset>(DEFAULT_QUALITY_PRESET);
+  const [joinPasscodeInput, setJoinPasscodeInput] = useState("");
   const [joinError, setJoinError] = useState<string | null>(null);
   const [joinResult, setJoinResult] = useState<JoinRoomResponse | null>(null);
   const [isJoining, setIsJoining] = useState(false);
@@ -197,6 +203,16 @@ export function App() {
     setJoinResult(null);
     setDisplayName("");
     setSelectedQualityPreset(DEFAULT_QUALITY_PRESET);
+    setJoinPasscodeInput("");
+  }, [viewState]);
+
+  // When the user navigates away from the home page, drop the in-memory
+  // plaintext passcode so it is not retained across route changes.
+  useEffect(() => {
+    if (viewState.kind !== "home") {
+      setCreateResult(null);
+      setCreatePasscodeInput("");
+    }
   }, [viewState]);
 
   async function handleCreateRoom() {
@@ -204,12 +220,19 @@ export function App() {
     setCreateError(null);
 
     try {
+      const requestBody: CreateRoomRequest = {
+        accessMode: selectedAccessMode,
+      };
+      if (selectedAccessMode === "passcode") {
+        requestBody.passcode = createPasscodeInput;
+      }
+
       const response = await fetch(`${apiBaseUrl}/api/rooms`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({}),
+        body: JSON.stringify(requestBody),
       });
 
       if (!response.ok) {
@@ -220,6 +243,10 @@ export function App() {
       const payload = (await response.json()) as CreateRoomResponse;
       setCreateResult(payload);
       saveStoredHostSecret(window.localStorage, payload.roomSlug, payload.hostSecret);
+      // Clear the plaintext input as soon as we have the server response.
+      // The plaintext returned in `payload.passcode` lives only in
+      // `createResult` state and is cleared on navigation below.
+      setCreatePasscodeInput("");
     } catch (error) {
       setCreateResult(null);
       setCreateError(error instanceof Error ? error.message : "Unable to create room");
@@ -234,6 +261,14 @@ export function App() {
     }
 
     await navigator.clipboard.writeText(toAbsoluteJoinUrl(createResult.joinUrl, window.location));
+  }
+
+  async function handleCopyPasscode() {
+    if (createResult?.passcode == null) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(createResult.passcode);
   }
 
   function handleOpenRoom() {
@@ -257,6 +292,7 @@ export function App() {
       const payload = await joinRoomRequest({
         apiBaseUrl,
         displayName,
+        passcode: joinPasscodeInput.length > 0 ? joinPasscodeInput : undefined,
         qualityPreset: selectedQualityPreset,
         requestedMedia: previewRequestedMedia,
         slug: viewState.slug,
@@ -273,6 +309,7 @@ export function App() {
         });
 
         clearPreview();
+        setJoinPasscodeInput("");
         pushRoute(window.history, window.location, getCallPageRoute(viewState.slug), setViewState);
       } else if (payload.joinState === "waiting") {
         const storedRequest: StoredLobbyRequest = {
@@ -349,10 +386,21 @@ export function App() {
         isInstallingApp,
         isStandaloneApp,
         installMessage,
+        onAccessModeChange: (mode) => {
+          setSelectedAccessMode(mode);
+          if (mode !== "passcode") {
+            setCreatePasscodeInput("");
+          }
+        },
         onCopyLink: handleCopyLink,
+        onCopyPasscode: handleCopyPasscode,
         onCreateRoom: handleCreateRoom,
         onInstallApp: handleInstallApp,
         onOpenRoom: handleOpenRoom,
+        onPasscodeInputChange: setCreatePasscodeInput,
+        passcodeError: null,
+        passcodeInput: createPasscodeInput,
+        selectedAccessMode,
         shareUrl: createResult ? toAbsoluteJoinUrl(createResult.joinUrl, window.location) : null,
         showInstallPrompt,
       }}
@@ -383,10 +431,12 @@ export function App() {
         onDisplayNameChange: setDisplayName,
         onHostLobbyAction: handleHostLobbyAction,
         onJoinRoom: handleJoinRoom,
+        onPasscodeInputChange: setJoinPasscodeInput,
         onPreviewAudioChange: setPreviewAudioEnabled,
         onPreviewVideoChange: setPreviewVideoEnabled,
         onQualityPresetChange: setSelectedQualityPreset,
         onStartPreview: handleStartPreview,
+        passcodeInput: joinPasscodeInput,
         previewAudioEnabled,
         previewError,
         previewState,

--- a/apps/web/src/features/home/home-page.test.ts
+++ b/apps/web/src/features/home/home-page.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getPasscodeClientError } from "./home-page.js";
+
+test("getPasscodeClientError accepts a well-formed passcode", () => {
+  assert.equal(getPasscodeClientError("blueFalc"), null);
+  assert.equal(getPasscodeClientError("abcd"), null);
+  assert.equal(getPasscodeClientError("a".repeat(64)), null);
+});
+
+test("getPasscodeClientError rejects empty input with a required message", () => {
+  const error = getPasscodeClientError("");
+  assert.ok(error != null);
+  assert.ok(/required/i.test(error));
+});
+
+test("getPasscodeClientError rejects input with outer whitespace", () => {
+  assert.ok(getPasscodeClientError(" leading")?.includes("whitespace"));
+  assert.ok(getPasscodeClientError("trailing ")?.includes("whitespace"));
+});
+
+test("getPasscodeClientError rejects input with control characters", () => {
+  assert.ok(getPasscodeClientError("abc\u0001def")?.includes("control"));
+});
+
+test("getPasscodeClientError rejects input outside the length bounds", () => {
+  assert.ok(getPasscodeClientError("abc")?.includes("4 to 64"));
+  assert.ok(getPasscodeClientError("a".repeat(65))?.includes("4 to 64"));
+});
+
+test("getPasscodeClientError never echoes the submitted value", () => {
+  const secret = "sensitive-rejected-value";
+  const error = getPasscodeClientError(` ${secret} `);
+  assert.ok(error != null);
+  assert.equal(error.includes(secret), false);
+});

--- a/apps/web/src/features/home/home-page.tsx
+++ b/apps/web/src/features/home/home-page.tsx
@@ -1,4 +1,4 @@
-import type { CreateRoomResponse } from "@lowtime/shared";
+import type { AccessMode, CreateRoomResponse } from "@lowtime/shared";
 
 import {
   installCardStyle,
@@ -15,13 +15,51 @@ interface HomePageProps {
   installMessage: string | null;
   showInstallPrompt: boolean;
   shareUrl: string | null;
+  selectedAccessMode: AccessMode;
+  passcodeInput: string;
+  passcodeError: string | null;
+  onAccessModeChange: (mode: AccessMode) => void;
+  onPasscodeInputChange: (value: string) => void;
   onCopyLink: () => Promise<void>;
+  onCopyPasscode: () => Promise<void>;
   onCreateRoom: () => Promise<void>;
   onInstallApp: () => Promise<void>;
   onOpenRoom: () => void;
 }
 
+const PASSCODE_MIN_LENGTH = 4;
+const PASSCODE_MAX_LENGTH = 64;
+
+/**
+ * Returns `null` when the input is an acceptable passcode and a short message
+ * when it is not. Kept local to the home page so the Start Call button can
+ * reflect validity synchronously; the server re-validates authoritatively.
+ */
+export function getPasscodeClientError(input: string): string | null {
+  if (input.length === 0) {
+    return "Passcode is required for passcode rooms.";
+  }
+  if (input !== input.trim()) {
+    return "Passcode must not start or end with whitespace.";
+  }
+  if (/\p{Cc}/u.test(input)) {
+    return "Passcode must not contain control characters.";
+  }
+  const codePointLength = [...input].length;
+  if (codePointLength < PASSCODE_MIN_LENGTH || codePointLength > PASSCODE_MAX_LENGTH) {
+    return `Passcode must be ${PASSCODE_MIN_LENGTH} to ${PASSCODE_MAX_LENGTH} characters.`;
+  }
+  return null;
+}
+
 export function HomePage(props: HomePageProps) {
+  const needsPasscodeInput = props.selectedAccessMode === "passcode";
+  const passcodeClientError = needsPasscodeInput
+    ? getPasscodeClientError(props.passcodeInput)
+    : null;
+  const submitDisabled =
+    props.isCreating || (needsPasscodeInput && passcodeClientError != null);
+
   return (
     <main>
       <h1>LowTime</h1>
@@ -41,7 +79,43 @@ export function HomePage(props: HomePageProps) {
           ) : null}
         </section>
       ) : null}
-      <button type="button" onClick={() => void props.onCreateRoom()} disabled={props.isCreating}>
+      <section>
+        <h2>Room Settings</h2>
+        <label>
+          Access mode
+          <select
+            value={props.selectedAccessMode}
+            onChange={(event) => props.onAccessModeChange(event.target.value as AccessMode)}
+            disabled={props.isCreating}
+          >
+            <option value="open">Open (anyone with the link)</option>
+            <option value="lobby">Lobby (host approves each join)</option>
+            <option value="passcode">Passcode (guests must enter a passcode)</option>
+          </select>
+        </label>
+        {needsPasscodeInput ? (
+          <label>
+            Room passcode
+            <input
+              type="password"
+              value={props.passcodeInput}
+              onChange={(event) => props.onPasscodeInputChange(event.target.value)}
+              placeholder={`${PASSCODE_MIN_LENGTH}-${PASSCODE_MAX_LENGTH} characters`}
+              aria-describedby="home-passcode-hint"
+              disabled={props.isCreating}
+            />
+          </label>
+        ) : null}
+        {needsPasscodeInput && passcodeClientError != null ? (
+          <p id="home-passcode-hint" role="alert">
+            {passcodeClientError}
+          </p>
+        ) : null}
+        {needsPasscodeInput && props.passcodeError != null ? (
+          <p role="alert">{props.passcodeError}</p>
+        ) : null}
+      </section>
+      <button type="button" onClick={() => void props.onCreateRoom()} disabled={submitDisabled}>
         {props.isCreating ? "Creating..." : "Start Call"}
       </button>
       {props.createError ? <p role="alert">{props.createError}</p> : null}
@@ -56,6 +130,20 @@ export function HomePage(props: HomePageProps) {
             <strong>Host secret:</strong> {props.createResult.hostSecret}
           </p>
           <p>Store the host secret locally. It is not included in the room link.</p>
+          {props.createResult.passcode ? (
+            <>
+              <p>
+                <strong>Passcode:</strong>{" "}
+                <code>{props.createResult.passcode}</code>
+              </p>
+              <p style={mutedParagraphStyle}>
+                Share the passcode through a different channel than the link. LowTime only shows it once.
+              </p>
+              <button type="button" onClick={() => void props.onCopyPasscode()}>
+                Copy Passcode
+              </button>{" "}
+            </>
+          ) : null}
           <button type="button" onClick={() => void props.onCopyLink()}>
             Copy Link
           </button>{" "}

--- a/apps/web/src/features/room/room-actions.test.ts
+++ b/apps/web/src/features/room/room-actions.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { joinRoomRequest } from "./room-actions.js";
+
+function createFetchStub(responseBody: unknown, ok = true) {
+  const calls: Array<{ url: string; body: unknown }> = [];
+
+  const stub = async (url: string, init?: RequestInit) => {
+    const bodyText = typeof init?.body === "string" ? init.body : "";
+    calls.push({
+      url,
+      body: bodyText === "" ? null : JSON.parse(bodyText),
+    });
+    return {
+      ok,
+      async json() {
+        return responseBody;
+      },
+    } as unknown as Response;
+  };
+
+  return { stub, calls };
+}
+
+test("joinRoomRequest forwards passcode when provided", async () => {
+  const { stub, calls } = createFetchStub({
+    joinState: "direct",
+    sessionId: "sess_1",
+    transportPreference: "sfu",
+  });
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = stub as unknown as typeof fetch;
+
+  try {
+    await joinRoomRequest({
+      apiBaseUrl: "http://localhost:3000",
+      displayName: "Sam",
+      passcode: "my-secret",
+      qualityPreset: "balanced",
+      requestedMedia: { audio: true, video: true },
+      slug: "Room123",
+    });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+
+  assert.equal(calls.length, 1);
+  const body = calls[0].body as Record<string, unknown>;
+  assert.equal(body.passcode, "my-secret");
+  assert.equal(body.displayName, "Sam");
+});
+
+test("joinRoomRequest omits passcode when empty or missing", async () => {
+  const { stub, calls } = createFetchStub({
+    joinState: "direct",
+    sessionId: "sess_1",
+    transportPreference: "sfu",
+  });
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = stub as unknown as typeof fetch;
+
+  try {
+    // Empty passcode.
+    await joinRoomRequest({
+      apiBaseUrl: "http://localhost:3000",
+      displayName: "Sam",
+      passcode: "",
+      qualityPreset: "balanced",
+      requestedMedia: { audio: true, video: true },
+      slug: "Room123",
+    });
+
+    // Omitted passcode.
+    await joinRoomRequest({
+      apiBaseUrl: "http://localhost:3000",
+      displayName: "Sam",
+      qualityPreset: "balanced",
+      requestedMedia: { audio: true, video: true },
+      slug: "Room123",
+    });
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+
+  assert.equal(calls.length, 2);
+  for (const call of calls) {
+    const body = call.body as Record<string, unknown>;
+    assert.equal("passcode" in body, false);
+  }
+});
+
+test("joinRoomRequest never writes passcode to any passed-in storage", async () => {
+  // `joinRoomRequest` does not receive a Storage argument; this test simply
+  // documents that invariant by asserting the function signature does not
+  // accept one. The compile-time check is part of `npm run typecheck`.
+  const signatureFields = new Set(Object.keys({
+    apiBaseUrl: "",
+    displayName: "",
+    passcode: "",
+    qualityPreset: "balanced" as const,
+    requestedMedia: { audio: true, video: true },
+    slug: "",
+  }));
+  assert.equal(signatureFields.has("storage"), false);
+});

--- a/apps/web/src/features/room/room-actions.ts
+++ b/apps/web/src/features/room/room-actions.ts
@@ -5,20 +5,27 @@ import { buildPreviewConstraints } from "../../device-preview.js";
 export async function joinRoomRequest(input: {
   apiBaseUrl: string;
   displayName: string;
+  passcode?: string;
   qualityPreset: QualityPreset;
   requestedMedia: RequestedMedia;
   slug: string;
 }): Promise<JoinRoomResponse> {
+  const body: Record<string, unknown> = {
+    displayName: input.displayName,
+    qualityPreset: input.qualityPreset,
+    requestedMedia: input.requestedMedia,
+  };
+
+  if (input.passcode != null && input.passcode.length > 0) {
+    body.passcode = input.passcode;
+  }
+
   const response = await fetch(`${input.apiBaseUrl}/api/rooms/${input.slug}/join`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      displayName: input.displayName,
-      qualityPreset: input.qualityPreset,
-      requestedMedia: input.requestedMedia,
-    }),
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) {

--- a/apps/web/src/features/room/room-page.test.ts
+++ b/apps/web/src/features/room/room-page.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { JoinRoomResponse } from "@lowtime/shared";
+
+import { derivePasscodeDeniedMessage } from "./room-page.js";
+
+test("derivePasscodeDeniedMessage returns null when no denial is active", () => {
+  assert.equal(derivePasscodeDeniedMessage(null), null);
+
+  const directResult: JoinRoomResponse = {
+    joinState: "direct",
+    sessionId: "sess_1",
+    transportPreference: "sfu",
+  };
+  assert.equal(derivePasscodeDeniedMessage(directResult), null);
+
+  const waitingResult: JoinRoomResponse = {
+    joinState: "waiting",
+    requestId: "req_1",
+  };
+  assert.equal(derivePasscodeDeniedMessage(waitingResult), null);
+});
+
+test("derivePasscodeDeniedMessage surfaces passcode_required with user-facing copy", () => {
+  const result: JoinRoomResponse = {
+    joinState: "denied",
+    reason: "passcode_required",
+  };
+  const message = derivePasscodeDeniedMessage(result);
+  assert.ok(message != null);
+  assert.ok(/required/i.test(message));
+});
+
+test("derivePasscodeDeniedMessage surfaces invalid_passcode with user-facing copy", () => {
+  const result: JoinRoomResponse = {
+    joinState: "denied",
+    reason: "invalid_passcode",
+  };
+  const message = derivePasscodeDeniedMessage(result);
+  assert.ok(message != null);
+  assert.ok(/incorrect/i.test(message));
+});
+
+test("derivePasscodeDeniedMessage ignores unrelated denial reasons", () => {
+  for (const reason of ["room_full", "room_expired"] as const) {
+    const result: JoinRoomResponse = {
+      joinState: "denied",
+      reason,
+    };
+    assert.equal(derivePasscodeDeniedMessage(result), null);
+  }
+});

--- a/apps/web/src/features/room/room-page.tsx
+++ b/apps/web/src/features/room/room-page.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { RefObject } from "react";
 
 import type { JoinRoomResponse, LobbyRequestSummary, QualityPreset, RoomSummary } from "@lowtime/shared";
@@ -28,6 +29,7 @@ interface RoomPageProps {
   isLoadingRoom: boolean;
   joinError: string | null;
   joinResult: JoinRoomResponse | null;
+  passcodeInput: string;
   previewAudioEnabled: boolean;
   previewError: string | null;
   previewState: PreviewState;
@@ -40,13 +42,49 @@ interface RoomPageProps {
   onDisplayNameChange: (value: string) => void;
   onHostLobbyAction: (requestId: string, action: "approve" | "deny") => Promise<void>;
   onJoinRoom: () => Promise<void>;
+  onPasscodeInputChange: (value: string) => void;
   onPreviewAudioChange: (checked: boolean) => void;
   onPreviewVideoChange: (checked: boolean) => void;
   onQualityPresetChange: (value: QualityPreset) => void;
   onStartPreview: () => Promise<void>;
 }
 
+/**
+ * Derives the user-visible passcode error from the current join response.
+ * Returns null when there is no relevant error to show.
+ */
+export function derivePasscodeDeniedMessage(
+  joinResult: JoinRoomResponse | null,
+): string | null {
+  if (joinResult?.joinState !== "denied") {
+    return null;
+  }
+  if (joinResult.reason === "passcode_required") {
+    return "Passcode is required for this room.";
+  }
+  if (joinResult.reason === "invalid_passcode") {
+    return "That passcode is incorrect.";
+  }
+  return null;
+}
+
 export function RoomPage(props: RoomPageProps) {
+  const passcodeInputRef = useRef<HTMLInputElement | null>(null);
+  const passcodeDeniedMessage = derivePasscodeDeniedMessage(props.joinResult);
+  const needsPasscodeInput = props.roomSummary?.accessMode === "passcode";
+  const joinButtonDisabled =
+    props.isJoining ||
+    props.displayName.trim().length === 0 ||
+    (needsPasscodeInput && props.passcodeInput.trim().length === 0);
+
+  // When the server rejects the join for a passcode reason, refocus the input
+  // so the user can correct it without reaching for the mouse.
+  useEffect(() => {
+    if (passcodeDeniedMessage != null && passcodeInputRef.current != null) {
+      passcodeInputRef.current.focus();
+    }
+  }, [passcodeDeniedMessage]);
+
   return (
     <main>
       <h1>LowTime</h1>
@@ -138,18 +176,36 @@ export function RoomPage(props: RoomPageProps) {
                 placeholder="Enter your name"
               />
             </label>
+            {needsPasscodeInput ? (
+              <label>
+                Passcode
+                <input
+                  ref={passcodeInputRef}
+                  type="password"
+                  value={props.passcodeInput}
+                  onChange={(event) => props.onPasscodeInputChange(event.target.value)}
+                  placeholder="Enter the room passcode"
+                  autoComplete="off"
+                />
+              </label>
+            ) : null}
             <div>
-              <button type="button" onClick={() => void props.onJoinRoom()} disabled={props.isJoining}>
+              <button type="button" onClick={() => void props.onJoinRoom()} disabled={joinButtonDisabled}>
                 {props.isJoining ? "Joining..." : "Join Room"}
               </button>
             </div>
             {props.joinError ? <p role="alert">{props.joinError}</p> : null}
+            {passcodeDeniedMessage != null ? (
+              <p role="alert">{passcodeDeniedMessage}</p>
+            ) : null}
             {props.joinResult?.joinState === "waiting" ? (
               <p>
                 Waiting for host approval. Request <code>{props.joinResult.requestId}</code> is queued.
               </p>
             ) : null}
-            {props.joinResult?.joinState === "denied" ? (
+            {props.joinResult?.joinState === "denied" &&
+            props.joinResult.reason !== "passcode_required" &&
+            props.joinResult.reason !== "invalid_passcode" ? (
               <p>
                 Join denied: <strong>{props.joinResult.reason}</strong>
               </p>

--- a/docs/03-room-and-user-flows.md
+++ b/docs/03-room-and-user-flows.md
@@ -109,7 +109,7 @@ Expired --> [*]
 ## Access Modes
 - `open`: Guests join directly if the room is not full and not expired.
 - `lobby`: Guests wait for host approval before token issuance.
-- `passcode`: Guests must provide a valid passcode before direct join or lobby placement.
+- `passcode`: Guests must provide a valid passcode. A correct passcode admits the guest directly (same flow as `open`). Layering passcode with lobby approval is deferred to a future release.
 
 ## Edge Cases
 - Guest opens the link before the host has joined the room.

--- a/docs/05-api-and-realtime-contracts.md
+++ b/docs/05-api-and-realtime-contracts.md
@@ -28,7 +28,8 @@ The API controls room lifecycle and admission. WebSocket signaling handles live 
 Request body:
 ```json
 {
-  "accessMode": "open",
+  "accessMode": "passcode",
+  "passcode": "blue-falcon-42",
   "maxParticipants": 2,
   "qualityCap": "balanced",
   "allowScreenShare": true
@@ -41,15 +42,24 @@ Response body:
   "roomSlug": "7Qn2kP9Zx4Lm",
   "joinUrl": "/r/7Qn2kP9Zx4Lm",
   "hostSecret": "base64url-secret",
+  "passcode": "blue-falcon-42",
   "expiresAt": "2026-03-24T18:00:00Z",
   "room": {
-    "accessMode": "open",
+    "slug": "7Qn2kP9Zx4Lm",
+    "accessMode": "passcode",
     "maxParticipants": 2,
     "qualityCap": "balanced",
-    "allowScreenShare": true
+    "allowScreenShare": true,
+    "status": "created",
+    "expiresAt": "2026-03-24T18:00:00Z"
   }
 }
 ```
+
+Current implementation notes:
+- The `passcode` request field is required when `accessMode` is `passcode` and is ignored for any other access mode. Passcodes must be 4 to 64 UTF-8 code points with no control characters and no leading or trailing whitespace.
+- The `passcode` response field is only present when the created room uses `accessMode` `passcode`. The plaintext is returned exactly once. The server stores only an Argon2id hash.
+- The nested `room` summary never includes the passcode plaintext or hash.
 
 ### `GET /api/rooms/:slug`
 Response body:
@@ -105,7 +115,9 @@ Response variants:
 Current implementation notes:
 - `open` rooms return `direct` with a generated `sessionId` and `transportPreference` of `sfu`.
 - `lobby` rooms return `waiting` with a generated `requestId`.
-- `passcode` rooms currently deny with `passcode_required` or `invalid_passcode` because passcode verification is not implemented yet.
+- `passcode` rooms verify the submitted `passcode` against the stored Argon2id hash. The server returns `{"joinState":"denied","reason":"passcode_required"}` when the body has no passcode, `{"joinState":"denied","reason":"invalid_passcode"}` when the passcode does not match, and the `direct` shape (same as `open` rooms) on a successful verification.
+- Repeated failures from the same `(client IP, room slug)` pair are throttled: 5 failed attempts within a 5 minute sliding window open a 60 second cooldown during which all passcode submissions from that pair return `invalid_passcode` without invoking the verifier. Neither the cooldown duration nor its existence is revealed in the response body.
+- The precedence of denial reasons is `room_expired` > `room_full` > `passcode_required` > `invalid_passcode`.
 
 ### `POST /api/rooms/:slug/token`
 Request body:
@@ -230,3 +242,42 @@ Current implementation notes:
   - `GET /api/rooms/:slug/lobby/:requestId` for guest waiting-room polling
   - `POST /api/rooms/:slug/lobby/:requestId/approve` for host admission
   - `POST /api/rooms/:slug/lobby/:requestId/deny` for host denial
+  - `POST /api/rooms/:slug/settings` for host-only access mode and passcode rotation
+
+### `POST /api/rooms/:slug/settings`
+Host-only via the `x-host-secret` header. The request body must change at least one of `accessMode` or `passcode`.
+
+Request body variants:
+```json
+{ "accessMode": "passcode", "passcode": "new-secret-9" }
+```
+
+```json
+{ "accessMode": "open" }
+```
+
+```json
+{ "passcode": "rotated-secret" }
+```
+
+Response body:
+```json
+{
+  "room": {
+    "slug": "7Qn2kP9Zx4Lm",
+    "accessMode": "passcode",
+    "maxParticipants": 2,
+    "qualityCap": "balanced",
+    "allowScreenShare": true,
+    "status": "created",
+    "expiresAt": "2026-03-24T18:00:00Z"
+  }
+}
+```
+
+Current implementation notes:
+- The settings response never echoes the new plaintext passcode. The host is expected to remember the value they just sent.
+- Transitioning to `accessMode = "passcode"` requires a non-empty `passcode` body that passes the same validation used at creation.
+- Transitioning away from `accessMode = "passcode"` clears the stored hash and ignores any submitted `passcode`.
+- A body with only `passcode` (no `accessMode`) is treated as a rotation and requires the room to already be in passcode mode.
+- Every accepted settings call clears the per-room rate limiter so a freshly-rotated passcode is not locked out by residual cooldown state.

--- a/docs/09-security-and-abuse.md
+++ b/docs/09-security-and-abuse.md
@@ -17,10 +17,13 @@ LowTime avoids account-based security controls, so link entropy, host-secret han
 - Allow the WebSocket `room.connect` event to include the host secret so the server can restore host role live.
 
 ## Passcode Handling
-- Store passcodes only as Argon2id hashes.
-- Compare passcodes on join before issuing media tokens.
-- Rate-limit repeated failures by IP and room slug.
-- Never echo passcodes back to the client or logs.
+- Store passcodes only as Argon2id hashes. The production baseline is `memoryCost` 19 MiB (19456 KiB), `timeCost` 2 iterations, `parallelism` 1, and a random 16-byte salt. `@node-rs/argon2` emits the encoded hash string these parameters produce.
+- Compare passcodes on join before issuing media tokens. The verify call delegates to the library's own constant-time comparison path.
+- Passcodes are 4 to 64 UTF-8 code points, case sensitive, no control characters, and no leading or trailing whitespace. The server rejects violations with an HTTP 400 that states the rule without echoing the submitted value.
+- Rate-limit repeated failures by `(client IP, room slug)`. The in-memory limiter trips at 5 failed attempts within a 5 minute sliding window and opens a 60 second cooldown during which passcode attempts from that pair are denied with `invalid_passcode` without invoking the verifier. The cooldown duration is not disclosed in the response body. Counters reset on a successful verification and on any settings-driven rotation or access-mode change.
+- In-memory scope: the limiter is per-process and resets on restart. For horizontally scaled deployments the limiter must move to shared storage (tracked with the Redis live room state work in Issue #33).
+- `trustProxy` is not enabled on Fastify today. Deployments behind a reverse proxy that sets `X-Forwarded-For` must enable `trustProxy` so `request.ip` reflects the client address used for rate-limit keys.
+- Never echo passcodes back to the client or logs. The plaintext is returned exactly once in the `CreateRoomResponse.passcode` field and never in any other REST response, settings response, or log line.
 
 ## Link And Room ID Policy
 - Use 12-character base58 room slugs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,11 +27,13 @@
       "dependencies": {
         "@fastify/cors": "^11.1.0",
         "@lowtime/shared": "^0.1.0",
+        "@node-rs/argon2": "^2.0.2",
         "fastify": "^5.2.1",
         "livekit-server-sdk": "^2.13.0"
       },
       "devDependencies": {
         "@types/node": "^22.15.30",
+        "fast-check": "^4.7.0",
         "tsx": "^4.19.4",
         "typescript": "^5.8.3"
       }
@@ -362,6 +364,37 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
       "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
@@ -1244,6 +1277,267 @@
       "resolved": "apps/web",
       "link": true
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@node-rs/argon2": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2/-/argon2-2.0.2.tgz",
+      "integrity": "sha512-t64wIsPEtNd4aUPuTAyeL2ubxATCBGmeluaKXEMAFk/8w6AJIVVkeLKMBpgLW6LU2t5cQxT+env/c6jxbtTQBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@node-rs/argon2-android-arm-eabi": "2.0.2",
+        "@node-rs/argon2-android-arm64": "2.0.2",
+        "@node-rs/argon2-darwin-arm64": "2.0.2",
+        "@node-rs/argon2-darwin-x64": "2.0.2",
+        "@node-rs/argon2-freebsd-x64": "2.0.2",
+        "@node-rs/argon2-linux-arm-gnueabihf": "2.0.2",
+        "@node-rs/argon2-linux-arm64-gnu": "2.0.2",
+        "@node-rs/argon2-linux-arm64-musl": "2.0.2",
+        "@node-rs/argon2-linux-x64-gnu": "2.0.2",
+        "@node-rs/argon2-linux-x64-musl": "2.0.2",
+        "@node-rs/argon2-wasm32-wasi": "2.0.2",
+        "@node-rs/argon2-win32-arm64-msvc": "2.0.2",
+        "@node-rs/argon2-win32-ia32-msvc": "2.0.2",
+        "@node-rs/argon2-win32-x64-msvc": "2.0.2"
+      }
+    },
+    "node_modules/@node-rs/argon2-android-arm-eabi": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-android-arm-eabi/-/argon2-android-arm-eabi-2.0.2.tgz",
+      "integrity": "sha512-DV/H8p/jt40lrao5z5g6nM9dPNPGEHL+aK6Iy/og+dbL503Uj0AHLqj1Hk9aVUSCNnsDdUEKp4TVMi0YakDYKw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-android-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-android-arm64/-/argon2-android-arm64-2.0.2.tgz",
+      "integrity": "sha512-1LKwskau+8O1ktKx7TbK7jx1oMOMt4YEXZOdSNIar1TQKxm6isZ0cRXgHLibPHEcNHgYRsJWDE9zvDGBB17QDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-darwin-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-darwin-arm64/-/argon2-darwin-arm64-2.0.2.tgz",
+      "integrity": "sha512-3TTNL/7wbcpNju5YcqUrCgXnXUSbD7ogeAKatzBVHsbpjZQbNb1NDxDjqqrWoTt6XL3z9mJUMGwbAk7zQltHtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-darwin-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-darwin-x64/-/argon2-darwin-x64-2.0.2.tgz",
+      "integrity": "sha512-vNPfkLj5Ij5111UTiYuwgxMqE7DRbOS2y58O2DIySzSHbcnu+nipmRKg+P0doRq6eKIJStyBK8dQi5Ic8pFyDw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-freebsd-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-freebsd-x64/-/argon2-freebsd-x64-2.0.2.tgz",
+      "integrity": "sha512-M8vQZk01qojQfCqQU0/O1j1a4zPPrz93zc9fSINY7Q/6RhQRBCYwDw7ltDCZXg5JRGlSaeS8cUXWyhPGar3cGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-arm-gnueabihf": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-arm-gnueabihf/-/argon2-linux-arm-gnueabihf-2.0.2.tgz",
+      "integrity": "sha512-7EmmEPHLzcu0G2GDh30L6G48CH38roFC2dqlQJmtRCxs6no3tTE/pvgBGatTp/o2n2oyOJcfmgndVFcUpwMnww==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-arm64-gnu": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-arm64-gnu/-/argon2-linux-arm64-gnu-2.0.2.tgz",
+      "integrity": "sha512-6lsYh3Ftbk+HAIZ7wNuRF4SZDtxtFTfK+HYFAQQyW7Ig3LHqasqwfUKRXVSV5tJ+xTnxjqgKzvZSUJCAyIfHew==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-arm64-musl": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-arm64-musl/-/argon2-linux-arm64-musl-2.0.2.tgz",
+      "integrity": "sha512-p3YqVMNT/4DNR67tIHTYGbedYmXxW9QlFmF39SkXyEbGQwpgSf6pH457/fyXBIYznTU/smnG9EH+C1uzT5j4hA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-x64-gnu": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-x64-gnu/-/argon2-linux-x64-gnu-2.0.2.tgz",
+      "integrity": "sha512-ZM3jrHuJ0dKOhvA80gKJqBpBRmTJTFSo2+xVZR+phQcbAKRlDMSZMFDiKbSTnctkfwNFtjgDdh5g1vaEV04AvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-linux-x64-musl": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-linux-x64-musl/-/argon2-linux-x64-musl-2.0.2.tgz",
+      "integrity": "sha512-of5uPqk7oCRF/44a89YlWTEfjsftPywyTULwuFDKyD8QtVZoonrJR6ZWvfFE/6jBT68S0okAkAzzMEdBVWdxWw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-wasm32-wasi": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-wasm32-wasi/-/argon2-wasm32-wasi-2.0.2.tgz",
+      "integrity": "sha512-U3PzLYKSQYzTERstgtHLd4ZTkOF9co57zTXT77r0cVUsleGZOrd6ut7rHzeWwoJSiHOVxxa0OhG1JVQeB7lLoQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@node-rs/argon2-win32-arm64-msvc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-win32-arm64-msvc/-/argon2-win32-arm64-msvc-2.0.2.tgz",
+      "integrity": "sha512-Eisd7/NM0m23ijrGr6xI2iMocdOuyl6gO27gfMfya4C5BODbUSP7ljKJ7LrA0teqZMdYHesRDzx36Js++/vhiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-win32-ia32-msvc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-win32-ia32-msvc/-/argon2-win32-ia32-msvc-2.0.2.tgz",
+      "integrity": "sha512-GsE2ezwAYwh72f9gIjbGTZOf4HxEksb5M2eCaj+Y5rGYVwAdt7C12Q2e9H5LRYxWcFvLH4m4jiSZpQQ4upnPAQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/argon2-win32-x64-msvc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@node-rs/argon2-win32-x64-msvc/-/argon2-win32-x64-msvc-2.0.2.tgz",
+      "integrity": "sha512-cJxWXanH4Ew9CfuZ4IAEiafpOBCe97bzoKowHCGk5lG/7kR4WF/eknnBlHW9m8q7t10mKq75kruPLtbSDqgRTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -1606,6 +1900,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2624,6 +2928,29 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
@@ -3536,6 +3863,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -35,6 +35,7 @@ export interface CreateRoomRequest {
   maxParticipants?: number;
   qualityCap?: QualityCap;
   allowScreenShare?: boolean;
+  passcode?: string;
 }
 
 export interface CreateRoomResponse {
@@ -42,6 +43,16 @@ export interface CreateRoomResponse {
   joinUrl: string;
   hostSecret: string;
   expiresAt: string;
+  room: RoomSummary;
+  passcode?: string;
+}
+
+export interface UpdateRoomSettingsRequest {
+  accessMode?: AccessMode;
+  passcode?: string;
+}
+
+export interface UpdateRoomSettingsResponse {
   room: RoomSummary;
 }
 


### PR DESCRIPTION
## Summary
Implements issue #12 (Phase 2: Passcode-protected rooms) end to end.

- Adds Argon2id passcode hashing, join-time verification, and an (IP, slug) rate limiter with a 60 second cooldown after 5 failures in a 5 minute window.
- Adds a host-only `POST /api/rooms/:slug/settings` endpoint for passcode rotation and access-mode changes. The settings response never echoes the new plaintext.
- Adds an access-mode selector plus conditional passcode input on the home page and a conditional `type=password` input on the room page with inline errors for `passcode_required` and `invalid_passcode`.
- Docs, `TODO.md`, and shared types updated in the same change.

Closes #12.

## Correctness Properties (fast-check)
Seven property tests cover the spec-level guarantees:

1. Argon2id hash/verify round-trip (Req 2.1, 4.1, 5.1)
2. Validator idempotence and rejection (Req 1.3, 1.4, 8.2)
3. Rate limiter safety under repeated failures (Req 3.2, 4.2, 6.1-6.4)
4. Rate limiter recovery (Req 5.3, 6.3)
5. No echo of plaintext or hash in responses or logs (Req 2.2-2.4, 7.1-7.3, 9.2)
6. Access-mode gating: no side effects on non-passcode rooms (Req 1.5, 4.3)
7. Rotation safety: old fails, new admits, limiter cleared (Req 8.1, 8.3)

## Files Touched
- Server: `domain/passcode-verifier.ts`, `domain/passcode-rate-limiter.ts`, `domain/room-validation.ts`, `domain/room-store.ts`, `server-support.ts`, `routes/rooms.ts`, `routes/settings.ts`, `app.ts`, new `passcode.test.ts`, new `test-helpers.ts` helpers.
- Web: `features/home/home-page.tsx`, `features/room/room-page.tsx`, `features/room/room-actions.ts`, `App.tsx`, plus new unit tests for each.
- Shared: `CreateRoomRequest.passcode`, `CreateRoomResponse.passcode`, and the `UpdateRoomSettingsRequest`/`Response` types.
- Docs: `docs/05-api-and-realtime-contracts.md`, `docs/09-security-and-abuse.md`, `docs/03-room-and-user-flows.md`, `TODO.md`.

## Dependencies Added
- `@node-rs/argon2` (prebuilt-binary Argon2id, no C++ toolchain required in Docker builds)
- `fast-check` dev-dep for property-based testing

## Verification
    npm run lint        # all workspaces clean
    npm run typecheck   # all workspaces clean
    npm run test        # 83 server + 40 web = 123 tests, all pass
    npm run build       # succeeds (server tsc + web vite build)