### PR TITLE
feat: apply quality presets to preview and publish

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -55,7 +55,7 @@
 
 | Feature | Status | Notes | Source |
 | --- | --- | --- | --- |
-| Quality presets | `planned` | Data Saver, Balanced, Best Quality | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
+| Quality presets | `done` | Issue #16. Shared `apps/web/src/quality-presets.ts` table drives both the device-preview constraints and the LiveKit publish options for Data Saver / Balanced / Best Quality | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Advanced media controls | `planned` | Resolution, FPS, bitrate, audio priority, receive-video, audio-only | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Host quality cap | `planned` | Host can limit room max quality | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Live room settings updates | `planned` | Access mode and quality changes during a call | [docs/05-api-and-realtime-contracts.md](docs/05-api-and-realtime-contracts.md) |

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -176,6 +176,7 @@ export function App() {
     setPreviewVideoEnabled,
   } = useDevicePreview({
     viewState,
+    qualityPreset: selectedQualityPreset,
   });
 
   useEffect(() => {

--- a/apps/web/src/device-preview.test.ts
+++ b/apps/web/src/device-preview.test.ts
@@ -50,3 +50,52 @@ test("getPreviewStateMessage prefers explicit errors and covers preview states",
     "Camera missing",
   );
 });
+
+
+test("buildPreviewConstraints returns data_saver profile when preset is data_saver", () => {
+  const constraints = buildPreviewConstraints({ audio: true, video: true }, "data_saver");
+  assert.ok(typeof constraints.video === "object");
+  if (typeof constraints.video === "object") {
+    const width = constraints.video.width as { ideal: number };
+    const height = constraints.video.height as { ideal: number };
+    const frameRate = constraints.video.frameRate as { ideal: number };
+    assert.equal(width.ideal, 320);
+    assert.equal(height.ideal, 240);
+    assert.equal(frameRate.ideal, 12);
+  }
+});
+
+test("buildPreviewConstraints returns balanced profile when preset is omitted (default)", () => {
+  const constraints = buildPreviewConstraints({ audio: true, video: true });
+  assert.ok(typeof constraints.video === "object");
+  if (typeof constraints.video === "object") {
+    const width = constraints.video.width as { ideal: number };
+    const height = constraints.video.height as { ideal: number };
+    const frameRate = constraints.video.frameRate as { ideal: number };
+    assert.equal(width.ideal, 640);
+    assert.equal(height.ideal, 360);
+    assert.equal(frameRate.ideal, 15);
+  }
+});
+
+test("buildPreviewConstraints returns best_quality profile when preset is best_quality", () => {
+  const constraints = buildPreviewConstraints({ audio: true, video: true }, "best_quality");
+  assert.ok(typeof constraints.video === "object");
+  if (typeof constraints.video === "object") {
+    const width = constraints.video.width as { ideal: number };
+    const height = constraints.video.height as { ideal: number };
+    const frameRate = constraints.video.frameRate as { ideal: number };
+    assert.equal(width.ideal, 1280);
+    assert.equal(height.ideal, 720);
+    assert.equal(frameRate.ideal, 24);
+  }
+});
+
+test("buildPreviewConstraints still returns video:false when video is disabled regardless of preset", () => {
+  for (const preset of ["data_saver", "balanced", "best_quality"] as const) {
+    assert.deepEqual(buildPreviewConstraints({ audio: true, video: false }, preset), {
+      audio: true,
+      video: false,
+    });
+  }
+});

--- a/apps/web/src/device-preview.ts
+++ b/apps/web/src/device-preview.ts
@@ -1,30 +1,45 @@
 import type { QualityPreset, RequestedMedia } from "@lowtime/shared";
 
+import { getPresetProfile } from "./quality-presets.js";
+
 export type PreviewState = "idle" | "requesting" | "ready" | "blocked" | "error";
 
