### PR TITLE
feat: add room expiry and cleanup jobs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -49,7 +49,7 @@
 | Passcode-protected rooms | `done` | Issue #12. Added Argon2id hash storage, join-time verification, `(IP, slug)` rate limiter, host-only settings endpoint for rotation, and access-mode + passcode UI on create and join screens | [docs/09-security-and-abuse.md](docs/09-security-and-abuse.md) |
 | Host reclaim after refresh | `done` | Issue #13. Added `POST /api/rooms/:slug/reclaim` with dedicated `(IP, slug)` rate limiter, `useHostReclaim` hook that silently validates cached host secrets on room-page mount, and a paste-a-secret form for hosts without a cached credential | [docs/03-room-and-user-flows.md](docs/03-room-and-user-flows.md) |
 | Reconnect window and session recovery | `planned` | Preserve identity during short disconnects | [docs/06-data-model-and-lifecycle.md](docs/06-data-model-and-lifecycle.md) |
-| Room expiry and cleanup jobs | `planned` | Expire inactive rooms and trim transient state | [docs/06-data-model-and-lifecycle.md](docs/06-data-model-and-lifecycle.md) |
+| Room expiry and cleanup jobs | `done` | Issue #15. Added activity-driven room expiry with a 2h inactivity timer, a 60-second cleanup loop, 10-minute lobby-request TTL with new `lobby_timeout` denial reason, and a 5-minute closed-room grace window. See `apps/server/src/domain/room-cleanup.ts` and `apps/server/src/domain/room-activity.ts` | [docs/06-data-model-and-lifecycle.md](docs/06-data-model-and-lifecycle.md) |
 
 ## Phase 3: Flexible Quality Controls
 

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -8,6 +8,7 @@ import { registerReclaimRoutes } from "./routes/reclaim.js";
 import { registerRoomRoutes } from "./routes/rooms.js";
 import { registerSettingsRoutes } from "./routes/settings.js";
 import { createInMemoryRoomStore, type RoomStore } from "./domain/room-store.js";
+import { startCleanupLoop } from "./domain/room-cleanup.js";
 import {
   createRouteContext,
   type BuildAppOptions,
@@ -31,6 +32,20 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   registerMediaRoutes(app, context);
   registerSettingsRoutes(app, context);
   registerReclaimRoutes(app, context);
+
+  const intervalMs = options.cleanupIntervalMs;
+  if (typeof intervalMs === "number" && Number.isFinite(intervalMs) && intervalMs > 0) {
+    const loop = startCleanupLoop({
+      store: context.roomStore,
+      intervalMs,
+      now: context.now,
+      logger: app.log,
+      scheduler: options.cleanupScheduler,
+    });
+    app.addHook("onClose", async () => {
+      loop.stop();
+    });
+  }
 
   return app;
 }

--- a/apps/server/src/domain/room-activity.ts
+++ b/apps/server/src/domain/room-activity.ts
@@ -1,0 +1,43 @@
+import { getRoomStatus } from "./room-status.js";
+import { ROOM_TTL_MS, type RoomStore } from "./room-store.js";
+
+/**
+ * Returns the ISO-8601 timestamp that represents `lastActivityAt + ROOM_TTL_MS`.
+ * Separated from the mutating helper so tests can exercise the calculation
+ * without constructing a store.
+ */
+export function computeExpiryFrom(lastActivityAt: string): string {
+  return new Date(Date.parse(lastActivityAt) + ROOM_TTL_MS).toISOString();
+}
+
+/**
+ * Bumps the room's `lastActivityAt` to `now` and recomputes `expiresAt` as
+ * `lastActivityAt + ROOM_TTL_MS`. No-op when the slug is unknown, when the
+ * computed status is already `"expired"`, or when the stored status is
+ * `"closed"`. Never throws.
+ *
+ * Called by every sanctioned write path (direct admission, lobby approve,
+ * settings update / passcode rotation). See
+ * `.kiro/specs/room-expiry-and-cleanup/requirements.md` Requirement 2 for the
+ * exhaustive list of call sites and their negative clauses.
+ */
+export function recordRoomActivity(store: RoomStore, slug: string, now: Date): void {
+  const room = store.getRoom(slug);
+  if (room == null) {
+    return;
+  }
+
+  if (room.status === "closed") {
+    return;
+  }
+
+  if (getRoomStatus(room, now) === "expired") {
+    return;
+  }
+
+  const lastActivityAt = now.toISOString();
+  const expiresAt = computeExpiryFrom(lastActivityAt);
+  store.setRoomActivity(slug, lastActivityAt, expiresAt);
+}
+
+export { ROOM_TTL_MS };

