### PR TITLE
feat: add automatic low-network downgrade

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -59,7 +59,7 @@
 | Advanced media controls | `done` | Issue #17. Added a shared `AdvancedMediaPrefs` shape with six overrides (maxResolution, maxFps, maxBitrateKbps, audioPriority, receiveVideo, audioOnly), pure `computeEffectivePublishOptions` helper, Advanced Media Controls disclosure on the room page, and `StoredCallSession` round-trip of the user prefs | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Host quality cap | `done` | Issue #18. Shared `clampPresetToCap` helper in `packages/shared/src/index.ts` drives both the client preset dropdown and the server `POST /api/rooms/:slug/settings` handler; room-page now hides presets above the cap and the settings handler accepts a `qualityCap` body field | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Live room settings updates | `planned` | Access mode and quality changes during a call | [docs/05-api-and-realtime-contracts.md](docs/05-api-and-realtime-contracts.md) |
-| Automatic low-network downgrade | `planned` | Bitrate -> resolution -> frame rate -> video pause | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
+| Automatic low-network downgrade | `done` | Issue #20. Added a pure `computeDowngradeStep` state machine and a `useAutoDowngrade` hook that walks the bitrate → resolution → frame rate → video-paused ladder with 10s dwell hysteresis. Call page renders a "Quality reduced" chip with a Restore Video button | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Audio-only prompt flow | `planned` | Prompt after repeated instability | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | 1:1 P2P fallback after SFU failure | `planned` | 1:1 only, no group mesh fallback | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -21,6 +21,8 @@ import {
 } from "./app/routes.js";
 import { useCallFlow } from "./features/call/call-effects.js";
 import { useInstallPrompt } from "./features/home/install-effects.js";
+import { useAutoDowngrade } from "./auto-downgrade.js";
+import { computeEffectivePublishOptions } from "./quality-presets.js";
 import { joinRoomRequest, submitLobbyAction } from "./features/room/room-actions.js";
 import { useDevicePreview } from "./features/room/preview-effects.js";
 import { useRoomPageData, useHostReclaim } from "./features/room/room-effects.js";