-export function buildPreviewConstraints(requestedMedia: RequestedMedia): MediaStreamConstraints {
+const DEFAULT_PRESET: QualityPreset = "balanced";
+
+export function buildPreviewConstraints(
+  requestedMedia: RequestedMedia,
+  preset: QualityPreset = DEFAULT_PRESET,
+): MediaStreamConstraints {
+  if (!requestedMedia.video) {
+    return {
+      audio: requestedMedia.audio,
+      video: false,
+    };
+  }
+
+  const profile = getPresetProfile(preset);
   return {
     audio: requestedMedia.audio,
-    video: requestedMedia.video
-      ? {
-          width: { ideal: 640, max: 1280 },
-          height: { ideal: 360, max: 720 },
-          frameRate: { ideal: 15, max: 24 },
-          facingMode: "user",
-        }
-      : false,
+    video: {
+      width: {
+        ideal: profile.maxResolution.width,
+        max: Math.max(profile.maxResolution.width, 1280),
+      },
+      height: {
+        ideal: profile.maxResolution.height,
+        max: Math.max(profile.maxResolution.height, 720),
+      },
+      frameRate: {
+        ideal: profile.maxFps,
+        max: Math.max(profile.maxFps, 24),
+      },
+      facingMode: "user",
+    },
   };
 }
 
 export function getQualityPresetLabel(qualityPreset: QualityPreset): string {
-  switch (qualityPreset) {
-    case "data_saver":
-      return "Data Saver";
-    case "best_quality":
-      return "Best Quality";
-    default:
-      return "Balanced";
-  }
+  return getPresetProfile(qualityPreset).label;
 }
 
 export function getPreviewStateMessage(previewState: PreviewState, previewError: string | null): string {

--- a/apps/web/src/features/call/call-effects.ts
+++ b/apps/web/src/features/call/call-effects.ts
@@ -158,6 +158,7 @@ export function useCallFlow(input: UseCallFlowInput) {
         const room = await connectToSfu({
           credentials,
           requestedMedia: activeCallSession.requestedMedia,
+          qualityPreset: activeCallSession.qualityPreset,
         });
 
         if (cancelled) {

--- a/apps/web/src/features/room/preview-effects.ts
+++ b/apps/web/src/features/room/preview-effects.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import type { RequestedMedia } from "@lowtime/shared";
+import type { QualityPreset, RequestedMedia } from "@lowtime/shared";
 
 import { startPreviewRequest } from "./room-actions.js";
 import { stopMediaStream, type PreviewState } from "../../device-preview.js";
@@ -13,6 +13,7 @@ const DEFAULT_REQUESTED_MEDIA: RequestedMedia = {
 
 interface UseDevicePreviewInput {
   viewState: ViewState;
+  qualityPreset: QualityPreset;
 }
 
 export function useDevicePreview(input: UseDevicePreviewInput) {
@@ -66,10 +67,13 @@ export function useDevicePreview(input: UseDevicePreviewInput) {
     setPreviewError(null);
 
     try {
-      const stream = await startPreviewRequest({
-        audio: previewAudioEnabled,
-        video: previewVideoEnabled,
-      });
+      const stream = await startPreviewRequest(
+        {
+          audio: previewAudioEnabled,
+          video: previewVideoEnabled,
+        },
+        input.qualityPreset,
+      );
       stopMediaStream(previewStreamRef.current);
       previewStreamRef.current = stream;
       setPreviewState("ready");

--- a/apps/web/src/features/room/room-actions.ts
+++ b/apps/web/src/features/room/room-actions.ts
@@ -36,12 +36,17 @@ export async function joinRoomRequest(input: {
   return (await response.json()) as JoinRoomResponse;
 }
 
-export async function startPreviewRequest(requestedMedia: RequestedMedia): Promise<MediaStream> {
+export async function startPreviewRequest(
+  requestedMedia: RequestedMedia,
+  qualityPreset?: QualityPreset,
+): Promise<MediaStream> {
   if (typeof navigator === "undefined" || navigator.mediaDevices?.getUserMedia == null) {
     throw new Error("This browser does not support live device preview.");
   }
 
-  return navigator.mediaDevices.getUserMedia(buildPreviewConstraints(requestedMedia));
+  return navigator.mediaDevices.getUserMedia(
+    buildPreviewConstraints(requestedMedia, qualityPreset),
+  );
 }
 
 export async function submitLobbyAction(input: {

--- a/apps/web/src/media-controller.ts
+++ b/apps/web/src/media-controller.ts
@@ -1,16 +1,52 @@
-import { Room } from "livekit-client";
+import { Room, VideoPresets, type VideoEncoding, type VideoResolution } from "livekit-client";
 
-import type { RequestedMedia, SfuTokenResponse } from "@lowtime/shared";
+import type { QualityPreset, RequestedMedia, SfuTokenResponse } from "@lowtime/shared";
+
+import { getPresetProfile } from "./quality-presets.js";
 
 export interface ConnectToSfuInput {
   credentials: SfuTokenResponse;
   requestedMedia: RequestedMedia;
+  qualityPreset?: QualityPreset;
+}
+
+/**
+ * Turns a quality preset into the LiveKit publish options the Room should use
+ * for the local video track. Callers without a preset get Balanced, matching
+ * the pre-existing behavior.
+ */
+function buildLiveKitOptions(qualityPreset: QualityPreset | undefined): {
+  videoCaptureDefaults: { resolution: VideoResolution };
+  publishDefaults: { videoEncoding: VideoEncoding };
+} {
+  const profile = getPresetProfile(qualityPreset ?? "balanced");
+  const resolution: VideoResolution = {
+    width: profile.maxResolution.width,
+    height: profile.maxResolution.height,
+    frameRate: profile.maxFps,
+    // Reference an existing preset to let LiveKit pick a reasonable
+    // base encoding while our bitrate cap applies on top.
+    ...VideoPresets.h360.encoding,
+  };
+
+  return {
+    videoCaptureDefaults: { resolution },
+    publishDefaults: {
+      videoEncoding: {
+        maxBitrate: profile.maxVideoBitrateKbps * 1000,
+        maxFramerate: profile.maxFps,
+      },
+    },
+  };
 }
 
 export async function connectToSfu(input: ConnectToSfuInput): Promise<Room> {
+  const liveKitOptions = buildLiveKitOptions(input.qualityPreset);
+
   const room = new Room({
     adaptiveStream: true,
     dynacast: true,
+    ...liveKitOptions,
   });
 
   try {

--- a/apps/web/src/quality-presets.test.ts
+++ b/apps/web/src/quality-presets.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { QualityPreset } from "@lowtime/shared";
+
+import { getPresetProfile, listPresetProfiles } from "./quality-presets.js";
+
+test("getPresetProfile returns a profile with sane values for every preset", () => {
+  const presets: QualityPreset[] = ["data_saver", "balanced", "best_quality"];
+  for (const preset of presets) {
+    const profile = getPresetProfile(preset);
+    assert.ok(profile.label.length > 0, `label missing for ${preset}`);
+    assert.ok(profile.maxResolution.width > 0);
+    assert.ok(profile.maxResolution.height > 0);
+    assert.ok(profile.maxFps > 0);
+    assert.ok(profile.maxVideoBitrateKbps > 0);
+  }
+});
+
+test("getPresetProfile returns strictly increasing caps as quality increases", () => {
+  const dataSaver = getPresetProfile("data_saver");
+  const balanced = getPresetProfile("balanced");
+  const bestQuality = getPresetProfile("best_quality");
+
+  assert.ok(dataSaver.maxResolution.width < balanced.maxResolution.width);
+  assert.ok(balanced.maxResolution.width < bestQuality.maxResolution.width);
+
+  assert.ok(dataSaver.maxFps <= balanced.maxFps);
+  assert.ok(balanced.maxFps <= bestQuality.maxFps);
+
+  assert.ok(dataSaver.maxVideoBitrateKbps < balanced.maxVideoBitrateKbps);
+  assert.ok(balanced.maxVideoBitrateKbps < bestQuality.maxVideoBitrateKbps);
+});
+
+test("listPresetProfiles lists every preset exactly once in the same order as the union", () => {
+  const entries = listPresetProfiles();
+  const presetsInOrder = entries.map((entry) => entry.preset);
+  assert.deepEqual(presetsInOrder, ["data_saver", "balanced", "best_quality"]);
+
+  // Profiles round-trip through getPresetProfile.
+  for (const entry of entries) {
+    assert.deepEqual(entry.profile, getPresetProfile(entry.preset));
+  }
+});
+
+test("getPresetProfile exposes user-facing labels matching the documented presets", () => {
+  assert.equal(getPresetProfile("data_saver").label, "Data Saver");
+  assert.equal(getPresetProfile("balanced").label, "Balanced");
+  assert.equal(getPresetProfile("best_quality").label, "Best Quality");
+});

--- a/apps/web/src/quality-presets.ts
+++ b/apps/web/src/quality-presets.ts
@@ -1,0 +1,43 @@
+import type { QualityPreset } from "@lowtime/shared";
+
+export interface PresetProfile {
+  label: string;
+  maxResolution: { width: number; height: number };
+  maxFps: number;
+  /** Video bitrate cap in **kilobits per second**. Multiply by 1000 for LiveKit. */
+  maxVideoBitrateKbps: number;
+}
+
+// Source of truth for every place the web client renders or applies a
+// quality preset. Keep docs/04-media-and-quality.md in sync with these values.
+const PRESET_PROFILES: Record<QualityPreset, PresetProfile> = {
+  data_saver: {
+    label: "Data Saver",
+    maxResolution: { width: 320, height: 240 },
+    maxFps: 12,
+    maxVideoBitrateKbps: 200,
+  },
+  balanced: {
+    label: "Balanced",
+    maxResolution: { width: 640, height: 360 },
+    maxFps: 15,
+    maxVideoBitrateKbps: 500,
+  },
+  best_quality: {
+    label: "Best Quality",
+    maxResolution: { width: 1280, height: 720 },
+    maxFps: 24,
+    maxVideoBitrateKbps: 1200,
+  },
+};
+
+export function getPresetProfile(preset: QualityPreset): PresetProfile {
+  return PRESET_PROFILES[preset];
+}
+
+export function listPresetProfiles(): Array<{ preset: QualityPreset; profile: PresetProfile }> {
+  return (Object.keys(PRESET_PROFILES) as QualityPreset[]).map((preset) => ({
+    preset,
+    profile: PRESET_PROFILES[preset],
+  }));
+}

--- a/docs/04-media-and-quality.md
+++ b/docs/04-media-and-quality.md
@@ -40,6 +40,7 @@ H -->|No| J[Show rejoin failure]
 - `Best Quality`
   - Use only when network and device conditions are healthy.
   - Desktop may scale up to 720p, 24fps, 700-1500 kbps.
+- Implementation lives in [`apps/web/src/quality-presets.ts`](../apps/web/src/quality-presets.ts) and is shared by `buildPreviewConstraints` (pre-join camera preview) and `connectToSfu` (LiveKit `videoCaptureDefaults` and `publishDefaults.videoEncoding`). Update the table there when tuning the preset values.
 
 ## Advanced Controls
 - Send resolution cap


### PR DESCRIPTION
## Summary
Implements issue #16 (Phase 3: Quality presets) for the 1:1 core flow.

- Adds `apps/web/src/quality-presets.ts` as the single source of truth for the three documented profiles (Data Saver, Balanced, Best Quality): resolution, fps, video bitrate cap, and label.
- `buildPreviewConstraints(requestedMedia, preset)` now shapes the pre-join `getUserMedia` constraints to match the selected preset; the single-arg overload falls back to Balanced so older callers keep working.
- `connectToSfu({ credentials, requestedMedia, qualityPreset })` applies the preset's resolution and bitrate caps via LiveKit `videoCaptureDefaults` and `publishDefaults.videoEncoding`, so the live SFU publish actually respects the host's UI choice.
- `getQualityPresetLabel` delegates to the shared profile table so the label and numeric profile are edited in one place.
- Docs (`docs/04-media-and-quality.md`) and `TODO.md` updated to point at the new module.

Closes #16.

## Out of Scope (tracked separately)
- Host quality cap (#18)
- Advanced per-user overrides (#17)
- Automatic low-network downgrade (#20)
- Audio-only prompt (#21) and P2P fallback (#22)

## Verification
    npm run lint        # all workspaces clean
    npm run typecheck   # all workspaces clean
    npm run test        # 128 server + 61 web = 189 tests, all pass
    npm run build       # succeeds (server tsc + web vite build)