### PR TITLE
feat: add host reclaim after refresh

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,7 +47,7 @@
 | --- | --- | --- | --- |
 | Lobby mode | `done` | Issue #11. Added pending lobby requests, host approval and denial endpoints, a waiting route, and host-side queue controls in the room screen | [docs/03-room-and-user-flows.md](docs/03-room-and-user-flows.md) |
 | Passcode-protected rooms | `done` | Issue #12. Added Argon2id hash storage, join-time verification, `(IP, slug)` rate limiter, host-only settings endpoint for rotation, and access-mode + passcode UI on create and join screens | [docs/09-security-and-abuse.md](docs/09-security-and-abuse.md) |
-| Host reclaim after refresh | `planned` | Restore host role from host secret | [docs/03-room-and-user-flows.md](docs/03-room-and-user-flows.md) |
+| Host reclaim after refresh | `done` | Issue #13. Added `POST /api/rooms/:slug/reclaim` with dedicated `(IP, slug)` rate limiter, `useHostReclaim` hook that silently validates cached host secrets on room-page mount, and a paste-a-secret form for hosts without a cached credential | [docs/03-room-and-user-flows.md](docs/03-room-and-user-flows.md) |
 | Reconnect window and session recovery | `planned` | Preserve identity during short disconnects | [docs/06-data-model-and-lifecycle.md](docs/06-data-model-and-lifecycle.md) |
 | Room expiry and cleanup jobs | `planned` | Expire inactive rooms and trim transient state | [docs/06-data-model-and-lifecycle.md](docs/06-data-model-and-lifecycle.md) |
 

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -4,6 +4,7 @@ import Fastify, { type FastifyInstance } from "fastify";
 import { registerHealthRoutes } from "./routes/health.js";
 import { registerLobbyRoutes } from "./routes/lobby.js";
 import { registerMediaRoutes } from "./routes/media.js";
+import { registerReclaimRoutes } from "./routes/reclaim.js";
 import { registerRoomRoutes } from "./routes/rooms.js";
 import { registerSettingsRoutes } from "./routes/settings.js";
 import { createInMemoryRoomStore, type RoomStore } from "./domain/room-store.js";
@@ -29,6 +30,7 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   registerLobbyRoutes(app, context);
   registerMediaRoutes(app, context);
   registerSettingsRoutes(app, context);
+  registerReclaimRoutes(app, context);
 
   return app;
 }