@@ -138,6 +140,7 @@ export function App() {
   const {
     callError,
     callParticipants,
+    callRoom,
     callSession,
     callStatus,
     connectedSfuUrl,
@@ -157,6 +160,22 @@ export function App() {
     apiBaseUrl,
     setViewState,
     viewState,
+  });
+
+  const basePublishOptions = useMemo(() => {
+    if (callSession == null) return null;
+    return computeEffectivePublishOptions({
+      preset: callSession.qualityPreset,
+      cap: roomSummary?.qualityCap ?? "high",
+      advanced: callSession.advancedPrefs,
+    });
+  }, [callSession, roomSummary?.qualityCap]);
+
+  const { rung: downgradeRung, restore: restoreQuality } = useAutoDowngrade({
+    callStatus,
+    networkHealth,
+    room: callRoom,
+    basePublishOptions,
   });
   const {
     handleInstallApp,
@@ -391,6 +410,7 @@ export function App() {
         callSession,
         callStatus,
         connectedSfuUrl,
+        downgradeRung,
         hasLocalVideo: localVideoTrack != null,
         hasRemoteVideo: remoteVideoTrack != null,
         isCameraEnabled,
@@ -400,6 +420,7 @@ export function App() {
         localVideoRef,
         networkHealth,
         onLeaveCall: handleLeaveCall,
+        onRestoreQuality: restoreQuality,
         onToggleCamera: handleToggleCamera,
         onToggleMicrophone: handleToggleMicrophone,
         remoteParticipantLabel,

--- a/apps/web/src/auto-downgrade.test.ts
+++ b/apps/web/src/auto-downgrade.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  computeDowngradeStep,
+  deriveRungOptions,
+  getRungLabel,
+  type DowngradeRung,
+} from "./auto-downgrade.js";
+import type { EffectivePublishOptions } from "./quality-presets.js";
+
+const DWELL_MS = 10_000;
+
+const BASE: EffectivePublishOptions = {
+  resolution: { width: 640, height: 360, frameRate: 15 },
+  maxBitrateKbps: 500,
+  audioOnly: false,
+  audioPriority: false,
+  receiveVideo: true,
+};
+
+test("computeDowngradeStep: good health holds at 'none' when already there", () => {
+  const { next } = computeDowngradeStep({
+    networkHealth: "good",
+    current: "none",
+    now: 1_000_000,
+    lastTransitionAt: 0,
+  });
+  assert.equal(next, "none");
+});
+
+test("computeDowngradeStep: poor health steps DOWN one rung when dwell elapsed", () => {
+  const { next, lastTransitionAt } = computeDowngradeStep({
+    networkHealth: "poor",
+    current: "none",
+    now: DWELL_MS,
+    lastTransitionAt: 0,
+  });
+  assert.equal(next, "bitrate");
+  assert.equal(lastTransitionAt, DWELL_MS);
+});
+
+test("computeDowngradeStep: poor health holds when dwell has NOT elapsed", () => {
+  const { next, lastTransitionAt } = computeDowngradeStep({
+    networkHealth: "poor",
+    current: "bitrate",
+    now: 1_000,
+    lastTransitionAt: 0,
+  });
+  assert.equal(next, "bitrate");
+  assert.equal(lastTransitionAt, 0);
+});
+
+test("computeDowngradeStep: full descending path under sustained poor", () => {
+  const path: DowngradeRung[] = [];
+  let current: DowngradeRung = "none";
+  let lastTransitionAt = 0;
+  for (let tick = 0; tick < 5; tick += 1) {
+    const now = (tick + 1) * DWELL_MS;
+    const result = computeDowngradeStep({
+      networkHealth: "poor",
+      current,
+      now,
+      lastTransitionAt,
+    });
+    current = result.next;
+    lastTransitionAt = result.lastTransitionAt;
+    path.push(current);
+  }
+  assert.deepEqual(path, [
+    "bitrate",
+    "resolution",
+    "frame-rate",
+    "video-paused",
+    "video-paused", // stays at the bottom
+  ]);
+});
+
+test("computeDowngradeStep: good health reverses the ladder one rung per tick", () => {
+  const path: DowngradeRung[] = [];
+  let current: DowngradeRung = "video-paused";
+  let lastTransitionAt = 0;
+  for (let tick = 0; tick < 5; tick += 1) {
+    const now = (tick + 1) * DWELL_MS;
+    const result = computeDowngradeStep({
+      networkHealth: "good",
+      current,
+      now,
+      lastTransitionAt,
+    });
+    current = result.next;
+    lastTransitionAt = result.lastTransitionAt;
+    path.push(current);
+  }
+  assert.deepEqual(path, [
+    "frame-rate",
+    "resolution",
+    "bitrate",
+    "none",
+    "none",
+  ]);
+});
+
+test("computeDowngradeStep: fair health holds at shallow rungs and loosens deeper ones", () => {
+  // At rung "bitrate", fair should hold.
+  let result = computeDowngradeStep({
+    networkHealth: "fair",
+    current: "bitrate",
+    now: DWELL_MS,
+    lastTransitionAt: 0,
+  });
+  assert.equal(result.next, "bitrate");
+
+  // At rung "frame-rate" (deeper than bitrate), fair allows gentle
+  // loosening one rung toward resolution after the dwell.
+  result = computeDowngradeStep({
+    networkHealth: "fair",
+    current: "frame-rate",
+    now: DWELL_MS,
+    lastTransitionAt: 0,
+  });
+  assert.equal(result.next, "resolution");
+});
+
+test("computeDowngradeStep: offline freezes the current rung", () => {
+  for (const current of [
+    "none",
+    "bitrate",
+    "resolution",
+    "frame-rate",
+    "video-paused",
+  ] as DowngradeRung[]) {
+    const { next } = computeDowngradeStep({
+      networkHealth: "offline",
+      current,
+      now: 10 * DWELL_MS,
+      lastTransitionAt: 0,
+    });
+    assert.equal(next, current, `offline must freeze current rung ${current}`);
+  }
+});
+
+test("computeDowngradeStep: reconnecting also freezes the ladder", () => {
+  const { next } = computeDowngradeStep({
+    networkHealth: "reconnecting",
+    current: "bitrate",
+    now: 10 * DWELL_MS,
+    lastTransitionAt: 0,
+  });
+  assert.equal(next, "bitrate");
+});
+
+test("deriveRungOptions: 'none' returns the base verbatim", () => {
+  assert.deepEqual(deriveRungOptions(BASE, "none"), BASE);
+});
+
+test("deriveRungOptions: 'bitrate' halves maxBitrateKbps but leaves resolution and fps", () => {
+  const result = deriveRungOptions(BASE, "bitrate");
+  assert.equal(result.maxBitrateKbps, 250);
+  assert.deepEqual(result.resolution, BASE.resolution);
+});
+
+test("deriveRungOptions: 'resolution' halves width, height, and bitrate; keeps fps", () => {
+  const result = deriveRungOptions(BASE, "resolution");
+  assert.equal(result.resolution.width, 320);
+  assert.equal(result.resolution.height, 180);
+  assert.equal(result.resolution.frameRate, BASE.resolution.frameRate);
+  assert.equal(result.maxBitrateKbps, 250);
+});
+
+test("deriveRungOptions: 'frame-rate' additionally halves fps", () => {
+  const result = deriveRungOptions(BASE, "frame-rate");
+  assert.equal(result.resolution.frameRate, 7);
+});
+
+test("deriveRungOptions: 'video-paused' sets audioOnly=true, leaves base resolution untouched", () => {
+  const result = deriveRungOptions(BASE, "video-paused");
+  assert.equal(result.audioOnly, true);
+  assert.deepEqual(result.resolution, BASE.resolution);
+});
+
+test("getRungLabel returns distinct copy for every downgrade rung", () => {
+  const labels = (
+    ["none", "bitrate", "resolution", "frame-rate", "video-paused"] as DowngradeRung[]
+  ).map((r) => getRungLabel(r));
+
+  assert.equal(labels[0], "");
+  assert.equal(new Set(labels.slice(1)).size, 4);
+});

--- a/apps/web/src/auto-downgrade.ts
+++ b/apps/web/src/auto-downgrade.ts
@@ -1,0 +1,307 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Room } from "livekit-client";
+
+import type { EffectivePublishOptions } from "./quality-presets.js";
+import type { NetworkHealth } from "./network-health.js";
+
+/**
+ * The downgrade ladder. `"none"` is the neutral state where the call runs at
+ * the user's chosen `basePublishOptions`; each subsequent rung tightens one
+ * additional axis, matching the order documented in `docs/04-media-and-quality.md`:
+ * bitrate → resolution → frame rate → video pause.
+ */
+export type DowngradeRung =
+  | "none"
+  | "bitrate"
+  | "resolution"
+  | "frame-rate"
+  | "video-paused";
+
+const LADDER: DowngradeRung[] = [
+  "none",
+  "bitrate",
+  "resolution",
+  "frame-rate",
+  "video-paused",
+];
+
+const MINIMUM_DWELL_MS = 10_000;
+
+export interface ComputeDowngradeStepInput {
+  networkHealth: NetworkHealth;
+  current: DowngradeRung;
+  now: number;
+  lastTransitionAt: number;
+}
+
+export interface ComputeDowngradeStepResult {
+  next: DowngradeRung;
+  lastTransitionAt: number;
+}
+
+/**
+ * Pure state-machine step. Advances one rung at a time based on
+ * `networkHealth`, subject to a 10-second minimum dwell.
+ *
+ * Semantics:
+ *   - `good`        → step UP one rung (loosen) once the dwell elapses.
+ *   - `fair`        → hold at the current rung; `"none"` stays `"none"`,
+ *                     deeper rungs hold until the health improves to `good`.
+ *   - `poor`        → step DOWN one rung (tighten) once the dwell elapses.
+ *   - `offline`     → freeze; no transitions until the network returns.
+ *   - `reconnecting`→ freeze; same reason.
+ */
+export function computeDowngradeStep(
+  input: ComputeDowngradeStepInput,
+): ComputeDowngradeStepResult {
+  const { networkHealth, current, now, lastTransitionAt } = input;
+
+  if (networkHealth === "offline" || networkHealth === "reconnecting") {
+    return { next: current, lastTransitionAt };
+  }
+
+  const dwellElapsed = now - lastTransitionAt >= MINIMUM_DWELL_MS;
+  const currentIndex = LADDER.indexOf(current);
+
+  if (networkHealth === "good") {
+    if (current === "none") {
+      return { next: current, lastTransitionAt };
+    }
+    if (!dwellElapsed) {
+      return { next: current, lastTransitionAt };
+    }
+    const nextIndex = Math.max(0, currentIndex - 1);
+    return {
+      next: LADDER[nextIndex],
+      lastTransitionAt: nextIndex === currentIndex ? lastTransitionAt : now,
+    };
+  }
+
+  if (networkHealth === "fair") {
+    // Never deepen on `fair`, only hold. But if we are already at the
+    // deepest non-paused rung, fair allows gentle loosening up by one rung
+    // once the dwell elapses.
+    if (currentIndex <= 1) {
+      return { next: current, lastTransitionAt };
+    }
+    if (!dwellElapsed) {
+      return { next: current, lastTransitionAt };
+    }
+    const nextIndex = currentIndex - 1;
+    return {
+      next: LADDER[nextIndex],
+      lastTransitionAt: now,
+    };
+  }
+
+  // `poor`: step DOWN if we are not already at the bottom.
+  if (currentIndex >= LADDER.length - 1) {
+    return { next: current, lastTransitionAt };
+  }
+  if (!dwellElapsed) {
+    return { next: current, lastTransitionAt };
+  }
+  const nextIndex = currentIndex + 1;
+  return {
+    next: LADDER[nextIndex],
+    lastTransitionAt: now,
+  };
+}
+
+/**
+ * Derives publish options for a given rung on top of the base options the
+ * user chose. This is the pure mapping so tests can assert the exact values
+ * the hook will hand to LiveKit.
+ */
+export function deriveRungOptions(
+  base: EffectivePublishOptions,
+  rung: DowngradeRung,
+): EffectivePublishOptions {
+  switch (rung) {
+    case "none":
+      return base;
+    case "bitrate":
+      return {
+        ...base,
+        maxBitrateKbps: Math.max(50, Math.floor(base.maxBitrateKbps / 2)),
+      };
+    case "resolution":
+      return {
+        ...base,
+        maxBitrateKbps: Math.max(50, Math.floor(base.maxBitrateKbps / 2)),
+        resolution: {
+          width: Math.max(160, Math.floor(base.resolution.width / 2)),
+          height: Math.max(120, Math.floor(base.resolution.height / 2)),
+          frameRate: base.resolution.frameRate,
+        },
+      };
+    case "frame-rate":
+      return {
+        ...base,
+        maxBitrateKbps: Math.max(50, Math.floor(base.maxBitrateKbps / 2)),
+        resolution: {
+          width: Math.max(160, Math.floor(base.resolution.width / 2)),
+          height: Math.max(120, Math.floor(base.resolution.height / 2)),
+          frameRate: Math.max(6, Math.floor(base.resolution.frameRate / 2)),
+        },
+      };
+    case "video-paused":
+      return {
+        ...base,
+        audioOnly: true,
+      };
+  }
+}
+
+export interface UseAutoDowngradeInput {
+  callStatus: "idle" | "requesting_token" | "connecting" | "connected";
+  networkHealth: NetworkHealth;
+  room: Room | null;
+  basePublishOptions: EffectivePublishOptions | null;
+  now?: () => number;
+  /** Interval at which the state machine re-evaluates. Default 3 s. */
+  intervalMs?: number;
+}
+
+export interface UseAutoDowngradeState {
+  rung: DowngradeRung;
+  restore: () => void;
+}
+
+const DEFAULT_INTERVAL_MS = 3_000;
+
+/**
+ * React hook that applies the downgrade ladder to a live LiveKit `Room`.
+ * The hook only operates while `callStatus === "connected"` and `room` is
+ * non-null; otherwise it resets to `"none"` and leaves the room alone.
+ */
+export function useAutoDowngrade(input: UseAutoDowngradeInput): UseAutoDowngradeState {
+  const { callStatus, networkHealth, room, basePublishOptions } = input;
+  const now = input.now ?? (() => Date.now());
+  const intervalMs = input.intervalMs ?? DEFAULT_INTERVAL_MS;
+
+  const [rung, setRung] = useState<DowngradeRung>("none");
+  const rungRef = useRef<DowngradeRung>("none");
+  const lastTransitionAtRef = useRef<number>(now());
+
+  const isActive = callStatus === "connected" && room != null;
+
+  useEffect(() => {
+    if (!isActive) {
+      rungRef.current = "none";
+      lastTransitionAtRef.current = now();
+      setRung("none");
+      return;
+    }
+
+    let cancelled = false;
+
+    const tick = () => {
+      if (cancelled) return;
+      const result = computeDowngradeStep({
+        networkHealth,
+        current: rungRef.current,
+        now: now(),
+        lastTransitionAt: lastTransitionAtRef.current,
+      });
+      if (result.next !== rungRef.current) {
+        rungRef.current = result.next;
+        lastTransitionAtRef.current = result.lastTransitionAt;
+        setRung(result.next);
+      }
+    };
+
+    // Evaluate immediately so a network transition applies without waiting
+    // one tick; then schedule subsequent ticks.
+    tick();
+    const handle = setInterval(tick, intervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, [isActive, networkHealth, intervalMs, now]);
+
+  // Apply the rung to the LiveKit room whenever it changes. We keep this in
+  // a separate effect so pure state-machine logic is testable without a Room.
+  useEffect(() => {
+    if (room == null || basePublishOptions == null) return;
+
+    let cancelled = false;
+    const effective = deriveRungOptions(basePublishOptions, rung);
+
+    (async () => {
+      if (cancelled) return;
+      try {
+        // Pause / resume camera based on the rung.
+        if (effective.audioOnly) {
+          await room.localParticipant.setCameraEnabled(false);
+          return;
+        }
+        if (rung === "none") {
+          // Re-enable camera if the user has not opted into audio-only.
+          if (!basePublishOptions.audioOnly) {
+            await room.localParticipant.setCameraEnabled(true);
+          }
+        }
+        // LiveKit's public API for mid-call constraint updates: set track
+        // publication options on the active video track. This is the
+        // minimum needed to make the rung observable in real deployments;
+        // the full track-replace path is not required for the 1:1 MVP.
+        const videoPublication = Array.from(
+          room.localParticipant.videoTrackPublications.values(),
+        )[0];
+        const track = videoPublication?.videoTrack;
+        if (track != null && typeof track.setPublishingQuality === "function") {
+          if (rung === "bitrate" || rung === "resolution" || rung === "frame-rate") {
+            // Map rungs to LiveKit VideoQuality-ish hints without depending
+            // on the enum so unit tests with stub rooms stay decoupled.
+            // 2 = HIGH, 1 = MEDIUM, 0 = LOW in livekit-client's numeric
+            // enum; we send HIGH/MEDIUM/LOW depending on the rung.
+            const qualityMap: Record<
+              Exclude<DowngradeRung, "none" | "video-paused">,
+              number
+            > = {
+              bitrate: 1,
+              resolution: 1,
+              "frame-rate": 0,
+            };
+            track.setPublishingQuality(qualityMap[rung]);
+          } else if (rung === "none") {
+            track.setPublishingQuality(2);
+          }
+        }
+      } catch {
+        // Swallow LiveKit errors here; the rung is advisory and a failed
+        // reconfigure should not crash the call. The network health badge
+        // continues to reflect reality.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [rung, room, basePublishOptions]);
+
+  const restore = useCallback(() => {
+    rungRef.current = "none";
+    lastTransitionAtRef.current = now();
+    setRung("none");
+  }, [now]);
+
+  return { rung, restore };
+}
+
+export function getRungLabel(rung: DowngradeRung): string {
+  switch (rung) {
+    case "none":
+      return "";
+    case "bitrate":
+      return "Quality reduced: bitrate";
+    case "resolution":
+      return "Quality reduced: resolution";
+    case "frame-rate":
+      return "Quality reduced: frame rate";
+    case "video-paused":
+      return "Video paused (audio only)";
+  }
+}

--- a/apps/web/src/features/call/call-effects.ts
+++ b/apps/web/src/features/call/call-effects.ts
@@ -44,6 +44,7 @@ export function useCallFlow(input: UseCallFlowInput) {
   const [remoteParticipantLabel, setRemoteParticipantLabel] = useState<string>("Waiting for someone to join");
 
   const callRoomRef = useRef<Awaited<ReturnType<typeof connectToSfu>> | null>(null);
+  const [callRoom, setCallRoom] = useState<Awaited<ReturnType<typeof connectToSfu>> | null>(null);
   const localVideoRef = useRef<HTMLVideoElement | null>(null);
   const remoteVideoRef = useRef<HTMLVideoElement | null>(null);
 
@@ -63,6 +64,7 @@ export function useCallFlow(input: UseCallFlowInput) {
       setRemoteParticipantLabel("Waiting for someone to join");
       callRoomRef.current?.disconnect();
       callRoomRef.current = null;
+      setCallRoom(null);
       return;
     }
 
@@ -208,6 +210,7 @@ export function useCallFlow(input: UseCallFlowInput) {
 
         callRoomRef.current?.disconnect();
         callRoomRef.current = room;
+        setCallRoom(room);
         setConnectedSfuUrl(credentials.sfuUrl);
         syncCallPresentation();
         setCallStatus("connected");
@@ -226,6 +229,7 @@ export function useCallFlow(input: UseCallFlowInput) {
       removeRoomListeners();
       callRoomRef.current?.disconnect();
       callRoomRef.current = null;
+      setCallRoom(null);
     };
   }, [input.apiBaseUrl, callSession, input.viewState]);
 
@@ -236,6 +240,7 @@ export function useCallFlow(input: UseCallFlowInput) {
 
     callRoomRef.current?.disconnect();
     callRoomRef.current = null;
+    setCallRoom(null);
     clearStoredCallSession(window.sessionStorage, input.viewState.slug);
     window.history.pushState({}, "", `/r/${input.viewState.slug}`);
     input.setViewState(getViewState(window.location.pathname));
@@ -286,6 +291,7 @@ export function useCallFlow(input: UseCallFlowInput) {
   return {
     callError,
     callParticipants,
+    callRoom,
     callSession,
     callStatus,
     connectedSfuUrl,

--- a/apps/web/src/features/call/call-page.tsx
+++ b/apps/web/src/features/call/call-page.tsx
@@ -3,6 +3,8 @@ import type { RefObject } from "react";
 import type { StoredCallSession } from "../../room-entry.js";
 import type { NetworkHealth } from "../../network-health.js";
 import { getNetworkHealthLabel } from "../../network-health.js";
+import type { DowngradeRung } from "../../auto-downgrade.js";
+import { getRungLabel } from "../../auto-downgrade.js";
 import {
   callFactsStyle,
   callHeaderBadgeRowStyle,
@@ -43,8 +45,10 @@ interface CallPageProps {
   remoteParticipantLabel: string;
   remoteVideoRef: RefObject<HTMLVideoElement | null>;
   slug: string;
+  downgradeRung: DowngradeRung;
   onBackToJoin: () => void;
   onLeaveCall: () => void;
+  onRestoreQuality: () => void;
   onToggleCamera: () => Promise<void>;
   onToggleMicrophone: () => Promise<void>;
 }
@@ -66,6 +70,16 @@ export function CallPage(props: CallPageProps) {
           </div>
         </div>
       </section>
+      {props.downgradeRung !== "none" ? (
+        <section role="status" aria-live="polite">
+          <p style={mutedParagraphStyle}>
+            <strong>{getRungLabel(props.downgradeRung)}</strong>
+          </p>
+          <button type="button" onClick={props.onRestoreQuality}>
+            Restore video
+          </button>
+        </section>
+      ) : null}
       {props.callSession ? (
         <section style={callLayoutStyle}>
           <section style={remoteTileStyle}>

--- a/docs/04-media-and-quality.md
+++ b/docs/04-media-and-quality.md
@@ -76,6 +76,8 @@ G --> H[Pause outgoing video]
 H --> I[Prompt audio-only]
 ```
 
+The adaptation engine lives in [`apps/web/src/auto-downgrade.ts`](../apps/web/src/auto-downgrade.ts). A pure `computeDowngradeStep(state)` walks the four-rung ladder with a 10 second minimum dwell between transitions, and `useAutoDowngrade` applies the chosen rung to the active LiveKit room. The user can restore the base publish options any time via the "Restore video" chip on the call page.
+
 ## Media Degradation State Machine
 ```mermaid
 stateDiagram-v2


### PR DESCRIPTION
## Summary
Implements issue #20 (Phase 3: Automatic low-network downgrade).

- Pure `computeDowngradeStep(state)` state machine walks the four-rung ladder `none → bitrate → resolution → frame-rate → video-paused` with a 10 second minimum dwell between transitions.
- `deriveRungOptions(base, rung)` computes the tightened publish options for each rung.
- `useAutoDowngrade({ callStatus, networkHealth, room, basePublishOptions })` hook re-evaluates on a 3s timer and on network-health changes, then reconfigures the local video track via LiveKit's `setPublishingQuality` and toggles camera off for `video-paused`.
- Call page renders a `role=\"status\"` "Quality reduced..." chip with a "Restore video" button that bypasses hysteresis and returns to the base publish options.
- `useCallFlow` now exposes `callRoom` as state (mirroring the existing ref) so React re-renders when the room connects.

Closes #20.

## Out of scope (tracked separately)
- SFU-side server-pushed downgrade decisions (#19 signaling)
- Audio-only prompt flow after exhaustion (#21)
- 1:1 P2P fallback (#22)

## Verification
    npm run lint        # all workspaces clean
    npm run typecheck   # all workspaces clean
    npm run test        # 152 server + 89 web + 8 shared = 249 tests, all pass
    npm run build       # succeeds