### PR TITLE
feat: add advanced media controls

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,7 +56,7 @@
 | Feature | Status | Notes | Source |
 | --- | --- | --- | --- |
 | Quality presets | `done` | Issue #16. Shared `apps/web/src/quality-presets.ts` table drives both the device-preview constraints and the LiveKit publish options for Data Saver / Balanced / Best Quality | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
-| Advanced media controls | `planned` | Resolution, FPS, bitrate, audio priority, receive-video, audio-only | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
+| Advanced media controls | `done` | Issue #17. Added a shared `AdvancedMediaPrefs` shape with six overrides (maxResolution, maxFps, maxBitrateKbps, audioPriority, receiveVideo, audioOnly), pure `computeEffectivePublishOptions` helper, Advanced Media Controls disclosure on the room page, and `StoredCallSession` round-trip of the user prefs | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Host quality cap | `done` | Issue #18. Shared `clampPresetToCap` helper in `packages/shared/src/index.ts` drives both the client preset dropdown and the server `POST /api/rooms/:slug/settings` handler; room-page now hides presets above the cap and the settings handler accepts a `qualityCap` body field | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Live room settings updates | `planned` | Access mode and quality changes during a call | [docs/05-api-and-realtime-contracts.md](docs/05-api-and-realtime-contracts.md) |
 | Automatic low-network downgrade | `planned` | Bitrate -> resolution -> frame rate -> video pause | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import type {
   AccessMode,
+  AdvancedMediaPrefs,
   CreateRoomRequest,
   CreateRoomResponse,
   JoinRoomResponse,
@@ -46,6 +47,7 @@ export function App() {
 
   const [displayName, setDisplayName] = useState("");
   const [selectedQualityPreset, setSelectedQualityPreset] = useState<QualityPreset>(DEFAULT_QUALITY_PRESET);
+  const [advancedPrefs, setAdvancedPrefs] = useState<AdvancedMediaPrefs>({});
   const [joinPasscodeInput, setJoinPasscodeInput] = useState("");
   const [joinError, setJoinError] = useState<string | null>(null);
   const [joinResult, setJoinResult] = useState<JoinRoomResponse | null>(null);
@@ -227,6 +229,7 @@ export function App() {
     setDisplayName("");
     setSelectedQualityPreset(DEFAULT_QUALITY_PRESET);
     setJoinPasscodeInput("");
+    setAdvancedPrefs({});
   }, [viewState]);
 
   // When the user navigates away from the home page, drop the in-memory
@@ -329,6 +332,7 @@ export function App() {
           qualityPreset: selectedQualityPreset,
           transportPreference: payload.transportPreference,
           requestedMedia: previewRequestedMedia,
+          advancedPrefs,
         });
 
         clearPreview();