--- a/apps/server/src/domain/reclaim-rate-limiter.ts
+++ b/apps/server/src/domain/reclaim-rate-limiter.ts
@@ -1,0 +1,133 @@
+import type { RoomSlug } from "@lowtime/shared";
+
+/**
+ * Identifies a single reclaim rate-limit bucket. Keyed by `(clientIp, slug)`
+ * so one noisy client against one room does not lock out unrelated clients
+ * or unrelated rooms (Requirement 5.5).
+ */
+export interface RateLimitKey {
+  clientIp: string;
+  slug: RoomSlug;
+}
+
+export interface ReclaimRateLimiterState {
+  failuresInWindow: number;
+  cooldownUntil: number | null;
+}
+
+/**
+ * Tracks failed host-secret submissions against `POST /api/rooms/:slug/reclaim`.
+ *
+ * Separate from `PasscodeRateLimiter` by design: a host-reclaim flood must
+ * not block guest passcode attempts on the same room, and settings-driven
+ * passcode rotations must not wipe reclaim-failure state. See
+ * docs/09-security-and-abuse.md and the host-reclaim-after-refresh design doc
+ * for the rationale.
+ */
+export interface ReclaimRateLimiter {
+  shouldAllow(key: RateLimitKey): boolean;
+  recordFailure(key: RateLimitKey): void;
+  recordSuccess(key: RateLimitKey): void;
+  /** Test-only helper that exposes the current bucket state. */
+  getState(key: RateLimitKey): ReclaimRateLimiterState;
+}
+
+export interface CreateReclaimRateLimiterOptions {
+  /** Sliding window duration in milliseconds. Default 5 minutes. */
+  windowMs?: number;
+  /** Failure count that triggers cooldown. Default 5. */
+  threshold?: number;
+  /** Cooldown duration in milliseconds. Default 60 seconds. */
+  cooldownMs?: number;
+  /** Injected clock for deterministic tests. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+interface Bucket {
+  failures: number[];
+  cooldownUntil: number | null;
+}
+
+const DEFAULT_WINDOW_MS = 5 * 60_000;
+const DEFAULT_THRESHOLD = 5;
+const DEFAULT_COOLDOWN_MS = 60_000;
+
+// Same non-printable separator the passcode limiter uses so a slug containing
+// a pipe or other visible separator cannot accidentally collide with another
+// (clientIp, slug) pair.
+const INTERNAL_KEY_DELIMITER = "\u0001";
+
+function keyFor(key: RateLimitKey): string {
+  return `${key.clientIp}${INTERNAL_KEY_DELIMITER}${key.slug}`;
+}
+
+export function createInMemoryReclaimRateLimiter(
+  options: CreateReclaimRateLimiterOptions = {},
+): ReclaimRateLimiter {
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+  const cooldownMs = options.cooldownMs ?? DEFAULT_COOLDOWN_MS;
+  const now = options.now ?? (() => Date.now());
+
+  const buckets = new Map<string, Bucket>();
+
+  function getBucket(internalKey: string): Bucket {
+    let bucket = buckets.get(internalKey);
+    if (bucket == null) {
+      bucket = { failures: [], cooldownUntil: null };
+      buckets.set(internalKey, bucket);
+    }
+    return bucket;
+  }
+
+  function prune(bucket: Bucket, current: number): void {
+    const cutoff = current - windowMs;
+    while (bucket.failures.length > 0 && bucket.failures[0] < cutoff) {
+      bucket.failures.shift();
+    }
+    if (bucket.cooldownUntil != null && current >= bucket.cooldownUntil) {
+      bucket.cooldownUntil = null;
+      bucket.failures.length = 0;
+    }
+  }
+
+  return {
+    shouldAllow(key) {
+      const current = now();
+      const bucket = getBucket(keyFor(key));
+      prune(bucket, current);
+      return bucket.cooldownUntil === null;
+    },
+    recordFailure(key) {
+      const current = now();
+      const bucket = getBucket(keyFor(key));
+      prune(bucket, current);
+
+      if (bucket.cooldownUntil !== null) {
+        return;
+      }
+
+      bucket.failures.push(current);
+      if (bucket.failures.length >= threshold) {
+        bucket.cooldownUntil = current + cooldownMs;
+      }
+    },
+    recordSuccess(key) {
+      const bucket = buckets.get(keyFor(key));
+      if (bucket == null) {
+        return;
+      }
+      bucket.failures.length = 0;
+      bucket.cooldownUntil = null;
+    },
+    getState(key) {
+      const current = now();
+      const bucket = getBucket(keyFor(key));
+      prune(bucket, current);
+      return {
+        failuresInWindow: bucket.failures.length,
+        cooldownUntil: bucket.cooldownUntil,
+      };
+    },
+  };
+}

--- a/apps/server/src/host-reclaim.test.ts
+++ b/apps/server/src/host-reclaim.test.ts
@@ -1,0 +1,743 @@
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+
+import fc from "fast-check";
+
+/*
+ * Tests for the host-reclaim-after-refresh feature.
+ *
+ * Sections (built up across tasks in .kiro/specs/host-reclaim-after-refresh/tasks.md):
+ *   - Rate Limiter: createInMemoryReclaimRateLimiter (task 2.1)
+ *   - HTTP: reclaim happy path (task 4.1)
+ *   - HTTP: reclaim failure modes (task 4.1)
+ *   - Property tests 1..5 (tasks 5.1..5.5)
+ */
+
+describe("Rate Limiter: createInMemoryReclaimRateLimiter", async () => {
+  const { createInMemoryReclaimRateLimiter } = await import(
+    "./domain/reclaim-rate-limiter.js"
+  );
+
+  function createStubClock(start = 0): { now: () => number; advance: (ms: number) => void } {
+    let current = start;
+    return {
+      now: () => current,
+      advance: (ms: number) => {
+        current += ms;
+      },
+    };
+  }
+
+  const keyA = { clientIp: "10.0.0.1", slug: "room-a" };
+  const keyB = { clientIp: "10.0.0.2", slug: "room-a" };
+  const keyC = { clientIp: "10.0.0.1", slug: "room-b" };
+
+  test("initial state allows requests with no failures", () => {
+    const clock = createStubClock();
+    const limiter = createInMemoryReclaimRateLimiter({ now: clock.now });
+
+    assert.equal(limiter.shouldAllow(keyA), true);
+    const state = limiter.getState(keyA);
+    assert.equal(state.failuresInWindow, 0);
+    assert.equal(state.cooldownUntil, null);
+  });
+
+  test("threshold is reached after 5 failures within the window", () => {
+    const clock = createStubClock();
+    const limiter = createInMemoryReclaimRateLimiter({ now: clock.now });
+
+    for (let i = 0; i < 4; i += 1) {
+      limiter.recordFailure(keyA);
+      assert.equal(limiter.shouldAllow(keyA), true);
+    }
+    limiter.recordFailure(keyA);
+    assert.equal(limiter.shouldAllow(keyA), false);
+  });
+
+  test("cooldown denies for 60 seconds by default and clears after the window", () => {
+    const clock = createStubClock(1_000_000);
+    const limiter = createInMemoryReclaimRateLimiter({ now: clock.now });
+
+    for (let i = 0; i < 5; i += 1) {
+      limiter.recordFailure(keyA);
+    }
+
+    clock.advance(30_000);
+    assert.equal(limiter.shouldAllow(keyA), false);
+
+    clock.advance(30_000 + 1);
+    assert.equal(limiter.shouldAllow(keyA), true);
+  });
+
+  test("recordSuccess clears the failure ring and any active cooldown", () => {
+    const clock = createStubClock();
+    const limiter = createInMemoryReclaimRateLimiter({ now: clock.now });
+
+    for (let i = 0; i < 5; i += 1) {
+      limiter.recordFailure(keyA);
+    }
+    assert.equal(limiter.shouldAllow(keyA), false);
+
+    limiter.recordSuccess(keyA);
+    const state = limiter.getState(keyA);
+    assert.equal(state.failuresInWindow, 0);
+    assert.equal(state.cooldownUntil, null);
+    assert.equal(limiter.shouldAllow(keyA), true);
+  });
+
+  test("failures older than the window are pruned", () => {
+    const clock = createStubClock();
+    const limiter = createInMemoryReclaimRateLimiter({
+      now: clock.now,
+      windowMs: 5 * 60_000,
+    });
+
+    for (let i = 0; i < 4; i += 1) {
+      limiter.recordFailure(keyA);
+    }
+    assert.equal(limiter.getState(keyA).failuresInWindow, 4);
+
+    clock.advance(5 * 60_000 + 1);
+    assert.equal(limiter.getState(keyA).failuresInWindow, 0);
+    assert.equal(limiter.shouldAllow(keyA), true);
+  });
+
+  test("keys are isolated by (clientIp, slug)", () => {
+    const clock = createStubClock();
+    const limiter = createInMemoryReclaimRateLimiter({ now: clock.now });
+
+    for (let i = 0; i < 5; i += 1) {
+      limiter.recordFailure(keyA);
+    }
+
+    assert.equal(limiter.shouldAllow(keyA), false);
+    assert.equal(limiter.shouldAllow(keyB), true);
+    assert.equal(limiter.shouldAllow(keyC), true);
+  });
+
+  test("deliberately exposes no clear(slug) helper; settings mutations must not wipe reclaim state", () => {
+    const limiter = createInMemoryReclaimRateLimiter();
+    // Compile-time check: `clear` is not part of the interface. The test
+    // exists to lock the intent documented in the design doc.
+    assert.equal(typeof (limiter as { clear?: unknown }).clear, "undefined");
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// HTTP integration tests
+// ---------------------------------------------------------------------------
+
+import { buildApp } from "./app.js";
+import { createInMemoryRoomStore } from "./domain/room-store.js";
+import {
+  TEST_LIVEKIT_CONFIG,
+  createMemoryLogger,
+  joinOutputs,
+} from "./test-helpers.js";
+
+function createFakeVerifier() {
+  const calls = { hash: 0, verify: 0 };
+  return {
+    calls,
+    async hash(plaintext: string) {
+      calls.hash += 1;
+      return `$fake$${plaintext}`;
+    },
+    async verify(encodedHash: string, plaintext: string) {
+      calls.verify += 1;
+      return encodedHash === `$fake$${plaintext}`;
+    },
+  };
+}
+
+async function createSyncReclaimLimiter(options?: {
+  threshold?: number;
+  cooldownMs?: number;
+  windowMs?: number;
+}) {
+  const mod = await import("./domain/reclaim-rate-limiter.js");
+  let now = 1_700_000_000_000;
+  const limiter = mod.createInMemoryReclaimRateLimiter({
+    now: () => now,
+    threshold: options?.threshold ?? 5,
+    cooldownMs: options?.cooldownMs ?? 60_000,
+    windowMs: options?.windowMs ?? 5 * 60_000,
+  });
+  return {
+    limiter,
+    advanceClock: (ms: number) => {
+      now += ms;
+    },
+    setClock: (value: number) => {
+      now = value;
+    },
+  };
+}
+
+async function setupRoom(payload: Record<string, unknown> = {}) {
+  const verifier = createFakeVerifier();
+  const { limiter: reclaimRateLimiter } = await createSyncReclaimLimiter();
+  const store = createInMemoryRoomStore();
+  const app = buildApp({
+    logger: false,
+    liveKitConfig: TEST_LIVEKIT_CONFIG,
+    passcodeVerifier: verifier,
+    reclaimRateLimiter,
+    roomStore: store,
+  });
+  const createResponse = await app.inject({
+    method: "POST",
+    url: "/api/rooms",
+    payload,
+  });
+  const body = createResponse.json() as {
+    roomSlug: string;
+    hostSecret: string;
+    passcode?: string;
+  };
+  return { app, store, reclaimRateLimiter, verifier, ...body };
+}
+
+describe("HTTP: reclaim happy path", () => {
+  test("returns 200 with { room, lobbyRequests: [] } for an open room", async () => {
+    const { app, roomSlug, hostSecret } = await setupRoom({ accessMode: "open" });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/reclaim`,
+      headers: { "x-host-secret": hostSecret },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as {
+      room: { slug: string; accessMode: string };
+      lobbyRequests: unknown[];
+    };
+    assert.equal(body.room.slug, roomSlug);
+    assert.equal(body.room.accessMode, "open");
+    assert.deepEqual(body.lobbyRequests, []);
+    await app.close();
+  });
+
+  test("returns the pending lobby queue for a lobby room", async () => {
+    const { app, roomSlug, hostSecret } = await setupRoom({ accessMode: "lobby" });
+
+    // Enqueue two guests so the reclaim response carries the queue.
+    await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/join`,
+      payload: { displayName: "Guest A" },
+    });
+    await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/join`,
+      payload: { displayName: "Guest B" },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/reclaim`,
+      headers: { "x-host-secret": hostSecret },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as {
+      lobbyRequests: { displayName: string; requestId: string }[];
+    };
+    assert.equal(body.lobbyRequests.length, 2);
+    assert.deepEqual(
+      body.lobbyRequests.map((entry) => entry.displayName).sort(),
+      ["Guest A", "Guest B"],
+    );
+    // Request id shape matches the lobby list endpoint.
+    for (const entry of body.lobbyRequests) {
+      assert.ok(entry.requestId.startsWith("req_"));
+    }
+    await app.close();
+  });
+
+  test("returns empty lobby list for a passcode room and never echoes passcode plaintext or hash", async () => {
+    const { app, store, roomSlug, hostSecret, passcode } = await setupRoom({
+      accessMode: "passcode",
+      passcode: "original-passcode-9",
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/reclaim`,
+      headers: { "x-host-secret": hostSecret },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.body;
+    const stored = store.getRoom(roomSlug);
+    assert.equal(body.includes(passcode ?? "UNUSED"), false);
+    assert.equal(stored?.passcodeHash != null && body.includes(stored.passcodeHash), false);
+    assert.deepEqual(JSON.parse(body).lobbyRequests, []);
+    await app.close();
+  });
+});
+
+describe("HTTP: reclaim failure modes", () => {
+  test("missing header returns 403 generic body without touching the limiter", async () => {
+    const { app, roomSlug, reclaimRateLimiter } = await setupRoom();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/reclaim`,
+    });
+
+    assert.equal(response.statusCode, 403);
+    const body = response.json() as { message: string };
+    assert.equal(body.message, "Host secret is required");
+    assert.equal(
+      reclaimRateLimiter.getState({ clientIp: "127.0.0.1", slug: roomSlug }).failuresInWindow,
+      0,
+    );
+    await app.close();
+  });
+
+  test("wrong header returns 403 generic body and records a failure", async () => {
+    const { app, roomSlug, reclaimRateLimiter } = await setupRoom();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/reclaim`,
+      headers: { "x-host-secret": "nope" },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(
+      reclaimRateLimiter.getState({ clientIp: "127.0.0.1", slug: roomSlug }).failuresInWindow,
+      1,
+    );
+    await app.close();
+  });
+
+  test("unknown slug returns 403 without recording a failure (anti-enumeration)", async () => {
+    const { app, reclaimRateLimiter } = await setupRoom();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/rooms/ThisRoomDoesNotExist/reclaim",
+      headers: { "x-host-secret": "anything" },
+    });
+
+    assert.equal(response.statusCode, 403);
+    const body = response.json() as { message: string };
+    assert.equal(body.message, "Host secret is required");
+    // Limiter untouched even for the "wrong" header on an unknown slug.
+    assert.equal(
+      reclaimRateLimiter.getState({
+        clientIp: "127.0.0.1",
+        slug: "ThisRoomDoesNotExist",
+      }).failuresInWindow,
+      0,
+    );
+    await app.close();
+  });
+
+  test("after 5 wrong attempts the next request is denied without calling hasValidHostSecret", async () => {
+    const { app, roomSlug, hostSecret } = await setupRoom();
+
+    for (let i = 0; i < 5; i += 1) {
+      await app.inject({
+        method: "POST",
+        url: `/api/rooms/${roomSlug}/reclaim`,
+        headers: { "x-host-secret": "wrong" },
+      });
+    }
+
+    // Even with the correct secret, cooldown wins.
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/reclaim`,
+      headers: { "x-host-secret": hostSecret },
+    });
+    assert.equal(response.statusCode, 403);
+    await app.close();
+  });
+
+  test("expired room with valid secret returns 409 without room body, and resets the counter", async () => {
+    // Use a clock we can jump forward past the 2-hour default TTL.
+    let now = new Date("2026-03-24T18:00:00Z");
+    const verifier = createFakeVerifier();
+    const { limiter } = await createSyncReclaimLimiter();
+    const store = createInMemoryRoomStore();
+    const app = buildApp({
+      logger: false,
+      liveKitConfig: TEST_LIVEKIT_CONFIG,
+      passcodeVerifier: verifier,
+      reclaimRateLimiter: limiter,
+      roomStore: store,
+      now: () => now,
+    });
+
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/rooms",
+      payload: {},
+    });
+    const { roomSlug, hostSecret } = createResponse.json() as {
+      roomSlug: string;
+      hostSecret: string;
+    };
+
+    // Prime a failure so we can observe the counter reset on the 409 path.
+    await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/reclaim`,
+      headers: { "x-host-secret": "wrong" },
+    });
+    assert.equal(
+      limiter.getState({ clientIp: "127.0.0.1", slug: roomSlug }).failuresInWindow,
+      1,
+    );
+
+    // Jump past the TTL.
+    now = new Date(now.getTime() + 10 * 60 * 60 * 1000);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/reclaim`,
+      headers: { "x-host-secret": hostSecret },
+    });
+
+    assert.equal(response.statusCode, 409);
+    const body = response.json() as { message: string; room?: unknown };
+    assert.equal(body.message, "Room is no longer available");
+    assert.equal(body.room, undefined);
+    assert.equal(
+      limiter.getState({ clientIp: "127.0.0.1", slug: roomSlug }).failuresInWindow,
+      0,
+    );
+    await app.close();
+  });
+
+  test("closed room with valid secret returns 409", async () => {
+    const { app, store, roomSlug, hostSecret } = await setupRoom();
+    const stored = store.getRoom(roomSlug);
+    if (stored != null) {
+      stored.status = "closed";
+    }
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/reclaim`,
+      headers: { "x-host-secret": hostSecret },
+    });
+
+    assert.equal(response.statusCode, 409);
+    await app.close();
+  });
+});
+
+describe("HTTP: reclaim reflects latest room state", () => {
+  test("accessMode change via settings is visible on the next reclaim call", async () => {
+    const { app, roomSlug, hostSecret } = await setupRoom({
+      accessMode: "passcode",
+      passcode: "original-passcode-9",
+    });
+
+    // Flip the room to open mode.
+    await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/settings`,
+      headers: { "x-host-secret": hostSecret },
+      payload: { accessMode: "open" },
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/api/rooms/${roomSlug}/reclaim`,
+      headers: { "x-host-secret": hostSecret },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as { room: { accessMode: string } };
+    assert.equal(body.room.accessMode, "open");
+    await app.close();
+  });
+});
+
+describe("Property 3: Reclaim is idempotent", () => {
+  /*
+   * Feature: host-reclaim-after-refresh, Property 3: Reclaim is idempotent
+   * Validates: Requirements 3.1, 3.2, 6.1
+   */
+  test("N reclaim calls produce the same response and do not mutate room state", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.integer({ min: 1, max: 8 }), async (n) => {
+        const { app, store, roomSlug, hostSecret } = await setupRoom({
+          accessMode: "open",
+        });
+
+        const snapshotBefore = JSON.parse(JSON.stringify(store.getRoom(roomSlug)));
+
+        const bodies: string[] = [];
+        for (let i = 0; i < n; i += 1) {
+          const response = await app.inject({
+            method: "POST",
+            url: `/api/rooms/${roomSlug}/reclaim`,
+            headers: { "x-host-secret": hostSecret },
+          });
+          bodies.push(response.body);
+        }
+
+        for (let i = 1; i < bodies.length; i += 1) {
+          assert.equal(bodies[i], bodies[0]);
+        }
+
+        const snapshotAfter = JSON.parse(JSON.stringify(store.getRoom(roomSlug)));
+        assert.deepEqual(snapshotAfter, snapshotBefore);
+        await app.close();
+      }),
+      { numRuns: 25 },
+    );
+  });
+});
+
+describe("Property 5: Unknown-room anti-enumeration", () => {
+  /*
+   * Feature: host-reclaim-after-refresh, Property 5: Unknown-room anti-enumeration
+   * Validates: Requirements 1.4, 5.6, 7.3
+   */
+  test("unknown-slug reclaim attempts never mutate the limiter and never call hasValidHostSecret", async () => {
+    const headerStateArb = fc.oneof(
+      fc.constant<"absent">("absent"),
+      fc.constant<"empty">("empty"),
+      fc.constant<"wrong">("wrong"),
+      fc.string({ minLength: 1, maxLength: 40 }).map((random) => ({ random } as const)),
+    );
+
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(headerStateArb, { minLength: 1, maxLength: 15 }),
+        async (events) => {
+          const verifier = createFakeVerifier();
+          const { limiter } = await createSyncReclaimLimiter();
+          const app = buildApp({
+            logger: false,
+            liveKitConfig: TEST_LIVEKIT_CONFIG,
+            passcodeVerifier: verifier,
+            reclaimRateLimiter: limiter,
+          });
+
+          const unknownSlug = "ThisRoomDoesNotExist123";
+
+          for (const event of events) {
+            const headers: Record<string, string> = {};
+            if (event === "wrong") {
+              headers["x-host-secret"] = "some-random-guess";
+            } else if (event === "empty") {
+              headers["x-host-secret"] = "";
+            } else if (typeof event === "object" && event !== null && "random" in event) {
+              headers["x-host-secret"] = (event as { random: string }).random;
+            }
+            // "absent": no header.
+
+            const response = await app.inject({
+              method: "POST",
+              url: `/api/rooms/${unknownSlug}/reclaim`,
+              headers,
+            });
+
+            assert.equal(response.statusCode, 403);
+            const body = response.json() as { message: string };
+            assert.equal(body.message, "Host secret is required");
+          }
+
+          const state = limiter.getState({ clientIp: "127.0.0.1", slug: unknownSlug });
+          assert.equal(state.failuresInWindow, 0);
+          assert.equal(state.cooldownUntil, null);
+          await app.close();
+        },
+      ),
+      { numRuns: 30 },
+    );
+  });
+});
+
+describe("Property 2: No echo of secrets", () => {
+  /*
+   * Feature: host-reclaim-after-refresh, Property 2: No echo of secrets
+   * Validates: Requirements 1.2, 1.3, 2.4, 7.1, 7.2, 7.3, 7.4, 6.3
+   *
+   * The real host secret is generated by the server and captured after
+   * create; the generator only controls the scenario (mix of reclaim attempts
+   * against wrong secrets). Captures server logs through createMemoryLogger
+   * and asserts no substring equal to the host secret appears outside the
+   * sanctioned create-response echo.
+   */
+  test("host secret plaintext never leaks in any non-create response body or log line", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.integer({ min: 1, max: 6 }),
+        fc.integer({ min: 0, max: 3 }),
+        async (correctAttempts, wrongAttempts) => {
+          const verifier = createFakeVerifier();
+          const { limiter } = await createSyncReclaimLimiter();
+          const store = createInMemoryRoomStore();
+          const memLogger = createMemoryLogger();
+          const app = buildApp({
+            logger: memLogger.loggerOption,
+            liveKitConfig: TEST_LIVEKIT_CONFIG,
+            passcodeVerifier: verifier,
+            reclaimRateLimiter: limiter,
+            roomStore: store,
+          });
+
+          const createResponse = await app.inject({
+            method: "POST",
+            url: "/api/rooms",
+            payload: {},
+          });
+          const { roomSlug, hostSecret } = createResponse.json() as {
+            roomSlug: string;
+            hostSecret: string;
+          };
+
+          const nonCreateBodies: string[] = [];
+
+          for (let i = 0; i < wrongAttempts; i += 1) {
+            const res = await app.inject({
+              method: "POST",
+              url: `/api/rooms/${roomSlug}/reclaim`,
+              headers: { "x-host-secret": `not-${hostSecret}` },
+            });
+            nonCreateBodies.push(res.body);
+          }
+
+          for (let i = 0; i < correctAttempts; i += 1) {
+            const res = await app.inject({
+              method: "POST",
+              url: `/api/rooms/${roomSlug}/reclaim`,
+              headers: { "x-host-secret": hostSecret },
+            });
+            nonCreateBodies.push(res.body);
+          }
+
+          await app.close();
+
+          const combined = joinOutputs(nonCreateBodies, memLogger.readCapturedLogs());
+
+          assert.equal(
+            combined.includes(hostSecret),
+            false,
+            "host secret plaintext leaked in response or log output",
+          );
+        },
+      ),
+      { numRuns: 15 },
+    );
+  });
+});
+
+
+describe("Property 1: Reclaim round-trip for valid credentials", () => {
+  /*
+   * Feature: host-reclaim-after-refresh, Property 1: Reclaim round-trip for valid credentials
+   * Validates: Requirements 1.1, 2.1, 2.2, 2.3, 6.1, 6.4
+   */
+  test("valid (slug, hostSecret) pairs always return 200 with room + lobbyRequests matching the sibling endpoints", async () => {
+    const accessModeArb = fc.constantFrom("open" as const, "lobby" as const);
+    const maxParticipantsArb = fc.integer({ min: 2, max: 4 });
+    const qualityCapArb = fc.constantFrom("low" as const, "balanced" as const, "high" as const);
+
+    await fc.assert(
+      fc.asyncProperty(
+        accessModeArb,
+        maxParticipantsArb,
+        qualityCapArb,
+        fc.integer({ min: 0, max: 2 }),
+        async (accessMode, maxParticipants, qualityCap, lobbyGuests) => {
+          const { app, roomSlug, hostSecret } = await setupRoom({
+            accessMode,
+            maxParticipants,
+            qualityCap,
+            allowScreenShare: true,
+          });
+
+          if (accessMode === "lobby") {
+            for (let i = 0; i < lobbyGuests && i < maxParticipants; i += 1) {
+              await app.inject({
+                method: "POST",
+                url: `/api/rooms/${roomSlug}/join`,
+                payload: { displayName: `Guest ${i}` },
+              });
+            }
+          }
+
+          const reclaim = await app.inject({
+            method: "POST",
+            url: `/api/rooms/${roomSlug}/reclaim`,
+            headers: { "x-host-secret": hostSecret },
+          });
+          assert.equal(reclaim.statusCode, 200);
+          const reclaimBody = reclaim.json() as {
+            room: Record<string, unknown>;
+            lobbyRequests: unknown[];
+          };
+
+          // Cross-check room summary matches GET /api/rooms/:slug.
+          const meta = await app.inject({
+            method: "GET",
+            url: `/api/rooms/${roomSlug}`,
+          });
+          assert.deepEqual(reclaimBody.room, meta.json());
+
+          if (accessMode === "lobby") {
+            const hostList = await app.inject({
+              method: "GET",
+              url: `/api/rooms/${roomSlug}/lobby`,
+              headers: { "x-host-secret": hostSecret },
+            });
+            assert.deepEqual(
+              reclaimBody.lobbyRequests,
+              (hostList.json() as { requests: unknown[] }).requests,
+            );
+          } else {
+            assert.deepEqual(reclaimBody.lobbyRequests, []);
+          }
+
+          await app.close();
+        },
+      ),
+      { numRuns: 30 },
+    );
+  });
+});
+
+describe("Property 4: Rate limiter safety under repeated failures", () => {
+  /*
+   * Feature: host-reclaim-after-refresh, Property 4: Rate limiter safety under repeated failures
+   * Validates: Requirements 3.3, 5.1, 5.2, 5.3, 5.4, 5.5
+   */
+  test("once threshold wrong-secret events hit, cooldowned requests are denied and never reach hasValidHostSecret", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.integer({ min: 5, max: 12 }), async (failureCount) => {
+        const { app, roomSlug, hostSecret } = await setupRoom();
+
+        for (let i = 0; i < failureCount; i += 1) {
+          const res = await app.inject({
+            method: "POST",
+            url: `/api/rooms/${roomSlug}/reclaim`,
+            headers: { "x-host-secret": `wrong-${i}` },
+          });
+          assert.equal(res.statusCode, 403);
+        }
+
+        // Cooldown is active even for the correct secret.
+        const res = await app.inject({
+          method: "POST",
+          url: `/api/rooms/${roomSlug}/reclaim`,
+          headers: { "x-host-secret": hostSecret },
+        });
+        assert.equal(res.statusCode, 403);
+        await app.close();
+      }),
+      { numRuns: 15 },
+    );
+  });
+});

--- a/apps/server/src/rooms.test.ts
+++ b/apps/server/src/rooms.test.ts
@@ -282,3 +282,28 @@ test("POST /api/rooms ignores a stray passcode field for non-passcode rooms", as
 
   await app.close();
 });
+
+
+test("POST /api/rooms continues to issue a host secret after the reclaim route is registered", async () => {
+  const app = buildApp();
+
+  const createResponse = await app.inject({
+    method: "POST",
+    url: "/api/rooms",
+  });
+  assert.equal(createResponse.statusCode, 200);
+  const { roomSlug, hostSecret } = createResponse.json();
+  assert.equal(typeof hostSecret, "string");
+  assert.ok(hostSecret.length > 0);
+
+  // The existing settings endpoint still accepts the x-host-secret header.
+  const settingsResponse = await app.inject({
+    method: "POST",
+    url: `/api/rooms/${roomSlug}/settings`,
+    headers: { "x-host-secret": hostSecret },
+    payload: { accessMode: "open" },
+  });
+  assert.equal(settingsResponse.statusCode, 200);
+
+  await app.close();
+});

--- a/apps/server/src/routes/reclaim.ts
+++ b/apps/server/src/routes/reclaim.ts
@@ -1,0 +1,94 @@
+import type { FastifyInstance } from "fastify";
+import type { ReclaimRoomResponse } from "@lowtime/shared";
+
+import { getRoomStatus, toRoomSummary } from "../domain/room-status.js";
+import {
+  hasValidHostSecret,
+  type RouteContext,
+} from "../server-support.js";
+
+/**
+ * Host reclaim endpoint. Verifies a submitted host secret and returns a
+ * host-visible view of the room so the web client can restore host UI in a
+ * single round trip (Requirement 2.1).
+ *
+ * Failure modes collapse to a single generic 403 body so the endpoint cannot
+ * be used to enumerate rooms or distinguish between "room does not exist",
+ * "wrong secret", "cooldown active", and "missing header". Expired and closed
+ * rooms return a distinct 409 so the web client can render a "room ended"
+ * state rather than pretending the reclaim succeeded.
+ *
+ * Ordering of checks is deliberate:
+ *   1. Missing header -> 403 without touching the limiter or the store.
+ *   2. Unknown slug   -> 403 without touching the limiter (anti-enumeration,
+ *                        Requirement 5.6).
+ *   3. Cooldown       -> 403 without invoking hasValidHostSecret.
+ *   4. Wrong secret   -> recordFailure, 403.
+ *   5. Expired/closed -> recordSuccess, 409.
+ *   6. Success        -> recordSuccess, 200 with { room, lobbyRequests }.
+ */
+export function registerReclaimRoutes(app: FastifyInstance, context: RouteContext) {
+  app.post<{
+    Params: { slug: string };
+    Headers: { "x-host-secret"?: string };
+    Reply: ReclaimRoomResponse | { message: string };
+  }>("/api/rooms/:slug/reclaim", async (request, reply) => {
+    const slug = request.params.slug;
+    const headerValue = request.headers["x-host-secret"];
+    const key = { clientIp: request.ip, slug };
+
+    if (headerValue == null) {
+      reply.code(403);
+      return { message: "Host secret is required" };
+    }
+
+    const room = context.roomStore.getRoom(slug);
+    if (room == null) {
+      // Anti-enumeration: do not touch the limiter when the room does not
+      // exist. A bot scanning random slugs should not lock out legitimate
+      // callers (Requirement 5.6).
+      reply.code(403);
+      return { message: "Host secret is required" };
+    }
+
+    if (!context.reclaimRateLimiter.shouldAllow(key)) {
+      reply.code(403);
+      return { message: "Host secret is required" };
+    }
+
+    if (!hasValidHostSecret(room, headerValue)) {
+      context.reclaimRateLimiter.recordFailure(key);
+      reply.code(403);
+      return { message: "Host secret is required" };
+    }
+
+    const roomStatus = getRoomStatus(room, context.now());
+    if (roomStatus === "expired" || roomStatus === "closed") {
+      // The caller proved possession of the secret, so clear the failure
+      // counter even though we are returning 409. This matches Requirement
+      // 5.3 which resets counters on successful verification independent of
+      // the downstream room state.
+      context.reclaimRateLimiter.recordSuccess(key);
+      reply.code(409);
+      return { message: "Room is no longer available" };
+    }
+
+    context.reclaimRateLimiter.recordSuccess(key);
+
+    const lobbyRequests =
+      room.accessMode === "lobby"
+        ? context.roomStore
+            .listLobbyRequests(room.slug)
+            .map((entry) => ({
+              requestId: entry.id,
+              displayName: entry.displayName,
+              createdAt: entry.createdAt,
+            }))
+        : [];
+
+    return {
+      room: toRoomSummary(room, context.now()),
+      lobbyRequests,
+    };
+  });
+}

--- a/apps/server/src/server-support.ts
+++ b/apps/server/src/server-support.ts
@@ -10,6 +10,10 @@ import {
   type PasscodeRateLimiter,
 } from "./domain/passcode-rate-limiter.js";
 import {
+  createInMemoryReclaimRateLimiter,
+  type ReclaimRateLimiter,
+} from "./domain/reclaim-rate-limiter.js";
+import {
   createInMemoryRoomStore,
   type RoomStore,
   type StoredRoom,
@@ -23,6 +27,7 @@ export interface BuildAppOptions {
   liveKitConfig?: LiveKitConfig | null;
   passcodeVerifier?: PasscodeVerifier;
   passcodeRateLimiter?: PasscodeRateLimiter;
+  reclaimRateLimiter?: ReclaimRateLimiter;
   /**
    * Overrides the Fastify logger option used by `buildApp`. Primarily used by
    * tests that capture log output into an in-memory buffer. When omitted the
@@ -37,6 +42,7 @@ export interface RouteContext {
   roomStore: RoomStore;
   passcodeVerifier: PasscodeVerifier;
   passcodeRateLimiter: PasscodeRateLimiter;
+  reclaimRateLimiter: ReclaimRateLimiter;
 }
 
 export function createRouteContext(options: BuildAppOptions = {}): RouteContext {
@@ -46,6 +52,7 @@ export function createRouteContext(options: BuildAppOptions = {}): RouteContext 
     roomStore: options.roomStore ?? createInMemoryRoomStore(),
     passcodeVerifier: options.passcodeVerifier ?? createArgon2idPasscodeVerifier(),
     passcodeRateLimiter: options.passcodeRateLimiter ?? createInMemoryPasscodeRateLimiter(),
+    reclaimRateLimiter: options.reclaimRateLimiter ?? createInMemoryReclaimRateLimiter(),
   };
 }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.5.0",
+    "fast-check": "^4.7.0",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",
     "vite": "^6.3.4"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,13 +22,12 @@ import { useCallFlow } from "./features/call/call-effects.js";
 import { useInstallPrompt } from "./features/home/install-effects.js";
 import { joinRoomRequest, submitLobbyAction } from "./features/room/room-actions.js";
 import { useDevicePreview } from "./features/room/preview-effects.js";
-import { useRoomPageData } from "./features/room/room-effects.js";
+import { useRoomPageData, useHostReclaim } from "./features/room/room-effects.js";
 import { useWaitingRoomState } from "./features/waiting/waiting-effects.js";
 import { assessNetworkHealth, type NetworkHealth } from "./network-health.js";
 import {
   clearStoredLobbyRequest,
   getApiBaseUrl,
-  loadStoredHostSecret,
   saveStoredHostSecret,
   saveStoredLobbyRequest,
   saveStoredCallSession,
@@ -58,10 +57,6 @@ export function App() {
       isOnline: typeof navigator === "undefined" ? true : navigator.onLine,
     }),
   );
-  const hostSecret = useMemo(
-    () => (viewState.kind === "home" ? null : loadStoredHostSecret(window.localStorage, viewState.slug)),
-    [viewState],
-  );
   const roomSlug = viewState.kind === "room" ? viewState.slug : null;
   const waitingSlug = viewState.kind === "waiting" ? viewState.slug : null;
   const waitingRequestId = viewState.kind === "waiting" ? viewState.requestId : null;
@@ -70,6 +65,21 @@ export function App() {
     () => getApiBaseUrl(import.meta.env.VITE_API_BASE_URL, window.location),
     [],
   );
+  const [cachedHasRoomSummary, setCachedHasRoomSummary] = useState(false);
+  const hostReclaim = useHostReclaim({
+    apiBaseUrl,
+    slug: roomSlug,
+    storage: window.localStorage,
+    hasRoomSummary: cachedHasRoomSummary,
+  });
+  const effectiveHostSecret =
+    hostReclaim.status === "unlocked" ? hostReclaim.hostSecret : null;
+  const hostSecret = effectiveHostSecret;
+  const reclaimRoomPageProps = {
+    reclaimStatus: hostReclaim.status,
+    reclaimManualError: hostReclaim.manualError,
+    onSubmitReclaimSecret: hostReclaim.submitManualSecret,
+  } as const;
   const {
     hostLobbyError,
     hostLobbyRequests,
@@ -80,9 +90,21 @@ export function App() {
     setHostLobbyRequests,
   } = useRoomPageData({
     apiBaseUrl,
-    hostSecret,
+    hostSecret: effectiveHostSecret,
     slug: roomSlug,
   });
+
+  useEffect(() => {
+    setCachedHasRoomSummary(roomSummary != null);
+  }, [roomSummary]);
+
+  // Seed the lobby queue with the reclaim response so the host sees pending
+  // requests without waiting for the next polling tick.
+  useEffect(() => {
+    if (hostReclaim.status === "unlocked" && hostReclaim.lobbyRequests.length > 0) {
+      setHostLobbyRequests(hostReclaim.lobbyRequests);
+    }
+  }, [hostReclaim.status, hostReclaim.lobbyRequests, setHostLobbyRequests]);
   const waitingApprovalHandler = useCallback((
     request: StoredLobbyRequest,
     status: Extract<LobbyRequestStatusResponse, { status: "approved" }>,
@@ -423,7 +445,7 @@ export function App() {
         displayName,
         hostLobbyError,
         hostLobbyRequests,
-        hostSecret,
+        hostSecret: effectiveHostSecret,
         isJoining,
         isLoadingRoom,
         joinError,
@@ -446,6 +468,7 @@ export function App() {
         roomSummary,
         selectedQualityPreset,
         slug: viewState.kind === "room" ? viewState.slug : roomSlug ?? "",
+        ...reclaimRoomPageProps,
       }}
       viewState={viewState}
       waitingPageProps={{

--- a/apps/web/src/features/room/host-reclaim.test.ts
+++ b/apps/web/src/features/room/host-reclaim.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+/*
+ * Integration-style tests for the host-reclaim flow. We exercise the action
+ * layer (reclaimHostRole) directly and verify its no-leak and persistence
+ * contracts. The hook `useHostReclaim` is covered indirectly through the
+ * action-layer guarantees plus typechecking; a fuller React renderer would
+ * add little value for these specific invariants at this stage.
+ */
+
+import { reclaimHostRole } from "./room-actions.js";
+import {
+  clearStoredHostSecret,
+  loadStoredHostSecret,
+  saveStoredHostSecret,
+} from "../../room-entry.js";
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  } as Storage;
+}
+
+function createReclaimFetchStub(
+  status: number,
+  body: unknown,
+): {
+  stub: typeof fetch;
+  calls: Array<{ url: string; method: string; headers: Record<string, string> }>;
+} {
+  const calls: Array<{ url: string; method: string; headers: Record<string, string> }> = [];
+  const stub = async (url: string, init?: RequestInit) => {
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      for (const [key, value] of Object.entries(init.headers as Record<string, string>)) {
+        headers[key.toLowerCase()] = value;
+      }
+    }
+    calls.push({ url, method: init?.method ?? "GET", headers });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      async json() {
+        return body;
+      },
+    } as unknown as Response;
+  };
+  return { stub: stub as unknown as typeof fetch, calls };
+}
+
+test("full manual-reclaim cycle persists the pasted secret on 200 and leaves it elsewhere alone", async () => {
+  const local = createMemoryStorage();
+  const session = createMemoryStorage();
+
+  const { stub, calls } = createReclaimFetchStub(200, {
+    room: {
+      slug: "Room123",
+      accessMode: "lobby",
+      maxParticipants: 2,
+      qualityCap: "balanced",
+      allowScreenShare: true,
+      status: "created",
+      expiresAt: "2026-03-24T18:00:00Z",
+    },
+    lobbyRequests: [],
+  });
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = stub;
+
+  try {
+    const pasted = "pasted-host-secret-value-ab12";
+    const outcome = await reclaimHostRole({
+      apiBaseUrl: "http://localhost:3000",
+      hostSecret: pasted,
+      slug: "Room123",
+    });
+
+    assert.equal(outcome.kind, "ok");
+    assert.equal(calls[0].headers["x-host-secret"], pasted);
+
+    // Simulate the hook's post-200 persistence step.
+    saveStoredHostSecret(local, "Room123", pasted);
+
+    // Must land in localStorage under the shared key, and nowhere else.
+    assert.equal(loadStoredHostSecret(local, "Room123"), pasted);
+    assert.equal(session.getItem("lowtime:host:Room123"), null);
+    assert.equal(local.getItem("lowtime:call:Room123"), null);
+    assert.equal(local.getItem("lowtime:lobby:Room123"), null);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("403 flow does not persist the pasted secret and clears any stale storage", async () => {
+  const local = createMemoryStorage();
+  // Pre-seed a stale secret so we can assert it gets cleared.
+  saveStoredHostSecret(local, "Room123", "stale-value");
+
+  const { stub } = createReclaimFetchStub(403, { message: "Host secret is required" });
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = stub;
+
+  try {
+    const pasted = "also-a-wrong-guess";
+    const outcome = await reclaimHostRole({
+      apiBaseUrl: "http://localhost:3000",
+      hostSecret: pasted,
+      slug: "Room123",
+    });
+
+    assert.equal(outcome.kind, "unauthorized");
+
+    // Simulate the hook's post-403 cleanup step for the automatic path.
+    clearStoredHostSecret(local, "Room123");
+    assert.equal(loadStoredHostSecret(local, "Room123"), null);
+
+    // The pasted value itself must not have been written anywhere.
+    assert.equal(local.getItem("lowtime:host:Room123"), null);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("409 flow preserves any stored secret so the host can retry later", async () => {
+  const local = createMemoryStorage();
+  saveStoredHostSecret(local, "Room123", "valid-but-room-gone");
+
+  const { stub } = createReclaimFetchStub(409, { message: "Room is no longer available" });
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = stub;
+
+  try {
+    const outcome = await reclaimHostRole({
+      apiBaseUrl: "http://localhost:3000",
+      hostSecret: "valid-but-room-gone",
+      slug: "Room123",
+    });
+
+    assert.equal(outcome.kind, "unavailable");
+    // Keep the stored secret per Requirement 9.4.
+    assert.equal(loadStoredHostSecret(local, "Room123"), "valid-but-room-gone");
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("reclaimHostRole does not accept a Storage parameter (no-leak invariant at the signature layer)", () => {
+  // The function signature accepts `{ apiBaseUrl, hostSecret, slug, signal? }`
+  // only. This test is a compile-time lock: if someone adds a Storage param
+  // in the future, this assertion fails and forces a review of the no-leak
+  // contract.
+  const accepted = {
+    apiBaseUrl: "",
+    hostSecret: "",
+    slug: "",
+    signal: undefined as AbortSignal | undefined,
+  };
+  const signatureFields = new Set(Object.keys(accepted));
+  assert.equal(signatureFields.has("storage"), false);
+});

--- a/apps/web/src/features/room/room-actions.test.ts
+++ b/apps/web/src/features/room/room-actions.test.ts
@@ -104,3 +104,124 @@ test("joinRoomRequest never writes passcode to any passed-in storage", async () 
   }));
   assert.equal(signatureFields.has("storage"), false);
 });
+
+
+import { reclaimHostRole } from "./room-actions.js";
+
+function createReclaimStub(
+  status: number,
+  body: unknown,
+): { stub: typeof fetch; calls: Array<{ url: string; headers: Record<string, string> }> } {
+  const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+  const stub = async (url: string, init?: RequestInit) => {
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      for (const [key, value] of Object.entries(init.headers as Record<string, string>)) {
+        headers[key.toLowerCase()] = value;
+      }
+    }
+    calls.push({ url, headers });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      async json() {
+        return body;
+      },
+    } as unknown as Response;
+  };
+  return { stub: stub as unknown as typeof fetch, calls };
+}
+
+test("reclaimHostRole sends x-host-secret header and returns ok on 200", async () => {
+  const { stub, calls } = createReclaimStub(200, {
+    room: {
+      slug: "Room123",
+      accessMode: "open",
+      maxParticipants: 2,
+      qualityCap: "balanced",
+      allowScreenShare: true,
+      status: "created",
+      expiresAt: "2026-03-24T18:00:00Z",
+    },
+    lobbyRequests: [],
+  });
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = stub;
+
+  try {
+    const outcome = await reclaimHostRole({
+      apiBaseUrl: "http://localhost:3000",
+      hostSecret: "secret-xyz",
+      slug: "Room123",
+    });
+
+    assert.equal(outcome.kind, "ok");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "http://localhost:3000/api/rooms/Room123/reclaim");
+    assert.equal(calls[0].headers["x-host-secret"], "secret-xyz");
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("reclaimHostRole returns 'unauthorized' on 403", async () => {
+  const { stub } = createReclaimStub(403, { message: "Host secret is required" });
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = stub;
+
+  try {
+    const outcome = await reclaimHostRole({
+      apiBaseUrl: "http://localhost:3000",
+      hostSecret: "bad",
+      slug: "Room123",
+    });
+    assert.equal(outcome.kind, "unauthorized");
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("reclaimHostRole returns 'unavailable' on 409", async () => {
+  const { stub } = createReclaimStub(409, { message: "Room is no longer available" });
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = stub;
+
+  try {
+    const outcome = await reclaimHostRole({
+      apiBaseUrl: "http://localhost:3000",
+      hostSecret: "secret",
+      slug: "Room123",
+    });
+    assert.equal(outcome.kind, "unavailable");
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("reclaimHostRole returns 'error' with a default message on non-parseable bodies", async () => {
+  const stub = async () => {
+    return {
+      ok: false,
+      status: 500,
+      async json() {
+        throw new Error("parse error");
+      },
+    } as unknown as Response;
+  };
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = stub as unknown as typeof fetch;
+
+  try {
+    const outcome = await reclaimHostRole({
+      apiBaseUrl: "http://localhost:3000",
+      hostSecret: "secret",
+      slug: "Room123",
+    });
+    assert.equal(outcome.kind, "error");
+    if (outcome.kind === "error") {
+      assert.ok(outcome.message.length > 0);
+    }
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});

--- a/apps/web/src/features/room/room-actions.ts
+++ b/apps/web/src/features/room/room-actions.ts
@@ -1,4 +1,4 @@
-import type { JoinRoomResponse, QualityPreset, RequestedMedia } from "@lowtime/shared";
+import type { JoinRoomResponse, QualityPreset, ReclaimRoomResponse, RequestedMedia } from "@lowtime/shared";
 
 import { buildPreviewConstraints } from "../../device-preview.js";
 
@@ -62,4 +62,61 @@ export async function submitLobbyAction(input: {
     const payload = (await response.json()) as { message?: string };
     throw new Error(payload.message ?? `Unable to ${input.action} lobby request`);
   }
+}
+
+export type ReclaimOutcome =
+  | { kind: "ok"; response: ReclaimRoomResponse }
+  | { kind: "unauthorized" }
+  | { kind: "unavailable" }
+  | { kind: "error"; message: string };
+
+/**
+ * Validates a stored or freshly pasted host secret against the server's
+ * reclaim endpoint. Returns a discriminated union so callers can map server
+ * responses to UI state without leaking raw HTTP status codes.
+ */
+export async function reclaimHostRole(input: {
+  apiBaseUrl: string;
+  hostSecret: string;
+  slug: string;
+  signal?: AbortSignal;
+}): Promise<ReclaimOutcome> {
+  let response: Response;
+  try {
+    response = await fetch(`${input.apiBaseUrl}/api/rooms/${input.slug}/reclaim`, {
+      method: "POST",
+      headers: {
+        "x-host-secret": input.hostSecret,
+      },
+      signal: input.signal,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unable to reclaim host role";
+    return { kind: "error", message };
+  }
+
+  if (response.ok) {
+    const payload = (await response.json()) as ReclaimRoomResponse;
+    return { kind: "ok", response: payload };
+  }
+
+  if (response.status === 403) {
+    return { kind: "unauthorized" };
+  }
+
+  if (response.status === 409) {
+    return { kind: "unavailable" };
+  }
+
+  let message = "Unable to reclaim host role";
+  try {
+    const payload = (await response.json()) as { message?: string };
+    if (typeof payload.message === "string" && payload.message.length > 0) {
+      message = payload.message;
+    }
+  } catch {
+    // Leave the default message when the body cannot be parsed.
+  }
+  return { kind: "error", message };
 }

--- a/apps/web/src/features/room/room-effects.ts
+++ b/apps/web/src/features/room/room-effects.ts
@@ -1,6 +1,13 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { LobbyRequestSummary, RoomSummary } from "@lowtime/shared";
+
+import {
+  clearStoredHostSecret,
+  loadStoredHostSecret,
+  saveStoredHostSecret,
+} from "../../room-entry.js";
+import { reclaimHostRole } from "./room-actions.js";
 
 export function useRoomPageData(input: {
   apiBaseUrl: string;
@@ -117,5 +124,186 @@ export function useRoomPageData(input: {
     roomSummary,
     setHostLobbyError,
     setHostLobbyRequests,
+  };
+}
+
+export type HostReclaimStatus =
+  | "idle"
+  | "checking"
+  | "unlocked"
+  | "needs-secret"
+  | "unavailable";
+
+export interface HostReclaimState {
+  status: HostReclaimStatus;
+  hostSecret: string | null;
+  lobbyRequests: LobbyRequestSummary[];
+  manualError: string | null;
+  submitManualSecret: (value: string) => Promise<void>;
+  clearManualError: () => void;
+}
+
+/**
+ * Drives the host-reclaim flow for the room page.
+ *
+ * On mount, reads the cached host secret from storage. If present, calls
+ * `/reclaim` once and transitions to `"unlocked"` on success, clearing the
+ * cached secret silently on a 403 (stale credential) and keeping it on a 409
+ * (unreclaimable room). When no secret is cached, transitions to
+ * `"needs-secret"` once the caller-supplied `roomSummary` signals that the
+ * slug resolves to a real room, enabling the Manual Reclaim Form.
+ *
+ * The hook owns the host-secret state for the room page; the only write to
+ * `localStorage` happens on a successful reclaim response.
+ */
+export function useHostReclaim(input: {
+  apiBaseUrl: string;
+  slug: string | null;
+  storage: Storage;
+  hasRoomSummary: boolean;
+}): HostReclaimState {
+  const { apiBaseUrl, slug, storage, hasRoomSummary } = input;
+
+  const [status, setStatus] = useState<HostReclaimStatus>("idle");
+  const [hostSecret, setHostSecret] = useState<string | null>(null);
+  const [lobbyRequests, setLobbyRequests] = useState<LobbyRequestSummary[]>([]);
+  const [manualError, setManualError] = useState<string | null>(null);
+
+  const hasFiredRef = useRef<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (slug == null) {
+      setStatus("idle");
+      setHostSecret(null);
+      setLobbyRequests([]);
+      setManualError(null);
+      hasFiredRef.current = null;
+      return;
+    }
+
+    // Only fire the automatic reclaim call once per (slug) mount.
+    if (hasFiredRef.current === slug) {
+      return;
+    }
+
+    const storedSecret = loadStoredHostSecret(storage, slug);
+
+    if (storedSecret == null) {
+      // No cached secret. Wait for the room summary to confirm the slug
+      // actually resolves to a room before offering the manual form.
+      if (hasRoomSummary) {
+        hasFiredRef.current = slug;
+        setStatus("needs-secret");
+        setHostSecret(null);
+        setLobbyRequests([]);
+      }
+      return;
+    }
+
+    hasFiredRef.current = slug;
+    setStatus("checking");
+    setHostSecret(storedSecret);
+    setManualError(null);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    void (async () => {
+      const outcome = await reclaimHostRole({
+        apiBaseUrl,
+        hostSecret: storedSecret,
+        slug,
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      if (outcome.kind === "ok") {
+        setStatus("unlocked");
+        setLobbyRequests(outcome.response.lobbyRequests);
+        return;
+      }
+
+      if (outcome.kind === "unauthorized") {
+        clearStoredHostSecret(storage, slug);
+        setHostSecret(null);
+        setStatus("needs-secret");
+        return;
+      }
+
+      if (outcome.kind === "unavailable") {
+        setStatus("unavailable");
+        return;
+      }
+
+      // Network or unexpected error: keep the stored secret (so a retry can
+      // still succeed) and surface the message on the manual form.
+      setStatus("needs-secret");
+      setManualError(outcome.message);
+    })();
+
+    return () => {
+      controller.abort();
+    };
+  }, [apiBaseUrl, slug, storage, hasRoomSummary]);
+
+  const submitManualSecret = useCallback(
+    async (value: string) => {
+      if (slug == null) {
+        return;
+      }
+      const trimmed = value.trim();
+      if (trimmed.length === 0) {
+        return;
+      }
+
+      setManualError(null);
+      setStatus("checking");
+
+      const outcome = await reclaimHostRole({
+        apiBaseUrl,
+        hostSecret: trimmed,
+        slug,
+      });
+
+      if (outcome.kind === "ok") {
+        saveStoredHostSecret(storage, slug, trimmed);
+        setHostSecret(trimmed);
+        setLobbyRequests(outcome.response.lobbyRequests);
+        setStatus("unlocked");
+        return;
+      }
+
+      if (outcome.kind === "unauthorized") {
+        setStatus("needs-secret");
+        setManualError("That host secret is not valid for this room.");
+        return;
+      }
+
+      if (outcome.kind === "unavailable") {
+        setStatus("unavailable");
+        setManualError("This room is no longer available.");
+        return;
+      }
+
+      setStatus("needs-secret");
+      setManualError(outcome.message);
+    },
+    [apiBaseUrl, slug, storage],
+  );
+
+  const clearManualError = useCallback(() => {
+    setManualError(null);
+  }, []);
+
+  return {
+    status,
+    hostSecret,
+    lobbyRequests,
+    manualError,
+    submitManualSecret,
+    clearManualError,
   };
 }

--- a/apps/web/src/features/room/room-page.tsx
+++ b/apps/web/src/features/room/room-page.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
-import type { RefObject } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { FormEvent, RefObject } from "react";
 
 import type { JoinRoomResponse, LobbyRequestSummary, QualityPreset, RoomSummary } from "@lowtime/shared";
 
@@ -35,6 +35,9 @@ interface RoomPageProps {
   previewState: PreviewState;
   previewVideoEnabled: boolean;
   previewVideoRef: RefObject<HTMLVideoElement | null>;
+  reclaimStatus: "idle" | "checking" | "unlocked" | "needs-secret" | "unavailable";
+  reclaimManualError: string | null;
+  onSubmitReclaimSecret: (value: string) => Promise<void>;
   roomError: string | null;
   roomSummary: RoomSummary | null;
   selectedQualityPreset: QualityPreset;
@@ -211,7 +214,7 @@ export function RoomPage(props: RoomPageProps) {
               </p>
             ) : null}
           </section>
-          {props.roomSummary.accessMode === "lobby" && props.hostSecret ? (
+          {props.roomSummary.accessMode === "lobby" && props.hostSecret && props.reclaimStatus === "unlocked" ? (
             <section style={previewCardStyle}>
               <div style={tileHeaderStyle}>
                 <h2 style={tileHeadingStyle}>Host Lobby Queue</h2>
@@ -244,8 +247,79 @@ export function RoomPage(props: RoomPageProps) {
               {props.hostLobbyError ? <p role="alert">{props.hostLobbyError}</p> : null}
             </section>
           ) : null}
+          {props.reclaimStatus === "unavailable" ? (
+            <section style={previewCardStyle}>
+              <p role="alert">This room is no longer available.</p>
+            </section>
+          ) : null}
+          {props.reclaimStatus === "needs-secret" ? (
+            <ManualReclaimForm
+              manualError={props.reclaimManualError}
+              onSubmit={props.onSubmitReclaimSecret}
+            />
+          ) : null}
         </>
       ) : null}
     </main>
+  );
+}
+
+function ManualReclaimForm(props: {
+  manualError: string | null;
+  onSubmit: (value: string) => Promise<void>;
+}) {
+  const [secret, setSecret] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const disabled = secret.trim().length === 0 || isSubmitting;
+
+  useEffect(() => {
+    if (props.manualError != null && inputRef.current != null) {
+      inputRef.current.focus();
+    }
+  }, [props.manualError]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (disabled) {
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      await props.onSubmit(secret);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <section style={previewCardStyle}>
+      <form onSubmit={handleSubmit} aria-labelledby="reclaim-heading">
+        <h2 id="reclaim-heading" style={tileHeadingStyle}>
+          Reclaim host role
+        </h2>
+        <p style={mutedParagraphStyle}>
+          Paste the host secret you were shown when the room was created.
+        </p>
+        <label>
+          Host secret
+          <input
+            ref={inputRef}
+            type="password"
+            value={secret}
+            onChange={(event) => setSecret(event.target.value)}
+            placeholder="Paste host secret"
+            autoComplete="off"
+          />
+        </label>
+        <div>
+          <button type="submit" disabled={disabled}>
+            {isSubmitting ? "Reclaiming..." : "Reclaim Host Role"}
+          </button>
+        </div>
+        {props.manualError ? <p role="alert">{props.manualError}</p> : null}
+      </form>
+    </section>
   );
 }

--- a/apps/web/src/room-entry.test.ts
+++ b/apps/web/src/room-entry.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   buildRequestedMedia,
   clearStoredCallSession,
+  clearStoredHostSecret,
   clearStoredLobbyRequest,
   getApiBaseUrl,
   getCallRoute,
@@ -126,4 +127,30 @@ test("stored lobby requests and host secret round-trip cleanly", () => {
 
   clearStoredLobbyRequest(mockStorage, "Room123");
   assert.equal(loadStoredLobbyRequest(mockStorage, "Room123"), null);
+});
+
+
+test("clearStoredHostSecret removes the host secret and is a no-op for missing keys", () => {
+  const storage = new Map<string, string>();
+  const mockStorage = {
+    getItem(key: string) {
+      return storage.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      storage.set(key, value);
+    },
+    removeItem(key: string) {
+      storage.delete(key);
+    },
+  } as Storage;
+
+  saveStoredHostSecret(mockStorage, "Room456", "host_secret_xyz");
+  assert.equal(loadStoredHostSecret(mockStorage, "Room456"), "host_secret_xyz");
+
+  clearStoredHostSecret(mockStorage, "Room456");
+  assert.equal(loadStoredHostSecret(mockStorage, "Room456"), null);
+
+  // No-op for a slug that has no cached secret.
+  clearStoredHostSecret(mockStorage, "RoomDoesNotExist");
+  assert.equal(loadStoredHostSecret(mockStorage, "RoomDoesNotExist"), null);
 });

--- a/apps/web/src/room-entry.ts
+++ b/apps/web/src/room-entry.ts
@@ -173,6 +173,10 @@ export function loadStoredHostSecret(storage: Storage, slug: string): string | n
   return value == null || value.trim() === "" ? null : value;
 }
 
+export function clearStoredHostSecret(storage: Storage, slug: string) {
+  storage.removeItem(getStoredHostSecretKey(slug));
+}
+
 function getStoredCallSessionKey(slug: string): string {
   return `lowtime:call:${slug}`;
 }

--- a/docs/03-room-and-user-flows.md
+++ b/docs/03-room-and-user-flows.md
@@ -128,4 +128,5 @@ Expired --> [*]
 - Guests should remain on the join screen until room admission is confirmed.
 - Current implementation supports a `/r/:slug/waiting/:requestId` route that polls lobby status until the host approves or denies the request.
 - Hosts can review pending lobby requests from the room page when the local browser still has the room host secret.
+- The host reclaim flow is currently REST-only via `POST /api/rooms/:slug/reclaim`. On room-page mount the web client silently validates the cached host secret with the server; on a 403 response the stale cache is cleared and the room page renders a paste-a-secret form in the Room Preview section. WebSocket-based reclaim via `room.connect` is deferred until signaling lands.
 - The reconnect window should preserve participant identity without creating duplicate live sessions.

--- a/docs/05-api-and-realtime-contracts.md
+++ b/docs/05-api-and-realtime-contracts.md
@@ -17,10 +17,10 @@ The API controls room lifecycle and admission. WebSocket signaling handles live 
 | `GET` | `/api/rooms/:slug` | None | Fetch room metadata for the join screen |
 | `POST` | `/api/rooms/:slug/join` | None | Validate join request and return admission state |
 | `POST` | `/api/rooms/:slug/token` | Session-scoped join data | Issue SFU or P2P join credentials |
-| `POST` | `/api/rooms/:slug/settings` | `X-LowTime-Host-Secret` | Change access mode, quality cap, room size, or screen-share policy |
-| `POST` | `/api/rooms/:slug/lobby/:requestId/approve` | `X-LowTime-Host-Secret` | Approve a waiting guest |
-| `POST` | `/api/rooms/:slug/lobby/:requestId/deny` | `X-LowTime-Host-Secret` | Deny a waiting guest |
-| `POST` | `/api/rooms/:slug/reclaim` | `X-LowTime-Host-Secret` | Restore host role after refresh or reconnect |
+| `POST` | `/api/rooms/:slug/settings` | `x-host-secret` | Change access mode or rotate the passcode |
+| `POST` | `/api/rooms/:slug/lobby/:requestId/approve` | `x-host-secret` | Approve a waiting guest |
+| `POST` | `/api/rooms/:slug/lobby/:requestId/deny` | `x-host-secret` | Deny a waiting guest |
+| `POST` | `/api/rooms/:slug/reclaim` | `x-host-secret` | Restore host role after refresh or reconnect |
 
 ## Key Request And Response Shapes
 
@@ -243,6 +243,42 @@ Current implementation notes:
   - `POST /api/rooms/:slug/lobby/:requestId/approve` for host admission
   - `POST /api/rooms/:slug/lobby/:requestId/deny` for host denial
   - `POST /api/rooms/:slug/settings` for host-only access mode and passcode rotation
+  - `POST /api/rooms/:slug/reclaim` for host reclaim after refresh
+- HTTP header names are case-insensitive per RFC 7230. All host-only endpoints use the lowercase `x-host-secret` form in the table; clients may send any casing.
+
+### `POST /api/rooms/:slug/reclaim`
+Host-only via the `x-host-secret` header.
+
+Request body: none required.
+
+Response body (200):
+```json
+{
+  "room": {
+    "slug": "7Qn2kP9Zx4Lm",
+    "accessMode": "lobby",
+    "maxParticipants": 2,
+    "qualityCap": "balanced",
+    "allowScreenShare": true,
+    "status": "active",
+    "expiresAt": "2026-03-24T18:00:00Z"
+  },
+  "lobbyRequests": [
+    { "requestId": "req_abc", "displayName": "Guest A", "createdAt": "2026-03-24T16:50:00Z" }
+  ]
+}
+```
+
+Failure responses:
+- `403` with `{ "message": "Host secret is required" }` for a missing header, a wrong header, or an unknown room slug. The endpoint deliberately returns the same shape for all four cases to prevent enumeration.
+- `409` with `{ "message": "Room is no longer available" }` when the host secret is valid but the room has expired or closed.
+
+Current implementation notes:
+- `lobbyRequests` is always present. It carries the current pending-approval queue for a room whose `accessMode` is `lobby` and is an empty array otherwise.
+- The response body never includes the plaintext host secret, the plaintext passcode, or the passcode hash.
+- Reclaim is idempotent. It does not mutate `status`, `expiresAt`, `accessMode`, the passcode hash, sessions, the lobby queue, or the passcode rate limiter.
+- Repeated failures from the same `(client IP, room slug)` pair are rate-limited under the same profile as passcode verification: 5 failed attempts within a 5 minute sliding window open a 60 second cooldown during which reclaim attempts from that pair return `403` without invoking the host-secret check. Successful attempts reset the counter. Unknown-slug attempts never touch the limiter.
+- A future WebSocket `room.connect` path (carrying the host secret as a payload field) is documented in the WebSocket Signaling section below and will be revisited when signaling lands.
 
 ### `POST /api/rooms/:slug/settings`
 Host-only via the `x-host-secret` header. The request body must change at least one of `accessMode` or `passcode`.

--- a/docs/09-security-and-abuse.md
+++ b/docs/09-security-and-abuse.md
@@ -25,6 +25,13 @@ LowTime avoids account-based security controls, so link entropy, host-secret han
 - `trustProxy` is not enabled on Fastify today. Deployments behind a reverse proxy that sets `X-Forwarded-For` must enable `trustProxy` so `request.ip` reflects the client address used for rate-limit keys.
 - Never echo passcodes back to the client or logs. The plaintext is returned exactly once in the `CreateRoomResponse.passcode` field and never in any other REST response, settings response, or log line.
 
+## Reclaim Rate Limiting
+- `POST /api/rooms/:slug/reclaim` validates the submitted host secret against the stored secret. Repeated failures from the same `(client IP, room slug)` pair are throttled: 5 failures within a 5 minute sliding window open a 60 second cooldown during which any reclaim attempt from that pair is denied with a generic 403 without invoking the host-secret comparison.
+- Failures on unknown room slugs are **not** recorded by the limiter. This is a deliberate anti-enumeration guard so a bot scanning random slugs cannot lock out legitimate callers on real rooms.
+- The reclaim limiter is a separate in-process component from the passcode limiter. Settings-driven passcode rotations do not clear reclaim-failure state, and vice versa.
+- Like the passcode limiter, the reclaim limiter is per-process and resets on restart; `trustProxy` must be enabled when the Fastify app sits behind a reverse proxy so `request.ip` reflects the client.
+- Cooldown state is never disclosed: the 403 response body is the same generic `"Host secret is required"` whether the secret is missing, wrong, or the caller is inside a cooldown.
+
 ## Link And Room ID Policy
 - Use 12-character base58 room slugs.
 - Treat the room link as public but unguessable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.5.0",
+        "fast-check": "^4.7.0",
         "tsx": "^4.19.4",
         "typescript": "^5.8.3",
         "vite": "^6.3.4"

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -56,6 +56,11 @@ export interface UpdateRoomSettingsResponse {
   room: RoomSummary;
 }
 
+export interface ReclaimRoomResponse {
+  room: RoomSummary;
+  lobbyRequests: LobbyRequestSummary[];
+}
+
 export interface JoinRoomRequest {
   displayName: string;
   passcode?: string;


### PR DESCRIPTION
## Summary
Implements issue #13 (Phase 2: Host reclaim after refresh) end to end.

- Adds `POST /api/rooms/:slug/reclaim` that validates the submitted host secret via the existing `hasValidHostSecret` helper and returns a host-visible snapshot of the room (`RoomSummary` + pending lobby queue) so the web client can restore host UI in one round trip.
- Adds a dedicated `(IP, slug)` reclaim rate limiter with the same 5-in-5min / 60s cooldown profile as the passcode limiter. Kept as a separate component so reclaim floods and passcode floods do not lock each other out, and settings-driven passcode rotations do not clear reclaim state.
- Adds a `useHostReclaim` hook that silently validates the cached host secret on room-page mount. On 403 the stale secret is cleared and a paste-a-secret form is rendered in the Room Preview section. On 409 the stored secret is retained and the page renders a "room unavailable" notice.
- Docs, `TODO.md`, and shared types updated in the same change.

Closes #13.

## Endpoint Contract
- `200` with `{ room: RoomSummary, lobbyRequests: LobbyRequestSummary[] }` on a valid secret. `lobbyRequests` is always present and is an empty array for non-lobby rooms.
- `403 { message: \"Host secret is required\" }` for missing header, wrong header, unknown slug, or active cooldown. Same body for all four cases by design (anti-enumeration).
- `409 { message: \"Room is no longer available\" }` for expired or closed rooms with a valid secret.

## Correctness Properties (fast-check)
Five property tests cover the spec-level guarantees:

1. Reclaim round-trip for valid credentials (Req 1.1, 2.1, 2.2, 2.3, 6.1, 6.4)
2. No echo of secrets (Req 1.2, 1.3, 2.4, 6.3, 7.1-7.4)
3. Reclaim is idempotent (Req 3.1, 3.2, 6.1)
4. Rate limiter safety under repeated failures (Req 3.3, 5.1-5.5)
5. Unknown-room anti-enumeration (Req 1.4, 5.6, 7.3)

## Files Touched
- Server: new `domain/reclaim-rate-limiter.ts` and `routes/reclaim.ts`, extended `server-support.ts` and `app.ts`, new `host-reclaim.test.ts`.
- Web: extended `features/room/room-actions.ts` with `reclaimHostRole`, extended `features/room/room-effects.ts` with `useHostReclaim`, extended `features/room/room-page.tsx` with the Manual Reclaim Form, and rewired host-secret ownership in `App.tsx` away from direct `localStorage` reads.
- Shared: new `ReclaimRoomResponse` type.
- Docs: `docs/05-api-and-realtime-contracts.md`, `docs/03-room-and-user-flows.md`, `docs/09-security-and-abuse.md`, `TODO.md`.

## Dependencies Added
- `fast-check` dev-dep on `apps/web` for Property-style action tests (already on `apps/server`).

## Verification
    npm run lint        # all workspaces clean
    npm run typecheck   # all workspaces clean
    npm run test        # 106 server + 49 web = 155 tests, all pass
    npm run build       # succeeds (server tsc + web vite build)