--- a/apps/server/src/domain/room-cleanup.ts
+++ b/apps/server/src/domain/room-cleanup.ts
@@ -1,0 +1,186 @@
+import type { FastifyBaseLogger } from "fastify";
+
+import { getRoomStatus } from "./room-status.js";
+import type { RoomStore } from "./room-store.js";
+
+/** Ten minutes. Lobby requests older than this are reaped by the tick. */
+export const LOBBY_REQUEST_TTL_MS = 10 * 60 * 1000;
+
+/** Five minutes. Closed rooms are kept in the store this long before reap. */
+export const CLOSED_ROOM_GRACE_WINDOW_MS = 5 * 60 * 1000;
+
+export interface CleanupOptions {
+  lobbyRequestTtlMs?: number;
+  closedRoomGraceWindowMs?: number;
+  logger?: Pick<FastifyBaseLogger, "info" | "error">;
+}
+
+export interface CleanupResult {
+  expiredRoomsRemoved: number;
+  closedRoomsReaped: number;
+  lobbyRequestsTimedOut: number;
+}
+
+/**
+ * Sweeps the Room_Store once.
+ *
+ *   1. Captures `now` once and reuses it for every comparison in the tick.
+ *   2. Iterates `store.listRoomSlugs()` (a fresh array) so in-tick deletions
+ *      do not confuse the iterator.
+ *   3. For each room, decides `idle-expired`, `closed-past-grace`, or `keep`.
+ *   4. For kept rooms that are not closed, reaps waiting lobby requests older
+ *      than `lobbyRequestTtlMs` and marks them denied with `"lobby_timeout"`.
+ *
+ * Emits one structured log record per state change at `info` level. A tick
+ * that performs no mutations emits no `info` records; Requirement 9.5 allows
+ * but does not require a `debug`-level heartbeat.
+ *
+ * The function is pure with respect to the clock (takes `now`) and the
+ * logger (takes a `Pick<FastifyBaseLogger, "info" | "error">`). Tests inject
+ * both deterministically.
+ */
+export function runCleanupTick(
+  store: RoomStore,
+  options: CleanupOptions,
+  now: Date,
+): CleanupResult {
+  const tickNow = now.getTime();
+  const lobbyTtl = options.lobbyRequestTtlMs ?? LOBBY_REQUEST_TTL_MS;
+  const closedGrace = options.closedRoomGraceWindowMs ?? CLOSED_ROOM_GRACE_WINDOW_MS;
+  const logger = options.logger;
+
+  let expiredRoomsRemoved = 0;
+  let closedRoomsReaped = 0;
+  let lobbyRequestsTimedOut = 0;
+
+  for (const slug of store.listRoomSlugs()) {
+    const room = store.getRoom(slug);
+    if (room == null) continue;
+
+    const status = getRoomStatus(room, now);
+
+    if (room.status !== "closed" && status === "expired") {
+      store.deleteRoom(slug);
+      expiredRoomsRemoved += 1;
+      logger?.info(
+        {
+          event: "room_cleanup",
+          action: "room_idle_expired",
+          roomSlug: slug,
+          lastActivityAt: room.lastActivityAt,
+          expiresAt: room.expiresAt,
+        },
+        "room expired",
+      );
+      continue;
+    }
+
+    if (room.status === "closed") {
+      if (room.closedAt != null && Date.parse(room.closedAt) + closedGrace <= tickNow) {
+        store.deleteRoom(slug);
+        closedRoomsReaped += 1;
+        logger?.info(
+          {
+            event: "room_cleanup",
+            action: "room_closed_reaped",
+            roomSlug: slug,
+            closedAt: room.closedAt,
+          },
+          "closed room reaped",
+        );
+      }
+      continue;
+    }
+
+    // Still-live room: reap stale waiting lobby requests.
+    for (const request of room.lobbyRequests) {
+      if (request.status !== "waiting") continue;
+      if (Date.parse(request.createdAt) + lobbyTtl > tickNow) continue;
+
+      store.denyLobbyRequest(slug, request.id, "lobby_timeout");
+      lobbyRequestsTimedOut += 1;
+      logger?.info(
+        {
+          event: "room_cleanup",
+          action: "lobby_request_timed_out",
+          roomSlug: slug,
+          requestId: request.id,
+          createdAt: request.createdAt,
+        },
+        "lobby request timed out",
+      );
+    }
+  }
+
+  return { expiredRoomsRemoved, closedRoomsReaped, lobbyRequestsTimedOut };
+}
+
+export interface CleanupScheduler {
+  schedule(callback: () => void, intervalMs: number): unknown;
+  cancel(handle: unknown): void;
+}
+
+export function createIntervalScheduler(): CleanupScheduler {
+  return {
+    schedule(callback, intervalMs) {
+      const handle = setInterval(callback, intervalMs);
+      // Allow the Node event loop to exit while the interval is pending so
+      // `buildApp` does not accidentally hold the process open.
+      const maybeUnref = (handle as unknown as { unref?: () => void }).unref;
+      if (typeof maybeUnref === "function") {
+        maybeUnref.call(handle);
+      }
+      return handle;
+    },
+    cancel(handle) {
+      clearInterval(handle as NodeJS.Timeout);
+    },
+  };
+}
+
+export interface StartCleanupLoopInput {
+  store: RoomStore;
+  intervalMs: number;
+  now: () => Date;
+  logger: Pick<FastifyBaseLogger, "info" | "error">;
+  scheduler?: CleanupScheduler;
+  cleanupOptions?: Omit<CleanupOptions, "logger">;
+}
+
+export interface CleanupLoopHandle {
+  stop(): void;
+}
+
+/**
+ * Starts the cleanup loop. Tick errors are caught and logged as
+ * `{ event: "room_cleanup", action: "tick_failed" }`; subsequent ticks
+ * continue to run.
+ */
+export function startCleanupLoop(input: StartCleanupLoopInput): CleanupLoopHandle {
+  const scheduler = input.scheduler ?? createIntervalScheduler();
+
+  const handle = scheduler.schedule(() => {
+    try {
+      runCleanupTick(
+        input.store,
+        { ...(input.cleanupOptions ?? {}), logger: input.logger },
+        input.now(),
+      );
+    } catch (error) {
+      input.logger.error(
+        {
+          event: "room_cleanup",
+          action: "tick_failed",
+          message: error instanceof Error ? error.message : String(error),
+        },
+        "cleanup tick failed",
+      );
+    }
+  }, input.intervalMs);
+
+  return {
+    stop() {
+      scheduler.cancel(handle);
+    },
+  };
+}

--- a/apps/server/src/domain/room-store.ts
+++ b/apps/server/src/domain/room-store.ts
@@ -8,11 +8,18 @@ import type {
   TransportPreference,
 } from "@lowtime/shared";
 