@@ -443,6 +447,7 @@ export function App() {
         pushRoute(window.history, window.location, getRoomRoute(viewState.slug), setViewState);
       }}
       roomPageProps={{
+        advancedPrefs,
         displayName,
         hostLobbyError,
         hostLobbyRequests,
@@ -451,6 +456,7 @@ export function App() {
         isLoadingRoom,
         joinError,
         joinResult,
+        onAdvancedPrefsChange: setAdvancedPrefs,
         onDisplayNameChange: setDisplayName,
         onHostLobbyAction: handleHostLobbyAction,
         onJoinRoom: handleJoinRoom,

--- a/apps/web/src/features/call/call-effects.ts
+++ b/apps/web/src/features/call/call-effects.ts
@@ -159,6 +159,7 @@ export function useCallFlow(input: UseCallFlowInput) {
           credentials,
           requestedMedia: activeCallSession.requestedMedia,
           qualityPreset: activeCallSession.qualityPreset,
+          advancedPrefs: activeCallSession.advancedPrefs,
         });
 
         if (cancelled) {

--- a/apps/web/src/features/room/room-page.tsx
+++ b/apps/web/src/features/room/room-page.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useRef, useState } from "react";
 import type { FormEvent, RefObject } from "react";
 
-import type { JoinRoomResponse, LobbyRequestSummary, QualityCap, QualityPreset, RoomSummary } from "@lowtime/shared";
+import type {
+  AdvancedMediaPrefs,
+  JoinRoomResponse,
+  LobbyRequestSummary,
+  QualityCap,
+  QualityPreset,
+  ResolutionCap,
+  RoomSummary,
+} from "@lowtime/shared";
 import { clampPresetToCap } from "@lowtime/shared";
 
 import type { PreviewState } from "../../device-preview.js";
@@ -22,6 +30,7 @@ import {
 } from "../page-styles.js";
 
 interface RoomPageProps {
+  advancedPrefs: AdvancedMediaPrefs;
   displayName: string;
   hostLobbyError: string | null;
   hostLobbyRequests: LobbyRequestSummary[];
@@ -43,6 +52,7 @@ interface RoomPageProps {
   roomSummary: RoomSummary | null;
   selectedQualityPreset: QualityPreset;
   slug: string;
+  onAdvancedPrefsChange: (updater: (current: AdvancedMediaPrefs) => AdvancedMediaPrefs) => void;
   onDisplayNameChange: (value: string) => void;
   onHostLobbyAction: (requestId: string, action: "approve" | "deny") => Promise<void>;
   onJoinRoom: () => Promise<void>;
@@ -221,6 +231,10 @@ export function RoomPage(props: RoomPageProps) {
                 />
               </label>
             ) : null}
+            <AdvancedMediaControls
+              advancedPrefs={props.advancedPrefs}
+              onChange={props.onAdvancedPrefsChange}
+            />
             <div>
               <button type="button" onClick={() => void props.onJoinRoom()} disabled={joinButtonDisabled}>
                 {props.isJoining ? "Joining..." : "Join Room"}
@@ -349,6 +363,142 @@ function ManualReclaimForm(props: {
         </div>
         {props.manualError ? <p role="alert">{props.manualError}</p> : null}
       </form>
+    </section>
+  );
+}
+
+
+const RESOLUTION_CAPS: ResolutionCap[] = ["240p", "360p", "480p", "720p"];
+
+function AdvancedMediaControls(props: {
+  advancedPrefs: AdvancedMediaPrefs;
+  onChange: (updater: (current: AdvancedMediaPrefs) => AdvancedMediaPrefs) => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  function updateField<K extends keyof AdvancedMediaPrefs>(
+    key: K,
+    value: AdvancedMediaPrefs[K] | undefined,
+  ) {
+    props.onChange((current) => {
+      const next = { ...current };
+      if (value === undefined) {
+        delete next[key];
+      } else {
+        next[key] = value;
+      }
+      return next;
+    });
+  }
+
+  return (
+    <section style={previewCardStyle}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-expanded={isOpen}
+        aria-controls="advanced-media-controls-panel"
+      >
+        {isOpen ? "Hide Advanced Media Controls" : "Show Advanced Media Controls"}
+      </button>
+      {isOpen ? (
+        <div id="advanced-media-controls-panel" style={previewOptionsStyle}>
+          <label style={toggleOptionStyle}>
+            Max send resolution
+            <select
+              value={props.advancedPrefs.maxResolution ?? ""}
+              onChange={(event) => {
+                const value = event.target.value;
+                updateField(
+                  "maxResolution",
+                  value === "" ? undefined : (value as ResolutionCap),
+                );
+              }}
+            >
+              <option value="">Use preset default</option>
+              {RESOLUTION_CAPS.map((cap) => (
+                <option key={cap} value={cap}>
+                  {cap}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={toggleOptionStyle}>
+            Max FPS
+            <input
+              type="number"
+              min={1}
+              max={60}
+              value={props.advancedPrefs.maxFps ?? ""}
+              placeholder="Preset default"
+              onChange={(event) => {
+                const raw = event.target.value;
+                if (raw === "") {
+                  updateField("maxFps", undefined);
+                  return;
+                }
+                const parsed = Number.parseInt(raw, 10);
+                if (Number.isFinite(parsed) && parsed > 0) {
+                  updateField("maxFps", parsed);
+                }
+              }}
+            />
+          </label>
+          <label style={toggleOptionStyle}>
+            Max video bitrate (kbps)
+            <input
+              type="number"
+              min={50}
+              step={50}
+              value={props.advancedPrefs.maxBitrateKbps ?? ""}
+              placeholder="Preset default"
+              onChange={(event) => {
+                const raw = event.target.value;
+                if (raw === "") {
+                  updateField("maxBitrateKbps", undefined);
+                  return;
+                }
+                const parsed = Number.parseInt(raw, 10);
+                if (Number.isFinite(parsed) && parsed > 0) {
+                  updateField("maxBitrateKbps", parsed);
+                }
+              }}
+            />
+          </label>
+          <label style={toggleOptionStyle}>
+            <input
+              type="checkbox"
+              checked={props.advancedPrefs.audioPriority === true}
+              onChange={(event) =>
+                updateField("audioPriority", event.target.checked || undefined)
+              }
+            />
+            Prioritize audio on weak links
+          </label>
+          <label style={toggleOptionStyle}>
+            <input
+              type="checkbox"
+              checked={props.advancedPrefs.audioOnly === true}
+              onChange={(event) =>
+                updateField("audioOnly", event.target.checked || undefined)
+              }
+            />
+            Join audio-only (no outbound video)
+          </label>
+          <label style={toggleOptionStyle}>
+            <input
+              type="checkbox"
+              checked={props.advancedPrefs.receiveVideo === false}
+              onChange={(event) =>
+                // `receiveVideo` defaults to true; only store the override
+                // when the user explicitly pauses incoming video.
+                updateField("receiveVideo", event.target.checked ? false : undefined)
+              }
+            />
+            Pause incoming video
+          </label>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/media-controller.ts
+++ b/apps/web/src/media-controller.ts
@@ -1,31 +1,41 @@
 import { Room, VideoPresets, type VideoEncoding, type VideoResolution } from "livekit-client";
 
-import type { QualityPreset, RequestedMedia, SfuTokenResponse } from "@lowtime/shared";
+import type {
+  AdvancedMediaPrefs,
+  QualityCap,
+  QualityPreset,
+  RequestedMedia,
+  SfuTokenResponse,
+} from "@lowtime/shared";
 
-import { getPresetProfile } from "./quality-presets.js";
+import {
+  computeEffectivePublishOptions,
+  type EffectivePublishOptions,
+} from "./quality-presets.js";
 
 export interface ConnectToSfuInput {
   credentials: SfuTokenResponse;
   requestedMedia: RequestedMedia;
   qualityPreset?: QualityPreset;
+  qualityCap?: QualityCap;
+  advancedPrefs?: AdvancedMediaPrefs;
 }
 
 /**
- * Turns a quality preset into the LiveKit publish options the Room should use
- * for the local video track. Callers without a preset get Balanced, matching
- * the pre-existing behavior.
+ * Turns the preset / cap / advanced-prefs triple into the LiveKit publish
+ * options the Room uses for its local video track. Callers without any of
+ * the optional fields get the legacy Balanced defaults.
  */
-function buildLiveKitOptions(qualityPreset: QualityPreset | undefined): {
+function buildLiveKitOptions(
+  effective: EffectivePublishOptions,
+): {
   videoCaptureDefaults: { resolution: VideoResolution };
-  publishDefaults: { videoEncoding: VideoEncoding };
+  publishDefaults: { videoEncoding: VideoEncoding; dtx: boolean };
 } {
-  const profile = getPresetProfile(qualityPreset ?? "balanced");
   const resolution: VideoResolution = {
-    width: profile.maxResolution.width,
-    height: profile.maxResolution.height,
-    frameRate: profile.maxFps,
-    // Reference an existing preset to let LiveKit pick a reasonable
-    // base encoding while our bitrate cap applies on top.
+    width: effective.resolution.width,
+    height: effective.resolution.height,
+    frameRate: effective.resolution.frameRate,
     ...VideoPresets.h360.encoding,
   };
 
@@ -33,15 +43,24 @@ function buildLiveKitOptions(qualityPreset: QualityPreset | undefined): {
     videoCaptureDefaults: { resolution },
     publishDefaults: {
       videoEncoding: {
-        maxBitrate: profile.maxVideoBitrateKbps * 1000,
-        maxFramerate: profile.maxFps,
+        maxBitrate: effective.maxBitrateKbps * 1000,
+        maxFramerate: effective.resolution.frameRate,
       },
+      // `dtx = true` lets WebRTC stop sending audio during silence, which
+      // keeps more bandwidth available for video. Flipped on when the user
+      // opts into audio priority.
+      dtx: effective.audioPriority,
     },
   };
 }
 
 export async function connectToSfu(input: ConnectToSfuInput): Promise<Room> {
-  const liveKitOptions = buildLiveKitOptions(input.qualityPreset);
+  const effective = computeEffectivePublishOptions({
+    preset: input.qualityPreset ?? "balanced",
+    cap: input.qualityCap ?? "high",
+    advanced: input.advancedPrefs,
+  });
+  const liveKitOptions = buildLiveKitOptions(effective);
 
   const room = new Room({
     adaptiveStream: true,
@@ -50,15 +69,20 @@ export async function connectToSfu(input: ConnectToSfuInput): Promise<Room> {
   });
 
   try {
+    // When the user asked to receive no remote video, we still connect with
+    // `autoSubscribe: true` but filter out video tracks via the room option
+    // below. Pure audio-only rooms keep the default.
     await room.connect(input.credentials.sfuUrl, input.credentials.token, {
-      autoSubscribe: true,
+      autoSubscribe: effective.receiveVideo,
     });
 
     if (input.requestedMedia.audio) {
       await room.localParticipant.setMicrophoneEnabled(true);
     }
 
-    if (input.requestedMedia.video) {
+    // Honor audioOnly: do NOT publish camera even when requestedMedia.video
+    // is true. The user can still flip camera on later via the call UI.
+    if (input.requestedMedia.video && !effective.audioOnly) {
       await room.localParticipant.setCameraEnabled(true);
     }
 

--- a/apps/web/src/quality-presets.test.ts
+++ b/apps/web/src/quality-presets.test.ts
@@ -48,3 +48,157 @@ test("getPresetProfile exposes user-facing labels matching the documented preset
   assert.equal(getPresetProfile("balanced").label, "Balanced");
   assert.equal(getPresetProfile("best_quality").label, "Best Quality");
 });
+
+
+import { computeEffectivePublishOptions } from "./quality-presets.js";
+
+test("computeEffectivePublishOptions without advanced prefs yields preset+cap defaults (Balanced)", () => {
+  const result = computeEffectivePublishOptions({ preset: "balanced", cap: "high" });
+  assert.equal(result.resolution.width, 640);
+  assert.equal(result.resolution.height, 360);
+  assert.equal(result.resolution.frameRate, 15);
+  assert.equal(result.maxBitrateKbps, 500);
+  assert.equal(result.audioOnly, false);
+  assert.equal(result.audioPriority, false);
+  assert.equal(result.receiveVideo, true);
+});
+
+test("computeEffectivePublishOptions clamps preset when the cap is lower than the chosen preset", () => {
+  const result = computeEffectivePublishOptions({ preset: "best_quality", cap: "low" });
+  // 'low' cap clamps to data_saver profile (320x240 @ 12fps @ 200 kbps).
+  assert.equal(result.resolution.width, 320);
+  assert.equal(result.resolution.height, 240);
+  assert.equal(result.resolution.frameRate, 12);
+  assert.equal(result.maxBitrateKbps, 200);
+});
+
+test("computeEffectivePublishOptions honors maxBitrateKbps when it tightens the preset", () => {
+  const result = computeEffectivePublishOptions({
+    preset: "best_quality",
+    cap: "high",
+    advanced: { maxBitrateKbps: 300 },
+  });
+  // Preset best_quality would allow 1200 kbps, but user asked for 300.
+  assert.equal(result.maxBitrateKbps, 300);
+});
+
+test("computeEffectivePublishOptions ignores maxBitrateKbps when it would loosen the preset", () => {
+  const result = computeEffectivePublishOptions({
+    preset: "data_saver",
+    cap: "high",
+    advanced: { maxBitrateKbps: 5000 },
+  });
+  // data_saver caps at 200 kbps; user request of 5000 must not take effect.
+  assert.equal(result.maxBitrateKbps, 200);
+});
+
+test("computeEffectivePublishOptions honors maxFps when it tightens, ignores it when it loosens", () => {
+  const tighter = computeEffectivePublishOptions({
+    preset: "best_quality",
+    cap: "high",
+    advanced: { maxFps: 10 },
+  });
+  assert.equal(tighter.resolution.frameRate, 10);
+
+  const looser = computeEffectivePublishOptions({
+    preset: "data_saver",
+    cap: "high",
+    advanced: { maxFps: 60 },
+  });
+  // data_saver caps at 12 fps; user request of 60 must not take effect.
+  assert.equal(looser.resolution.frameRate, 12);
+});
+
+test("computeEffectivePublishOptions honors maxResolution when it tightens, ignores it when equal or larger", () => {
+  const tighter = computeEffectivePublishOptions({
+    preset: "best_quality",
+    cap: "high",
+    advanced: { maxResolution: "360p" },
+  });
+  assert.equal(tighter.resolution.width, 640);
+  assert.equal(tighter.resolution.height, 360);
+
+  const sameSize = computeEffectivePublishOptions({
+    preset: "balanced",
+    cap: "high",
+    advanced: { maxResolution: "360p" },
+  });
+  // Balanced is 640x360; user-specified 360p matches so no change.
+  assert.equal(sameSize.resolution.width, 640);
+  assert.equal(sameSize.resolution.height, 360);
+
+  const larger = computeEffectivePublishOptions({
+    preset: "data_saver",
+    cap: "high",
+    advanced: { maxResolution: "720p" },
+  });
+  // Data Saver is 320x240; user-specified 720p must not take effect.
+  assert.equal(larger.resolution.width, 320);
+  assert.equal(larger.resolution.height, 240);
+});
+
+test("computeEffectivePublishOptions toggles audioOnly, audioPriority, receiveVideo flags", () => {
+  const audioOnly = computeEffectivePublishOptions({
+    preset: "balanced",
+    cap: "high",
+    advanced: { audioOnly: true },
+  });
+  assert.equal(audioOnly.audioOnly, true);
+
+  const priority = computeEffectivePublishOptions({
+    preset: "balanced",
+    cap: "high",
+    advanced: { audioPriority: true },
+  });
+  assert.equal(priority.audioPriority, true);
+
+  const noReceive = computeEffectivePublishOptions({
+    preset: "balanced",
+    cap: "high",
+    advanced: { receiveVideo: false },
+  });
+  assert.equal(noReceive.receiveVideo, false);
+});
+
+test("computeEffectivePublishOptions combines all overrides at once", () => {
+  const result = computeEffectivePublishOptions({
+    preset: "best_quality",
+    cap: "high",
+    advanced: {
+      maxResolution: "240p",
+      maxFps: 8,
+      maxBitrateKbps: 100,
+      audioPriority: true,
+      audioOnly: true,
+      receiveVideo: false,
+    },
+  });
+  assert.equal(result.resolution.width, 320);
+  assert.equal(result.resolution.height, 240);
+  assert.equal(result.resolution.frameRate, 8);
+  assert.equal(result.maxBitrateKbps, 100);
+  assert.equal(result.audioOnly, true);
+  assert.equal(result.audioPriority, true);
+  assert.equal(result.receiveVideo, false);
+});
+
+test("computeEffectivePublishOptions still clamps to cap before applying advanced prefs", () => {
+  // User picked best_quality with maxBitrate 900, but cap is balanced.
+  // Cap clamps preset to balanced (500 kbps max), and user-chosen 900 is
+  // greater than the clamped preset, so the preset ceiling wins.
+  const capOverrules = computeEffectivePublishOptions({
+    preset: "best_quality",
+    cap: "balanced",
+    advanced: { maxBitrateKbps: 900 },
+  });
+  assert.equal(capOverrules.maxBitrateKbps, 500);
+
+  // But if the user asks for 250 kbps, that tightens past the cap-clamped
+  // 500, so the user value wins.
+  const userOverrules = computeEffectivePublishOptions({
+    preset: "best_quality",
+    cap: "balanced",
+    advanced: { maxBitrateKbps: 250 },
+  });
+  assert.equal(userOverrules.maxBitrateKbps, 250);
+});

--- a/apps/web/src/quality-presets.ts
+++ b/apps/web/src/quality-presets.ts
@@ -41,3 +41,81 @@ export function listPresetProfiles(): Array<{ preset: QualityPreset; profile: Pr
     profile: PRESET_PROFILES[preset],
   }));
 }
+
+import {
+  clampPresetToCap,
+  resolutionCapToPixels,
+  type AdvancedMediaPrefs,
+  type QualityCap,
+} from "@lowtime/shared";
+
+/**
+ * The reduced, LiveKit-shaped output of combining a `QualityPreset`, a
+ * `QualityCap`, and any per-user `AdvancedMediaPrefs` into the final publish
+ * parameters. The web client's `connectToSfu` consumes this shape directly.
+ */
+export interface EffectivePublishOptions {
+  resolution: { width: number; height: number; frameRate: number };
+  maxBitrateKbps: number;
+  audioOnly: boolean;
+  audioPriority: boolean;
+  receiveVideo: boolean;
+}
+
+export interface ComputeEffectivePublishOptionsInput {
+  preset: QualityPreset;
+  cap: QualityCap;
+  advanced?: AdvancedMediaPrefs;
+}
+
+/**
+ * Combines a preset profile, the host-imposed cap, and the user's advanced
+ * prefs into the final `EffectivePublishOptions`. Overrides only ever tighten
+ * the preset baseline; a user cannot raise the limits above what the preset
+ * and cap allow.
+ */
+export function computeEffectivePublishOptions(
+  input: ComputeEffectivePublishOptionsInput,
+): EffectivePublishOptions {
+  const preset = clampPresetToCap(input.preset, input.cap);
+  const profile = getPresetProfile(preset);
+  const advanced = input.advanced ?? {};
+
+  const presetPixels = profile.maxResolution.width * profile.maxResolution.height;
+  const userPixels =
+    advanced.maxResolution != null
+      ? resolutionCapToPixels(advanced.maxResolution).width *
+        resolutionCapToPixels(advanced.maxResolution).height
+      : Number.POSITIVE_INFINITY;
+
+  // Pick the tighter resolution: user-chosen tier if strictly smaller, else
+  // preset resolution. Equal resolutions defer to the preset for stability.
+  const resolutionSource =
+    advanced.maxResolution != null && userPixels < presetPixels
+      ? resolutionCapToPixels(advanced.maxResolution)
+      : profile.maxResolution;
+
+  const frameRate =
+    advanced.maxFps != null && advanced.maxFps > 0 && advanced.maxFps < profile.maxFps
+      ? advanced.maxFps
+      : profile.maxFps;
+
+  const maxBitrateKbps =
+    advanced.maxBitrateKbps != null &&
+    advanced.maxBitrateKbps > 0 &&
+    advanced.maxBitrateKbps < profile.maxVideoBitrateKbps
+      ? advanced.maxBitrateKbps
+      : profile.maxVideoBitrateKbps;
+
+  return {
+    resolution: {
+      width: resolutionSource.width,
+      height: resolutionSource.height,
+      frameRate,
+    },
+    maxBitrateKbps,
+    audioOnly: advanced.audioOnly === true,
+    audioPriority: advanced.audioPriority === true,
+    receiveVideo: advanced.receiveVideo !== false,
+  };
+}

--- a/apps/web/src/room-entry.test.ts
+++ b/apps/web/src/room-entry.test.ts
@@ -83,6 +83,7 @@ test("stored call sessions round-trip and clear cleanly", () => {
       audio: true,
       video: true,
     },
+    advancedPrefs: undefined,
   });
 
   clearStoredCallSession(mockStorage, "Room123");
@@ -153,4 +154,78 @@ test("clearStoredHostSecret removes the host secret and is a no-op for missing k
   // No-op for a slug that has no cached secret.
   clearStoredHostSecret(mockStorage, "RoomDoesNotExist");
   assert.equal(loadStoredHostSecret(mockStorage, "RoomDoesNotExist"), null);
+});
+
+
+test("stored call sessions round-trip advancedPrefs", () => {
+  const storage = new Map<string, string>();
+  const mockStorage = {
+    getItem(key: string) {
+      return storage.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      storage.set(key, value);
+    },
+    removeItem(key: string) {
+      storage.delete(key);
+    },
+  } as Storage;
+
+  saveStoredCallSession(mockStorage, "Room789", {
+    sessionId: "sess_789",
+    displayName: "Avery",
+    qualityPreset: "balanced",
+    transportPreference: "sfu",
+    requestedMedia: {
+      audio: true,
+      video: true,
+    },
+    advancedPrefs: {
+      maxResolution: "360p",
+      maxFps: 12,
+      maxBitrateKbps: 300,
+      audioPriority: true,
+      audioOnly: false,
+      receiveVideo: true,
+    },
+  });
+
+  const loaded = loadStoredCallSession(mockStorage, "Room789");
+  assert.deepEqual(loaded?.advancedPrefs, {
+    maxResolution: "360p",
+    maxFps: 12,
+    maxBitrateKbps: 300,
+    audioPriority: true,
+    audioOnly: false,
+    receiveVideo: true,
+  });
+});
+
+test("stored call sessions without advancedPrefs load with advancedPrefs undefined", () => {
+  const storage = new Map<string, string>();
+  const mockStorage = {
+    getItem(key: string) {
+      return storage.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      storage.set(key, value);
+    },
+    removeItem(key: string) {
+      storage.delete(key);
+    },
+  } as Storage;
+
+  saveStoredCallSession(mockStorage, "RoomLegacy", {
+    sessionId: "sess_legacy",
+    displayName: "Legacy",
+    qualityPreset: "balanced",
+    transportPreference: "sfu",
+    requestedMedia: {
+      audio: true,
+      video: true,
+    },
+  });
+
+  const loaded = loadStoredCallSession(mockStorage, "RoomLegacy");
+  assert.equal(loaded?.advancedPrefs, undefined);
 });

--- a/apps/web/src/room-entry.ts
+++ b/apps/web/src/room-entry.ts
@@ -1,4 +1,9 @@
-import type { QualityPreset, RequestedMedia, TransportPreference } from "@lowtime/shared";
+import type {
+  AdvancedMediaPrefs,
+  QualityPreset,
+  RequestedMedia,
+  TransportPreference,
+} from "@lowtime/shared";
 
 export type ViewState =
   | { kind: "home" }
@@ -12,6 +17,7 @@ export interface StoredCallSession {
   qualityPreset: QualityPreset;
   requestedMedia: RequestedMedia;
   transportPreference: TransportPreference;
+  advancedPrefs?: AdvancedMediaPrefs;
 }
 
 export interface StoredLobbyRequest {
@@ -112,10 +118,17 @@ export function loadStoredCallSession(storage: Storage, slug: string): StoredCal
         audio: parsed.requestedMedia.audio,
         video: parsed.requestedMedia.video,
       },
+      advancedPrefs: isRecord(parsed.advancedPrefs)
+        ? (parsed.advancedPrefs as AdvancedMediaPrefs)
+        : undefined,
     };
   } catch {
     return null;
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 export function clearStoredCallSession(storage: Storage, slug: string) {

--- a/docs/04-media-and-quality.md
+++ b/docs/04-media-and-quality.md
@@ -52,6 +52,7 @@ H -->|No| J[Show rejoin failure]
 - Hide self-view
 - Front and rear camera switch on mobile
 - Mic and speaker selection where browser APIs allow it
+- The web client exposes six of these overrides today through an "Advanced Media Controls" disclosure on the room page. The user-visible shape lives in [`packages/shared/src/index.ts`](../packages/shared/src/index.ts) as `AdvancedMediaPrefs`, and the pure `computeEffectivePublishOptions` helper in [`apps/web/src/quality-presets.ts`](../apps/web/src/quality-presets.ts) is the single place that combines the preset profile, the host cap, and the user overrides into the final LiveKit publish options. The host quality cap always clamps first; user overrides can only tighten, never loosen, the preset + cap baseline.
 
 ## Host Quality Policy
 - Host quality cap values are `Low`, `Balanced`, and `High`.

--- a/packages/shared/src/advanced-media-prefs.test.ts
+++ b/packages/shared/src/advanced-media-prefs.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolutionCapToPixels, type ResolutionCap } from "./index.js";
+
+test("resolutionCapToPixels returns the documented pixel dimensions for every tier", () => {
+  const expected: Record<ResolutionCap, { width: number; height: number }> = {
+    "240p": { width: 320, height: 240 },
+    "360p": { width: 640, height: 360 },
+    "480p": { width: 854, height: 480 },
+    "720p": { width: 1280, height: 720 },
+  };
+
+  for (const [cap, dims] of Object.entries(expected) as Array<[
+    ResolutionCap,
+    { width: number; height: number },
+  ]>) {
+    assert.deepEqual(resolutionCapToPixels(cap), dims);
+  }
+});
+
+test("resolutionCapToPixels is idempotent when round-tripped through the map", () => {
+  const caps: ResolutionCap[] = ["240p", "360p", "480p", "720p"];
+  for (const cap of caps) {
+    const first = resolutionCapToPixels(cap);
+    const second = resolutionCapToPixels(cap);
+    assert.deepEqual(first, second);
+  }
+});
+
+test("resolutionCapToPixels produces strictly increasing pixel counts", () => {
+  const caps: ResolutionCap[] = ["240p", "360p", "480p", "720p"];
+  let previousPixels = 0;
+  for (const cap of caps) {
+    const { width, height } = resolutionCapToPixels(cap);
+    const pixels = width * height;
+    assert.ok(pixels > previousPixels);
+    previousPixels = pixels;
+  }
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -53,6 +53,36 @@ export interface UpdateRoomSettingsRequest {
   qualityCap?: QualityCap;
 }
 
+export type ResolutionCap = "240p" | "360p" | "480p" | "720p";
+
+export interface AdvancedMediaPrefs {
+  maxResolution?: ResolutionCap;
+  maxFps?: number;
+  maxBitrateKbps?: number;
+  audioPriority?: boolean;
+  receiveVideo?: boolean;
+  audioOnly?: boolean;
+}
+
+/**
+ * Maps a `ResolutionCap` to its pixel dimensions. Total and idempotent.
+ */
+export function resolutionCapToPixels(cap: ResolutionCap): {
+  width: number;
+  height: number;
+} {
+  switch (cap) {
+    case "240p":
+      return { width: 320, height: 240 };
+    case "360p":
+      return { width: 640, height: 360 };
+    case "480p":
+      return { width: 854, height: 480 };
+    case "720p":
+      return { width: 1280, height: 720 };
+  }
+}
+
 export interface UpdateRoomSettingsResponse {
   room: RoomSummary;
 }


### PR DESCRIPTION
## Summary
Implements issue #17 (Phase 3: Advanced media controls) for the 1:1 core flow.

- New shared types `AdvancedMediaPrefs` and `ResolutionCap` in `@lowtime/shared`, plus a `resolutionCapToPixels` helper.
- Pure `computeEffectivePublishOptions({ preset, cap, advanced })` helper in `apps/web/src/quality-presets.ts` combines preset profile + host cap + user overrides. Overrides only tighten the baseline; a user cannot raise limits above what the preset and cap allow.
- `connectToSfu` now accepts `{ qualityCap, advancedPrefs }` and wires the effective options into LiveKit `videoCaptureDefaults`, `publishDefaults.videoEncoding`, `publishDefaults.dtx`, and `autoSubscribe`. Camera publishing is skipped when `audioOnly` is true.
- `StoredCallSession` gains an optional `advancedPrefs` field; prefs are persisted on successful direct join and round-tripped across refresh.
- Room page renders an Advanced Media Controls disclosure with six controls: max resolution, max fps, max video bitrate (kbps), audio priority toggle, audio-only join, and pause incoming video.

Closes #17.

## Out of scope (tracked separately)
- Live propagation of prefs to peers via signaling (#19)
- Automatic low-network downgrade (#20)
- Audio-only prompt after repeated instability (#21)

## Verification
    npm run lint        # all workspaces clean
    npm run typecheck   # all workspaces clean
    npm run test        # 152 server + 75 web + 8 shared = 235 tests, all pass
    npm run build       # succeeds