+/** Two hours. Inactivity TTL applied to rooms on every activity bump. */
+export const ROOM_TTL_MS = 2 * 60 * 60 * 1000;
+
+export type LobbyDenialReason = "host_denied" | "room_expired" | "room_closed" | "lobby_timeout";
+
 export interface StoredRoom extends RoomSummary {
   hostSecret: string;
   passcodeHash: string | null;
   sessions: StoredSession[];
   lobbyRequests: StoredLobbyRequest[];
+  lastActivityAt: string;
+  closedAt: string | null;
 }
 
 export interface CreateStoredRoomInput {
@@ -20,7 +27,11 @@ export interface CreateStoredRoomInput {
   maxParticipants: number;
   qualityCap: QualityCap;
   allowScreenShare: boolean;
-  expiresAt: string;
+  /**
+   * Seed timestamp for `lastActivityAt`. Defaults to the ambient clock passed
+   * into `createRoom`. Tests use this seam to freeze the initial expiry.
+   */
+  initialActivity?: string;
   passcodeHash?: string;
 }
 
@@ -36,32 +47,68 @@ export interface StoredLobbyRequest {
   status: "waiting" | "approved" | "denied";
   sessionId?: string;
   transportPreference?: TransportPreference;
-  denialReason?: "host_denied" | "room_expired" | "room_closed";
+  denialReason?: LobbyDenialReason;
 }
 
 export interface RoomStore {
-  createRoom(input: CreateStoredRoomInput): StoredRoom;
+  /**
+   * Creates a new room. `now` is the authoritative wall-clock used to seed
+   * `lastActivityAt` when `input.initialActivity` is omitted, and to compute
+   * the derived `expiresAt = lastActivityAt + ROOM_TTL_MS`.
+   */
+  createRoom(input: CreateStoredRoomInput, now: Date): StoredRoom;
   getRoom(slug: RoomSlug): StoredRoom | undefined;
+  /** Returns a fresh array of slugs. Safe to iterate while mutating the store. */
+  listRoomSlugs(): RoomSlug[];
+  /** Removes a room and its sub-arrays. Returns the removed record. */
+  deleteRoom(slug: RoomSlug): StoredRoom | undefined;
+  /** Updates the activity seed and the derived expiry together. */
+  setRoomActivity(
+    slug: RoomSlug,
+    lastActivityAt: string,
+    expiresAt: string,
+  ): boolean;
   setPasscodeHash(slug: RoomSlug, hash: string): boolean;
   clearPasscodeHash(slug: RoomSlug): boolean;
   createSession(roomSlug: RoomSlug, displayName: string): StoredSession | undefined;
-  createLobbyRequest(roomSlug: RoomSlug, displayName: string, createdAt: string): StoredLobbyRequest | undefined;
+  createLobbyRequest(
+    roomSlug: RoomSlug,
+    displayName: string,
+    createdAt: string,
+  ): StoredLobbyRequest | undefined;
   listLobbyRequests(roomSlug: RoomSlug): StoredLobbyRequest[];
-  getLobbyRequest(roomSlug: RoomSlug, requestId: string): StoredLobbyRequest | undefined;
-  approveLobbyRequest(roomSlug: RoomSlug, requestId: string): StoredLobbyRequest | undefined;
-  denyLobbyRequest(roomSlug: RoomSlug, requestId: string, reason: "host_denied" | "room_expired" | "room_closed"): StoredLobbyRequest | undefined;
+  getLobbyRequest(
+    roomSlug: RoomSlug,
+    requestId: string,
+  ): StoredLobbyRequest | undefined;
+  approveLobbyRequest(
+    roomSlug: RoomSlug,
+    requestId: string,
+  ): StoredLobbyRequest | undefined;
+  denyLobbyRequest(
+    roomSlug: RoomSlug,
+    requestId: string,
+    reason: LobbyDenialReason,
+  ): StoredLobbyRequest | undefined;
+}
+
+function computeExpiry(lastActivityAt: string): string {
+  return new Date(Date.parse(lastActivityAt) + ROOM_TTL_MS).toISOString();
 }
 
 export function createInMemoryRoomStore(): RoomStore {
   const rooms = new Map<RoomSlug, StoredRoom>();
 
   return {
-    createRoom(input) {
+    createRoom(input, now) {
       let slug = createSlug();
 
       while (rooms.has(slug)) {
         slug = createSlug();
       }
+
+      const lastActivityAt = input.initialActivity ?? now.toISOString();
+      const expiresAt = computeExpiry(lastActivityAt);
 
       const room: StoredRoom = {
         slug,
@@ -70,11 +117,13 @@ export function createInMemoryRoomStore(): RoomStore {
         qualityCap: input.qualityCap,
         allowScreenShare: input.allowScreenShare,
         status: "created",
-        expiresAt: input.expiresAt,
+        expiresAt,
         hostSecret: createHostSecret(),
         passcodeHash: input.passcodeHash ?? null,
         sessions: [],
         lobbyRequests: [],
+        lastActivityAt,
+        closedAt: null,
       };
 
       rooms.set(slug, room);
@@ -83,6 +132,26 @@ export function createInMemoryRoomStore(): RoomStore {
     },
     getRoom(slug) {
       return rooms.get(slug);
+    },
+    listRoomSlugs() {
+      return [...rooms.keys()];
+    },
+    deleteRoom(slug) {
+      const room = rooms.get(slug);
+      if (room == null) {
+        return undefined;
+      }
+      rooms.delete(slug);
+      return room;
+    },
+    setRoomActivity(slug, lastActivityAt, expiresAt) {
+      const room = rooms.get(slug);
+      if (room == null) {
+        return false;
+      }
+      room.lastActivityAt = lastActivityAt;
+      room.expiresAt = expiresAt;
+      return true;
     },
     setPasscodeHash(slug, hash) {
       const room = rooms.get(slug);
@@ -169,6 +238,14 @@ export function createInMemoryRoomStore(): RoomStore {
       const request = rooms.get(roomSlug)?.lobbyRequests.find((entry) => entry.id === requestId);
       if (request == null) {
         return undefined;
+      }
+
+      // Do not overwrite an existing denialReason (Requirement 10.5). The tick
+      // only reaches this call path for still-"waiting" requests, but a direct
+      // caller that bypasses the status guard would otherwise erase a valid
+      // prior reason.
+      if (request.status !== "waiting" && request.denialReason != null) {
+        return request;
       }
 
       request.status = "denied";

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -2,7 +2,11 @@ import { buildApp, parsePort } from "./app.js";
 
 const port = parsePort(process.env.PORT);
 const host = process.env.HOST ?? "0.0.0.0";
-const app = buildApp();
+const app = buildApp({
+  // Runs every 60 seconds in production; tests omit this option so the loop
+  // does not fire during `node --test` runs.
+  cleanupIntervalMs: 60_000,
+});
 
 app
   .listen({ port, host })

--- a/apps/server/src/passcode.test.ts
+++ b/apps/server/src/passcode.test.ts
@@ -630,19 +630,24 @@ describe("Rate Limiter: recovery (Property 4)", async () => {
 describe("Room store: passcode hash storage", async () => {
   const { createInMemoryRoomStore } = await import("./domain/room-store.js");
 
+  const testNow = new Date("2026-03-24T12:00:00Z");
+
   function baseInput() {
     return {
       accessMode: "passcode" as const,
       maxParticipants: 2,
       qualityCap: "balanced" as const,
       allowScreenShare: true,
-      expiresAt: new Date("2026-03-24T18:00:00Z").toISOString(),
+      initialActivity: testNow.toISOString(),
     };
   }
 
   test("createRoom stores the passcodeHash when provided", () => {
     const store = createInMemoryRoomStore();
-    const room = store.createRoom({ ...baseInput(), passcodeHash: "$argon2id$stub" });
+    const room = store.createRoom(
+      { ...baseInput(), passcodeHash: "$argon2id$stub" },
+      testNow,
+    );
     assert.equal(room.passcodeHash, "$argon2id$stub");
 
     const fetched = store.getRoom(room.slug);
@@ -651,13 +656,16 @@ describe("Room store: passcode hash storage", async () => {
 
   test("createRoom leaves passcodeHash null when not provided", () => {
     const store = createInMemoryRoomStore();
-    const room = store.createRoom({ ...baseInput(), accessMode: "open" });
+    const room = store.createRoom({ ...baseInput(), accessMode: "open" }, testNow);
     assert.equal(room.passcodeHash, null);
   });
 
   test("setPasscodeHash replaces the stored hash and returns true", () => {
     const store = createInMemoryRoomStore();
-    const room = store.createRoom({ ...baseInput(), passcodeHash: "$argon2id$old" });
+    const room = store.createRoom(
+      { ...baseInput(), passcodeHash: "$argon2id$old" },
+      testNow,
+    );
 
     const ok = store.setPasscodeHash(room.slug, "$argon2id$new");
     assert.equal(ok, true);
@@ -671,7 +679,10 @@ describe("Room store: passcode hash storage", async () => {
 
   test("clearPasscodeHash nulls the stored hash and returns true", () => {
     const store = createInMemoryRoomStore();
-    const room = store.createRoom({ ...baseInput(), passcodeHash: "$argon2id$stub" });
+    const room = store.createRoom(
+      { ...baseInput(), passcodeHash: "$argon2id$stub" },
+      testNow,
+    );
 
     const ok = store.clearPasscodeHash(room.slug);
     assert.equal(ok, true);

--- a/apps/server/src/room-cleanup.test.ts
+++ b/apps/server/src/room-cleanup.test.ts
@@ -1,0 +1,581 @@
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+
+import fc from "fast-check";
+
+import { buildApp } from "./app.js";
+import { recordRoomActivity, computeExpiryFrom } from "./domain/room-activity.js";
+import {
+  CLOSED_ROOM_GRACE_WINDOW_MS,
+  LOBBY_REQUEST_TTL_MS,
+  runCleanupTick,
+  startCleanupLoop,
+  type CleanupScheduler,
+} from "./domain/room-cleanup.js";
+import {
+  createInMemoryRoomStore,
+  ROOM_TTL_MS,
+} from "./domain/room-store.js";
+import { TEST_LIVEKIT_CONFIG, createMemoryLogger } from "./test-helpers.js";
+
+function parseLogLines(raw: string): Array<Record<string, unknown>> {
+  return raw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      try {
+        return JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        return null;
+      }
+    })
+    .filter((entry): entry is Record<string, unknown> => entry != null);
+}
+
+function cleanupActions(logs: string): string[] {
+  return parseLogLines(logs)
+    .filter((entry) => entry.event === "room_cleanup")
+    .map((entry) => String(entry.action));
+}
+
+describe("recordRoomActivity", () => {
+  test("bumps lastActivityAt and expiresAt for a known, non-closed room", () => {
+    const store = createInMemoryRoomStore();
+    const t0 = new Date("2026-03-24T12:00:00Z");
+    const room = store.createRoom(
+      {
+        accessMode: "open",
+        maxParticipants: 2,
+        qualityCap: "balanced",
+        allowScreenShare: true,
+      },
+      t0,
+    );
+
+    const t1 = new Date(t0.getTime() + 30 * 60 * 1000);
+    recordRoomActivity(store, room.slug, t1);
+
+    const fetched = store.getRoom(room.slug);
+    assert.equal(fetched?.lastActivityAt, t1.toISOString());
+    assert.equal(
+      fetched?.expiresAt,
+      new Date(t1.getTime() + ROOM_TTL_MS).toISOString(),
+    );
+  });
+
+  test("unknown slug is a no-op and does not throw", () => {
+    const store = createInMemoryRoomStore();
+    assert.doesNotThrow(() => {
+      recordRoomActivity(store, "not-a-room", new Date());
+    });
+  });
+
+  test("closed room is not bumped", () => {
+    const store = createInMemoryRoomStore();
+    const t0 = new Date("2026-03-24T12:00:00Z");
+    const room = store.createRoom(
+      {
+        accessMode: "open",
+        maxParticipants: 2,
+        qualityCap: "balanced",
+        allowScreenShare: true,
+      },
+      t0,
+    );
+    room.status = "closed";
+    room.closedAt = t0.toISOString();
+    const originalExpiry = room.expiresAt;
+
+    recordRoomActivity(store, room.slug, new Date(t0.getTime() + 1_000));
+
+    const fetched = store.getRoom(room.slug);
+    assert.equal(fetched?.expiresAt, originalExpiry);
+  });
+
+  test("expired room is not bumped", () => {
+    const store = createInMemoryRoomStore();
+    const t0 = new Date("2026-03-24T12:00:00Z");
+    const room = store.createRoom(
+      {
+        accessMode: "open",
+        maxParticipants: 2,
+        qualityCap: "balanced",
+        allowScreenShare: true,
+      },
+      t0,
+    );
+    const originalExpiry = room.expiresAt;
+
+    // Move past the TTL boundary.
+    recordRoomActivity(store, room.slug, new Date(t0.getTime() + ROOM_TTL_MS + 1));
+
+    const fetched = store.getRoom(room.slug);
+    assert.equal(fetched?.expiresAt, originalExpiry);
+  });
+
+  test("bumps are monotonically non-decreasing across successive calls", () => {
+    const store = createInMemoryRoomStore();
+    const t0 = new Date("2026-03-24T12:00:00Z");
+    const room = store.createRoom(
+      {
+        accessMode: "open",
+        maxParticipants: 2,
+        qualityCap: "balanced",
+        allowScreenShare: true,
+      },
+      t0,
+    );
+
+    for (const dt of [1_000, 2_000, 3_000, 4_000]) {
+      const t = new Date(t0.getTime() + dt);
+      recordRoomActivity(store, room.slug, t);
+      const fetched = store.getRoom(room.slug);
+      assert.equal(fetched?.lastActivityAt, t.toISOString());
+    }
+  });
+
+  test("computeExpiryFrom returns exactly lastActivityAt + TTL", () => {
+    const base = "2026-03-24T12:00:00.000Z";
+    assert.equal(
+      computeExpiryFrom(base),
+      new Date(Date.parse(base) + ROOM_TTL_MS).toISOString(),
+    );
+  });
+});
+
+describe("runCleanupTick", () => {
+  function seedActiveRoom(store: ReturnType<typeof createInMemoryRoomStore>, t0: Date) {
+    return store.createRoom(
+      {
+        accessMode: "open",
+        maxParticipants: 2,
+        qualityCap: "balanced",
+        allowScreenShare: true,
+      },
+      t0,
+    );
+  }
+
+  test("empty store is a no-op and emits no info records", () => {
+    const store = createInMemoryRoomStore();
+    const memLogger = createMemoryLogger();
+    const result = runCleanupTick(
+      store,
+      { logger: { info: () => {}, error: () => {} } },
+      new Date(),
+    );
+    assert.deepEqual(result, {
+      expiredRoomsRemoved: 0,
+      closedRoomsReaped: 0,
+      lobbyRequestsTimedOut: 0,
+    });
+    assert.equal(cleanupActions(memLogger.readCapturedLogs()).length, 0);
+  });
+
+  test("removes rooms whose expiresAt is in the past", () => {
+    const store = createInMemoryRoomStore();
+    const t0 = new Date("2026-03-24T12:00:00Z");
+    const room = seedActiveRoom(store, t0);
+
+    const memLogger = createMemoryLogger();
+    const info = (fields: Record<string, unknown>) => {
+      memLogger.loggerOption.stream.write(JSON.stringify(fields) + "\n");
+    };
+    const logger = { info, error: () => {} };
+
+    // Tick at a time strictly past the room's expiry.
+    const tickTime = new Date(t0.getTime() + ROOM_TTL_MS + 1);
+    const result = runCleanupTick(store, { logger }, tickTime);
+
+    assert.equal(result.expiredRoomsRemoved, 1);
+    assert.equal(store.getRoom(room.slug), undefined);
+
+    const actions = cleanupActions(memLogger.readCapturedLogs());
+    assert.equal(actions.filter((a) => a === "room_idle_expired").length, 1);
+  });
+
+  test("keeps rooms whose expiresAt is still in the future", () => {
+    const store = createInMemoryRoomStore();
+    const t0 = new Date("2026-03-24T12:00:00Z");
+    const room = seedActiveRoom(store, t0);
+
+    const result = runCleanupTick(store, {}, new Date(t0.getTime() + 30 * 60_000));
+    assert.equal(result.expiredRoomsRemoved, 0);
+    assert.ok(store.getRoom(room.slug) != null);
+  });
+
+  test("reaps closed rooms only after the grace window elapses", () => {
+    const store = createInMemoryRoomStore();
+    const t0 = new Date("2026-03-24T12:00:00Z");
+    const room = seedActiveRoom(store, t0);
+    room.status = "closed";
+    room.closedAt = t0.toISOString();
+
+    // Inside the grace window: retain.
+    const insideResult = runCleanupTick(
+      store,
+      {},
+      new Date(t0.getTime() + CLOSED_ROOM_GRACE_WINDOW_MS - 1),
+    );
+    assert.equal(insideResult.closedRoomsReaped, 0);
+    assert.ok(store.getRoom(room.slug) != null);
+
+    // At exactly the boundary: reap.
+    const atBoundaryResult = runCleanupTick(
+      store,
+      {},
+      new Date(t0.getTime() + CLOSED_ROOM_GRACE_WINDOW_MS),
+    );
+    assert.equal(atBoundaryResult.closedRoomsReaped, 1);
+    assert.equal(store.getRoom(room.slug), undefined);
+  });
+
+  test("transitions stale waiting lobby requests to denied with reason lobby_timeout", () => {
+    const store = createInMemoryRoomStore();
+    const t0 = new Date("2026-03-24T12:00:00Z");
+    const room = store.createRoom(
+      {
+        accessMode: "lobby",
+        maxParticipants: 2,
+        qualityCap: "balanced",
+        allowScreenShare: true,
+      },
+      t0,
+    );
+    const reqOld = store.createLobbyRequest(room.slug, "OldGuest", t0.toISOString());
+    assert.ok(reqOld != null);
+
+    // Fresh request less than the TTL old.
+    const tFresh = new Date(t0.getTime() + 5 * 60_000);
+    const reqFresh = store.createLobbyRequest(room.slug, "FreshGuest", tFresh.toISOString());
+    assert.ok(reqFresh != null);
+
+    const tick = new Date(t0.getTime() + LOBBY_REQUEST_TTL_MS + 1);
+    const result = runCleanupTick(store, {}, tick);
+
+    assert.equal(result.lobbyRequestsTimedOut, 1);
+    assert.equal(store.getLobbyRequest(room.slug, reqOld.id)?.status, "denied");
+    assert.equal(store.getLobbyRequest(room.slug, reqOld.id)?.denialReason, "lobby_timeout");
+
+    // Fresh request is still waiting.
+    assert.equal(store.getLobbyRequest(room.slug, reqFresh.id)?.status, "waiting");
+  });
+
+  test("does not emit lobby_request_timed_out for requests on a room that itself expires", () => {
+    const store = createInMemoryRoomStore();
+    const t0 = new Date("2026-03-24T12:00:00Z");
+    const room = store.createRoom(
+      {
+        accessMode: "lobby",
+        maxParticipants: 2,
+        qualityCap: "balanced",
+        allowScreenShare: true,
+      },
+      t0,
+    );
+    store.createLobbyRequest(room.slug, "Guest", t0.toISOString());
+
+    const memLogger = createMemoryLogger();
+    const info = (fields: Record<string, unknown>) => {
+      memLogger.loggerOption.stream.write(JSON.stringify(fields) + "\n");
+    };
+    const logger = { info, error: () => {} };
+
+    const tick = new Date(t0.getTime() + ROOM_TTL_MS + 1);
+    const result = runCleanupTick(store, { logger }, tick);
+
+    assert.equal(result.expiredRoomsRemoved, 1);
+    assert.equal(result.lobbyRequestsTimedOut, 0);
+    const actions = cleanupActions(memLogger.readCapturedLogs());
+    assert.equal(actions.includes("lobby_request_timed_out"), false);
+    assert.equal(actions.includes("room_idle_expired"), true);
+  });
+
+  test("is idempotent: running twice at the same now produces zero new mutations", () => {
+    const store = createInMemoryRoomStore();
+    const t0 = new Date("2026-03-24T12:00:00Z");
+    const room = store.createRoom(
+      {
+        accessMode: "lobby",
+        maxParticipants: 2,
+        qualityCap: "balanced",
+        allowScreenShare: true,
+      },
+      t0,
+    );
+    store.createLobbyRequest(room.slug, "Guest", t0.toISOString());
+
+    const memLogger = createMemoryLogger();
+    const info = (fields: Record<string, unknown>) => {
+      memLogger.loggerOption.stream.write(JSON.stringify(fields) + "\n");
+    };
+    const logger = { info, error: () => {} };
+
+    const tick = new Date(t0.getTime() + LOBBY_REQUEST_TTL_MS + 1);
+    const firstRun = runCleanupTick(store, { logger }, tick);
+    const firstLogs = memLogger.readCapturedLogs();
+
+    const secondRun = runCleanupTick(store, { logger }, tick);
+
+    assert.equal(firstRun.lobbyRequestsTimedOut, 1);
+    assert.deepEqual(secondRun, {
+      expiredRoomsRemoved: 0,
+      closedRoomsReaped: 0,
+      lobbyRequestsTimedOut: 0,
+    });
+    // Second tick must not add any new cleanup log records.
+    const secondLogs = memLogger.readCapturedLogs().slice(firstLogs.length);
+    assert.equal(cleanupActions(secondLogs).length, 0);
+  });
+});
+
+describe("startCleanupLoop", () => {
+  function createFakeScheduler(): {
+    scheduler: CleanupScheduler;
+    fire: () => void;
+    cancelled: boolean[];
+    intervalMs: number | null;
+  } {
+    let callback: (() => void) | null = null;
+    let intervalMs: number | null = null;
+    const cancelled: boolean[] = [];
+    const scheduler: CleanupScheduler = {
+      schedule(fn, ms) {
+        callback = fn;
+        intervalMs = ms;
+        return {};
+      },
+      cancel(_handle) {
+        cancelled.push(true);
+        void _handle;
+      },
+    };
+    return {
+      scheduler,
+      fire() {
+        if (callback == null) throw new Error("scheduler did not schedule a callback");
+        callback();
+      },
+      get cancelled() {
+        return cancelled;
+      },
+      get intervalMs() {
+        return intervalMs;
+      },
+    };
+  }
+
+  test("schedules exactly one callback and the callback runs a tick against the injected now", () => {
+    const store = createInMemoryRoomStore();
+    const t0 = new Date("2026-03-24T12:00:00Z");
+    const room = store.createRoom(
+      {
+        accessMode: "open",
+        maxParticipants: 2,
+        qualityCap: "balanced",
+        allowScreenShare: true,
+      },
+      t0,
+    );
+
+    const fake = createFakeScheduler();
+    const logger = { info: () => {}, error: () => {} };
+
+    // Fast-forward the injected clock past the room's TTL.
+    const nowValue = new Date(t0.getTime() + ROOM_TTL_MS + 10);
+    const handle = startCleanupLoop({
+      store,
+      intervalMs: 1_000,
+      now: () => nowValue,
+      logger,
+      scheduler: fake.scheduler,
+    });
+
+    assert.equal(fake.intervalMs, 1_000);
+    assert.ok(store.getRoom(room.slug) != null);
+
+    fake.fire();
+    assert.equal(store.getRoom(room.slug), undefined);
+
+    handle.stop();
+    assert.equal(fake.cancelled.length, 1);
+  });
+
+  test("catches tick errors and logs one tick_failed record without stopping the loop", () => {
+    const errorLog: unknown[] = [];
+    const infoLog: unknown[] = [];
+    const logger = {
+      info: (payload: unknown) => infoLog.push(payload),
+      error: (payload: unknown) => errorLog.push(payload),
+    };
+
+    // Store stub whose listRoomSlugs throws once, then succeeds.
+    let shouldThrow = true;
+    const store = {
+      ...createInMemoryRoomStore(),
+      listRoomSlugs() {
+        if (shouldThrow) {
+          shouldThrow = false;
+          throw new Error("boom");
+        }
+        return [];
+      },
+    } as unknown as ReturnType<typeof createInMemoryRoomStore>;
+
+    const fake = createFakeScheduler();
+    const handle = startCleanupLoop({
+      store,
+      intervalMs: 500,
+      now: () => new Date(),
+      logger,
+      scheduler: fake.scheduler,
+    });
+
+    fake.fire(); // throws, logged
+    fake.fire(); // succeeds
+
+    const actions = errorLog.map((p) => (p as { action?: string }).action);
+    assert.equal(actions.filter((a) => a === "tick_failed").length, 1);
+
+    handle.stop();
+  });
+});
+
+describe("buildApp integration: cleanupIntervalMs", () => {
+  function createFakeScheduler() {
+    let callback: (() => void) | null = null;
+    let scheduleCalls = 0;
+    let cancelCalls = 0;
+    const scheduler: CleanupScheduler = {
+      schedule(fn) {
+        scheduleCalls += 1;
+        callback = fn;
+        return { fake: true };
+      },
+      cancel() {
+        cancelCalls += 1;
+      },
+    };
+    return {
+      scheduler,
+      get scheduleCalls() {
+        return scheduleCalls;
+      },
+      get cancelCalls() {
+        return cancelCalls;
+      },
+      fire() {
+        if (callback != null) callback();
+      },
+    };
+  }
+
+  test("starts the loop when cleanupIntervalMs is a positive finite number", async () => {
+    const fake = createFakeScheduler();
+    const app = buildApp({
+      logger: false,
+      liveKitConfig: TEST_LIVEKIT_CONFIG,
+      cleanupIntervalMs: 60_000,
+      cleanupScheduler: fake.scheduler,
+    });
+    assert.equal(fake.scheduleCalls, 1);
+
+    await app.close();
+    assert.equal(fake.cancelCalls, 1);
+  });
+
+  for (const invalid of [undefined, 0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+    test(`does NOT start the loop when cleanupIntervalMs is ${String(invalid)}`, async () => {
+      const fake = createFakeScheduler();
+      const app = buildApp({
+        logger: false,
+        liveKitConfig: TEST_LIVEKIT_CONFIG,
+        cleanupIntervalMs: invalid as number | undefined,
+        cleanupScheduler: fake.scheduler,
+      });
+      assert.equal(fake.scheduleCalls, 0);
+      await app.close();
+    });
+  }
+});
+
+describe("Property: cleanup tick is idempotent for any in-memory store snapshot", () => {
+  /*
+   * Feature: room-expiry-and-cleanup, Property 5: Cleanup tick idempotence
+   * Validates: Requirements 4.4, 10.5, 9.5
+   */
+  test("running the tick twice at the same instant leaves the store in the same shape", () => {
+    const scenarioArb = fc.record({
+      roomCount: fc.integer({ min: 1, max: 5 }),
+      lastActivityOffsetMs: fc.integer({ min: -3 * ROOM_TTL_MS, max: 0 }),
+      lobbyRequestCount: fc.integer({ min: 0, max: 3 }),
+      lobbyRequestAgeMs: fc.integer({
+        min: 0,
+        max: 2 * LOBBY_REQUEST_TTL_MS,
+      }),
+      closedFraction: fc.double({ min: 0, max: 1, noNaN: true }),
+      closedAtOffsetMs: fc.integer({
+        min: -2 * CLOSED_ROOM_GRACE_WINDOW_MS,
+        max: 2 * CLOSED_ROOM_GRACE_WINDOW_MS,
+      }),
+    });
+
+    fc.assert(
+      fc.property(scenarioArb, (scenario) => {
+        const store = createInMemoryRoomStore();
+        const tickTime = new Date("2026-03-24T12:00:00Z");
+        const tickMs = tickTime.getTime();
+
+        for (let i = 0; i < scenario.roomCount; i += 1) {
+          const lastActivityAt = new Date(tickMs + scenario.lastActivityOffsetMs);
+          const initialActivity = lastActivityAt.toISOString();
+          const room = store.createRoom(
+            {
+              accessMode: "lobby",
+              maxParticipants: 2,
+              qualityCap: "balanced",
+              allowScreenShare: true,
+              initialActivity,
+            },
+            lastActivityAt,
+          );
+
+          for (let r = 0; r < scenario.lobbyRequestCount; r += 1) {
+            const createdAtMs = tickMs - scenario.lobbyRequestAgeMs;
+            store.createLobbyRequest(
+              room.slug,
+              `Guest-${r}`,
+              new Date(createdAtMs).toISOString(),
+            );
+          }
+
+          // Closed rooms sampled via a simple fraction-driven decision.
+          if (scenario.closedFraction < 0.3) {
+            room.status = "closed";
+            room.closedAt = new Date(tickMs - scenario.closedAtOffsetMs).toISOString();
+          }
+        }
+
+        const firstResult = runCleanupTick(store, {}, tickTime);
+        const snapshotAfterFirst = JSON.stringify(
+          store.listRoomSlugs().map((slug) => store.getRoom(slug)),
+        );
+
+        const secondResult = runCleanupTick(store, {}, tickTime);
+        const snapshotAfterSecond = JSON.stringify(
+          store.listRoomSlugs().map((slug) => store.getRoom(slug)),
+        );
+
+        assert.deepEqual(secondResult, {
+          expiredRoomsRemoved: 0,
+          closedRoomsReaped: 0,
+          lobbyRequestsTimedOut: 0,
+        });
+        assert.equal(snapshotAfterFirst, snapshotAfterSecond);
+        void firstResult;
+      }),
+      { numRuns: 50 },
+    );
+  });
+});

--- a/apps/server/src/routes/lobby.ts
+++ b/apps/server/src/routes/lobby.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 import type { LobbyRequestStatusResponse, LobbyRequestSummary } from "@lowtime/shared";
 
 import { getRoomStatus } from "../domain/room-status.js";
+import { recordRoomActivity } from "../domain/room-activity.js";
 import {
   hasValidHostSecret,
   type RouteContext,
@@ -112,6 +113,7 @@ export function registerLobbyRoutes(app: FastifyInstance, context: RouteContext)
       }
 
       room.status = "active";
+      recordRoomActivity(context.roomStore, room.slug, context.now());
 
       return {
         status: "approved",

--- a/apps/server/src/routes/rooms.ts
+++ b/apps/server/src/routes/rooms.ts
@@ -8,9 +8,9 @@ import type {
 } from "@lowtime/shared";
 
 import { toRoomSummary, getRoomStatus } from "../domain/room-status.js";
+import { recordRoomActivity } from "../domain/room-activity.js";
 import { validateCreateRoomRequest, validateJoinRoomRequest } from "../domain/room-validation.js";
 import {
-  createRoomExpiry,
   type RouteContext,
 } from "../server-support.js";
 
@@ -32,11 +32,15 @@ export function registerRoomRoutes(app: FastifyInstance, context: RouteContext) 
       const passcodeHash =
         plainPasscode != null ? await context.passcodeVerifier.hash(plainPasscode) : undefined;
 
-      const room = context.roomStore.createRoom({
-        ...storeInput,
-        expiresAt: createRoomExpiry(context.now()),
-        passcodeHash,
-      });
+      const now = context.now();
+      const room = context.roomStore.createRoom(
+        {
+          ...storeInput,
+          initialActivity: now.toISOString(),
+          passcodeHash,
+        },
+        now,
+      );
 
       const responseBody: CreateRoomResponse = {
         roomSlug: room.slug,
@@ -171,6 +175,7 @@ export function registerRoomRoutes(app: FastifyInstance, context: RouteContext) 
       }
 
       room.status = "active";
+      recordRoomActivity(context.roomStore, room.slug, context.now());
 
       return {
         joinState: "direct",

--- a/apps/server/src/routes/settings.ts
+++ b/apps/server/src/routes/settings.ts
@@ -5,6 +5,7 @@ import type {
 } from "@lowtime/shared";
 
 import { toRoomSummary } from "../domain/room-status.js";
+import { recordRoomActivity } from "../domain/room-activity.js";
 import { validateUpdateSettingsRequest } from "../domain/room-validation.js";
 import {
   hasValidHostSecret,
@@ -55,6 +56,7 @@ export function registerSettingsRoutes(app: FastifyInstance, context: RouteConte
       room.accessMode = decision.accessMode;
       context.roomStore.clearPasscodeHash(room.slug);
       context.passcodeRateLimiter.clear(room.slug);
+      recordRoomActivity(context.roomStore, room.slug, context.now());
       return { room: toRoomSummary(room, context.now()) };
     }
 
@@ -74,6 +76,7 @@ export function registerSettingsRoutes(app: FastifyInstance, context: RouteConte
       room.accessMode = "passcode";
     }
     context.passcodeRateLimiter.clear(room.slug);
+    recordRoomActivity(context.roomStore, room.slug, context.now());
 
     return { room: toRoomSummary(room, context.now()) };
   });

--- a/apps/server/src/server-support.ts
+++ b/apps/server/src/server-support.ts
@@ -13,13 +13,12 @@ import {
   createInMemoryReclaimRateLimiter,
   type ReclaimRateLimiter,
 } from "./domain/reclaim-rate-limiter.js";
+import type { CleanupScheduler } from "./domain/room-cleanup.js";
 import {
   createInMemoryRoomStore,
   type RoomStore,
   type StoredRoom,
 } from "./domain/room-store.js";
-
-const DEFAULT_ROOM_TTL_MS = 2 * 60 * 60 * 1000;
 
 export interface BuildAppOptions {
   now?: () => Date;
@@ -28,6 +27,14 @@ export interface BuildAppOptions {
   passcodeVerifier?: PasscodeVerifier;
   passcodeRateLimiter?: PasscodeRateLimiter;
   reclaimRateLimiter?: ReclaimRateLimiter;
+  /**
+   * Interval in ms for the cleanup loop. When omitted, `0`, negative, or
+   * non-finite, the cleanup loop does not start. Tests build Fastify without
+   * this option so they remain deterministic.
+   */
+  cleanupIntervalMs?: number;
+  /** Injected scheduler for deterministic tests. Defaults to `setInterval`. */
+  cleanupScheduler?: CleanupScheduler;
   /**
    * Overrides the Fastify logger option used by `buildApp`. Primarily used by
    * tests that capture log output into an in-memory buffer. When omitted the
@@ -54,10 +61,6 @@ export function createRouteContext(options: BuildAppOptions = {}): RouteContext 
     passcodeRateLimiter: options.passcodeRateLimiter ?? createInMemoryPasscodeRateLimiter(),
     reclaimRateLimiter: options.reclaimRateLimiter ?? createInMemoryReclaimRateLimiter(),
   };
-}
-
-export function createRoomExpiry(now: Date): string {
-  return new Date(now.getTime() + DEFAULT_ROOM_TTL_MS).toISOString();
 }
 
 export function hasValidHostSecret(room: StoredRoom, hostSecret: string | undefined): boolean {

--- a/apps/web/src/features/waiting/waiting-page.test.ts
+++ b/apps/web/src/features/waiting/waiting-page.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getLobbyDenialMessage } from "./waiting-page.js";
+
+test("getLobbyDenialMessage returns a distinct non-empty copy for every reason", () => {
+  const reasons = ["host_denied", "room_expired", "room_closed", "lobby_timeout"] as const;
+
+  const messages = reasons.map((reason) => getLobbyDenialMessage(reason));
+
+  for (const message of messages) {
+    assert.ok(message.length > 0);
+  }
+
+  // All four messages must be pairwise distinct so the UI actually differentiates.
+  assert.equal(new Set(messages).size, messages.length);
+});
+
+test("getLobbyDenialMessage uses the new wording for lobby_timeout", () => {
+  const message = getLobbyDenialMessage("lobby_timeout");
+  assert.ok(/10 minutes/i.test(message), "lobby_timeout copy should mention the 10-minute window");
+});
+
+test("getLobbyDenialMessage preserves room_expired copy wording", () => {
+  const message = getLobbyDenialMessage("room_expired");
+  assert.ok(/expired/i.test(message));
+});
+
+test("getLobbyDenialMessage preserves host_denied copy wording", () => {
+  const message = getLobbyDenialMessage("host_denied");
+  assert.ok(/host/i.test(message));
+});

--- a/apps/web/src/features/waiting/waiting-page.tsx
+++ b/apps/web/src/features/waiting/waiting-page.tsx
@@ -11,6 +11,25 @@ interface WaitingPageProps {
   onBackToJoin: () => void;
 }
 
+/**
+ * User-facing copy for each lobby denial reason. Kept pure and exported so a
+ * unit test can lock the mapping for every reason the shared type allows.
+ */
+export function getLobbyDenialMessage(
+  reason: Extract<LobbyRequestStatusResponse, { status: "denied" }>["reason"],
+): string {
+  switch (reason) {
+    case "host_denied":
+      return "The host denied your request.";
+    case "room_expired":
+      return "This room has expired. Ask for a fresh link.";
+    case "room_closed":
+      return "This room has ended.";
+    case "lobby_timeout":
+      return "We didn't hear from the host within 10 minutes. Please ask for a fresh link.";
+  }
+}
+
 export function WaitingPage(props: WaitingPageProps) {
   return (
     <main style={callPageStyle}>
@@ -43,9 +62,7 @@ export function WaitingPage(props: WaitingPageProps) {
           <p>Approval is still pending.</p>
         ) : null}
         {props.waitingStatus?.status === "denied" ? (
-          <p role="alert">
-            Host denied this request: <strong>{props.waitingStatus.reason}</strong>
-          </p>
+          <p role="alert">{getLobbyDenialMessage(props.waitingStatus.reason)}</p>
         ) : null}
         {props.waitingError ? <p role="alert">{props.waitingError}</p> : null}
         <button type="button" onClick={props.onBackToJoin}>

--- a/docs/03-room-and-user-flows.md
+++ b/docs/03-room-and-user-flows.md
@@ -106,6 +106,8 @@ Closed --> [*]
 Expired --> [*]
 ```
 
+Note: the `Expiring` sub-state is not yet surfaced in the API. The current implementation transitions directly from `"active"` (or `"created"`) to `"expired"` when the 2-hour inactivity timer elapses; there is no pre-expiry warning interval today. When a participant activity operation (direct admission, lobby approval, passcode rotation, access-mode change) hits the server, `lastActivityAt` is bumped and `expiresAt` is recomputed as `lastActivityAt + 2h`. The server-side cleanup loop runs every 60 seconds and removes rooms whose `expiresAt` has elapsed.
+
 ## Access Modes
 - `open`: Guests join directly if the room is not full and not expired.
 - `lobby`: Guests wait for host approval before token issuance.

--- a/docs/06-data-model-and-lifecycle.md
+++ b/docs/06-data-model-and-lifecycle.md
@@ -67,10 +67,11 @@ H --> I[Cleanup durable and ephemeral state]
 ```
 
 ## Cleanup Jobs
-- Run a frequent sweeper to expire rooms whose inactivity timer has elapsed.
-- Remove lobby requests older than 10 minutes.
-- Delete reconnect state once the 5-minute recovery window ends.
-- Trim the chat ring buffer to a fixed maximum count while the room is live.
+- A server-side cleanup loop runs on a configurable cadence (60 seconds by default in production, controlled by `BuildAppOptions.cleanupIntervalMs`). Tests omit the option so they never start real timers.
+- **Room inactivity expiry**: every tick inspects each Stored_Room, compares `lastActivityAt + 2h` to `now`, and removes rooms whose expiry has elapsed. `POST /api/rooms`, direct admission via `POST /api/rooms/:slug/join`, lobby approval via `POST /api/rooms/:slug/lobby/:requestId/approve`, and settings updates via `POST /api/rooms/:slug/settings` all bump `lastActivityAt` via the `recordRoomActivity` helper. Reclaim calls, GET endpoints, denied joins, and invalid passcode attempts do not bump activity.
+- **Lobby request TTL**: waiting lobby requests older than 10 minutes are transitioned to `{ status: "denied", reason: "lobby_timeout" }`. The new `"lobby_timeout"` reason is distinct from `"room_expired"` so the web client can differentiate "the room itself expired" from "you sat in the lobby too long".
+- **Closed-room grace window**: rooms whose `status === "closed"` remain in the store for 5 minutes after close so the web client has a chance to render a "room unavailable" message before the slug 404s. They are reaped by the same sweeper on the next tick past the grace window. No close endpoint exists yet; the plumbing is in place for the first close code path.
+- Every cleanup action emits a structured info-level log record with `event: "room_cleanup"` and one of `action: "room_idle_expired" | "room_closed_reaped" | "lobby_request_timed_out"`. A tick-level error is caught and logged as `action: "tick_failed"`; subsequent ticks continue.
 
 ## Edge Cases
 - Redis restarts while a room is active.
@@ -86,3 +87,5 @@ H --> I[Cleanup durable and ephemeral state]
 - Rebuild missing Redis live state from PostgreSQL only when safe and strictly necessary.
 - Treat Redis as canonical for current presence, but not for long-term room existence.
 - Keep chat ephemeral by design and do not write chat history to PostgreSQL in v1.
+- `last_activity_at` and `closed_at` live only in the in-memory Room_Store today and will become durable columns with the PostgreSQL migration (Issue #32). The cleanup loop uses them to drive inactivity expiry and the closed-room grace window, respectively.
+- Reconnect-window semantics are tracked separately under Issue #14 and are not coupled to the cleanup loop in the current implementation.

--- a/docs/10-observability-and-operations.md
+++ b/docs/10-observability-and-operations.md
@@ -86,3 +86,9 @@ B --> K
 - Redact secrets in logs, traces, and error reporting by default.
 - Keep dashboard ownership clear once the team grows.
 - Current implementation exposes a client-side network health badge in the call header using browser online state plus lightweight connection heuristics; deeper transport-quality metrics are still future work. The PWA shell caches only static app assets, so room state and live call state should still be treated as network-dependent.
+- The server-side cleanup loop emits structured info-level log records scoped under `event: "room_cleanup"`. Action values today:
+  - `room_idle_expired`: a room was removed because `now >= lastActivityAt + 2h`.
+  - `room_closed_reaped`: a room whose `status === "closed"` was removed after the 5-minute grace window.
+  - `lobby_request_timed_out`: a waiting lobby request older than 10 minutes transitioned to `{ status: "denied", reason: "lobby_timeout" }`.
+  - `tick_failed`: `error` level; a single cleanup tick threw; subsequent ticks continue.
+  Structured cleanup counters for dashboards are deferred to the observability roadmap.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -107,7 +107,7 @@ export interface LobbyRequestStatusApprovedResponse {
 
 export interface LobbyRequestStatusDeniedResponse {
   status: "denied";
-  reason: "host_denied" | "room_expired" | "room_closed";
+  reason: "host_denied" | "room_expired" | "room_closed" | "lobby_timeout";
 }
 
 export type LobbyRequestStatusResponse =


### PR DESCRIPTION
## Summary
Implements issue #15 (Phase 2: Room expiry and cleanup jobs) end to end.

- Adds `lastActivityAt` to `StoredRoom` and replaces the "2h from `createdAt`" expiry with "2h from `lastActivityAt`". Direct admission, lobby approval, settings updates, and passcode rotations all bump the activity clock via the new `recordRoomActivity` helper. Reclaim, GET endpoints, denied joins, and invalid passcode attempts do not bump.
- Adds `runCleanupTick` plus a scheduled cleanup loop. Ticks every 60 seconds in production (`apps/server/src/index.ts`); the loop is off in tests by default. The loop:
  - expires idle rooms and removes them from the in-memory store,
  - reaps closed rooms 5 minutes after their `closedAt` timestamp (plumbed for a future close endpoint),
  - denies waiting lobby requests older than 10 minutes with a new `\"lobby_timeout\"` reason.
- Shared type `LobbyRequestStatusDeniedResponse.reason` gains `\"lobby_timeout\"`. The web waiting page now renders distinct copy per reason via a pure `getLobbyDenialMessage` helper.
- Docs, `TODO.md`, and `packages/shared/src/index.ts` updated in the same change.

Closes #15.

## Observability
Structured info-level cleanup logs scoped under `event: \"room_cleanup\"`:

- `room_idle_expired` - room removed because `now >= lastActivityAt + 2h`.
- `room_closed_reaped` - closed room removed past the 5-minute grace.
- `lobby_request_timed_out` - waiting request denied after 10 minutes.
- `tick_failed` (error level) - a tick threw; subsequent ticks continue.

Structured metrics for cleanup counts are deferred to the observability roadmap.

## Design Notes
- New domain modules: `apps/server/src/domain/room-cleanup.ts` (tick + scheduler) and `apps/server/src/domain/room-activity.ts` (recordRoomActivity helper + ROOM_TTL_MS constant).
- Dedicated scheduler interface so tests inject a fake scheduler; production uses `setInterval` with `.unref()` to allow graceful process exit.
- Tick captures `now` once and reuses it, iterating a fresh `listRoomSlugs()` snapshot so in-tick deletions do not confuse the loop.
- `StoredRoom` gains `closedAt: string | null` as a seam; no close route writes it today but the grace-window plumbing is in place.

## Property-Style Test
One property-based idempotence test (`fast-check`) asserts that running the tick twice at the same simulated instant leaves the store snapshot identical and reports zero new mutations. Runs at 50 iterations.

## Verification
    npm run lint        # all workspaces clean
    npm run typecheck   # all workspaces clean
    npm run test        # 128 server + 53 web = 181 tests, all pass
    npm run build       # succeeds (server tsc + web vite build)