### PR TITLE
feat: add audio-only prompt flow

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -60,7 +60,7 @@
 | Host quality cap | `done` | Issue #18. Shared `clampPresetToCap` helper in `packages/shared/src/index.ts` drives both the client preset dropdown and the server `POST /api/rooms/:slug/settings` handler; room-page now hides presets above the cap and the settings handler accepts a `qualityCap` body field | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Live room settings updates | `planned` | Access mode and quality changes during a call | [docs/05-api-and-realtime-contracts.md](docs/05-api-and-realtime-contracts.md) |
 | Automatic low-network downgrade | `done` | Issue #20. Added a pure `computeDowngradeStep` state machine and a `useAutoDowngrade` hook that walks the bitrate → resolution → frame rate → video-paused ladder with 10s dwell hysteresis. Call page renders a "Quality reduced" chip with a Restore Video button | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
-| Audio-only prompt flow | `planned` | Prompt after repeated instability | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
+| Audio-only prompt flow | `done` | Issue #21. After 30 seconds at the `video-paused` downgrade rung, the call page shows a non-blocking dialog offering "Continue audio-only" or "Keep trying video". Accepting pins `advancedPrefs.audioOnly` to true on the stored session | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | 1:1 P2P fallback after SFU failure | `planned` | 1:1 only, no group mesh fallback | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 
 ## Phase 4: Collaboration Features

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,6 +22,7 @@ import {
 import { useCallFlow } from "./features/call/call-effects.js";
 import { useInstallPrompt } from "./features/home/install-effects.js";
 import { useAutoDowngrade } from "./auto-downgrade.js";
+import { useAudioOnlyPrompt } from "./audio-only-prompt.js";
 import { computeEffectivePublishOptions } from "./quality-presets.js";
 import { joinRoomRequest, submitLobbyAction } from "./features/room/room-actions.js";
 import { useDevicePreview } from "./features/room/preview-effects.js";
@@ -171,12 +172,36 @@ export function App() {
     });
   }, [callSession, roomSummary?.qualityCap]);
 
-  const { rung: downgradeRung, restore: restoreQuality } = useAutoDowngrade({
+  const { rung: downgradeRung, lastTransitionAt, restore: restoreQuality } = useAutoDowngrade({
     callStatus,
     networkHealth,
     room: callRoom,
     basePublishOptions,
   });
+
+  const { promptState: audioOnlyPromptState, accept: acceptAudioOnlyPrompt, dismiss: dismissAudioOnlyPrompt } =
+    useAudioOnlyPrompt({
+      rung: downgradeRung,
+      lastRungTransitionAt: lastTransitionAt,
+    });
+
+  // Accepting the audio-only suggestion locks the session into audio-only by
+  // updating the stored session and bumping advanced prefs on the fly. The
+  // auto-downgrade hook then keeps the ladder at its current rung because
+  // `basePublishOptions.audioOnly` is now true.
+  const handleAcceptAudioOnly = useCallback(() => {
+    acceptAudioOnlyPrompt();
+    if (viewState.kind === "call" && callSession != null) {
+      const nextSession = {
+        ...callSession,
+        advancedPrefs: {
+          ...(callSession.advancedPrefs ?? {}),
+          audioOnly: true,
+        },
+      };
+      saveStoredCallSession(window.sessionStorage, viewState.slug, nextSession);
+    }
+  }, [acceptAudioOnlyPrompt, callSession, viewState]);
   const {
     handleInstallApp,
     installMessage,
@@ -405,6 +430,7 @@ export function App() {
   return (
     <AppShell
       callPageProps={{
+        audioOnlyPromptState,
         callError,
         callParticipants,
         callSession,
@@ -419,6 +445,8 @@ export function App() {
         isTogglingMic,
         localVideoRef,
         networkHealth,
+        onAcceptAudioOnly: handleAcceptAudioOnly,
+        onDismissAudioOnly: dismissAudioOnlyPrompt,
         onLeaveCall: handleLeaveCall,
         onRestoreQuality: restoreQuality,
         onToggleCamera: handleToggleCamera,

--- a/apps/web/src/audio-only-prompt.test.ts
+++ b/apps/web/src/audio-only-prompt.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  computePromptState,
+  DISMISS_COOLDOWN_MS,
+  PROMPT_TRIGGER_MS,
+  type PromptState,
+} from "./audio-only-prompt.js";
+
+test("computePromptState: returns hidden when rung is not video-paused (from any state)", () => {
+  const states: PromptState[] = ["hidden", "suggested", "accepted", "dismissed"];
+  for (const state of states) {
+    const result = computePromptState({
+      now: 1_000_000,
+      rung: "none",
+      lastRungTransitionAt: 0,
+      currentState: state,
+      dismissedAt: 500_000,
+    });
+    assert.equal(result.next, "hidden", `state=${state} should reset to hidden off-rung`);
+    assert.equal(result.dismissedAt, null);
+  }
+});
+
+test("computePromptState: fires suggested after the trigger window elapses", () => {
+  const result = computePromptState({
+    now: PROMPT_TRIGGER_MS,
+    rung: "video-paused",
+    lastRungTransitionAt: 0,
+    currentState: "hidden",
+    dismissedAt: null,
+  });
+  assert.equal(result.next, "suggested");
+  assert.equal(result.dismissedAt, null);
+});
+
+test("computePromptState: holds at hidden while the streak is below the trigger", () => {
+  const result = computePromptState({
+    now: PROMPT_TRIGGER_MS - 1,
+    rung: "video-paused",
+    lastRungTransitionAt: 0,
+    currentState: "hidden",
+    dismissedAt: null,
+  });
+  assert.equal(result.next, "hidden");
+});
+
+test("computePromptState: accepted is terminal while on video-paused", () => {
+  const result = computePromptState({
+    now: 10 * PROMPT_TRIGGER_MS,
+    rung: "video-paused",
+    lastRungTransitionAt: 0,
+    currentState: "accepted",
+    dismissedAt: null,
+  });
+  assert.equal(result.next, "accepted");
+});
+
+test("computePromptState: dismissed re-suggests after the cooldown elapses", () => {
+  const dismissedAt = 1_000_000;
+  // Before cooldown: stay dismissed.
+  const duringCooldown = computePromptState({
+    now: dismissedAt + DISMISS_COOLDOWN_MS - 1,
+    rung: "video-paused",
+    lastRungTransitionAt: 0,
+    currentState: "dismissed",
+    dismissedAt,
+  });
+  assert.equal(duringCooldown.next, "dismissed");
+
+  // After cooldown + the trigger window: re-suggest.
+  const afterCooldown = computePromptState({
+    now: dismissedAt + DISMISS_COOLDOWN_MS + PROMPT_TRIGGER_MS,
+    rung: "video-paused",
+    lastRungTransitionAt: dismissedAt + DISMISS_COOLDOWN_MS,
+    currentState: "dismissed",
+    dismissedAt,
+  });
+  assert.equal(afterCooldown.next, "suggested");
+});
+
+test("computePromptState: dismissed holds if the trigger window has not re-elapsed", () => {
+  const dismissedAt = 1_000_000;
+  const result = computePromptState({
+    // Cooldown elapsed but the rung streak is young.
+    now: dismissedAt + DISMISS_COOLDOWN_MS + 100,
+    rung: "video-paused",
+    lastRungTransitionAt: dismissedAt + DISMISS_COOLDOWN_MS + 50,
+    currentState: "dismissed",
+    dismissedAt,
+  });
+  // The helper cleared dismissed, but the streak is only 50 ms so stays hidden.
+  assert.equal(result.next, "hidden");
+});
+
+test("computePromptState: the state never transitions backward on its own", () => {
+  // suggested is idempotent while rung holds and the streak is above the trigger.
+  const result = computePromptState({
+    now: 2 * PROMPT_TRIGGER_MS,
+    rung: "video-paused",
+    lastRungTransitionAt: 0,
+    currentState: "suggested",
+    dismissedAt: null,
+  });
+  assert.equal(result.next, "suggested");
+});

--- a/apps/web/src/audio-only-prompt.ts
+++ b/apps/web/src/audio-only-prompt.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { DowngradeRung } from "./auto-downgrade.js";
+
+export type PromptState = "hidden" | "suggested" | "accepted" | "dismissed";
+
+export const PROMPT_TRIGGER_MS = 30_000;
+export const DISMISS_COOLDOWN_MS = 60_000;
+
+export interface ComputePromptStateInput {
+  now: number;
+  rung: DowngradeRung;
+  lastRungTransitionAt: number;
+  currentState: PromptState;
+  dismissedAt: number | null;
+}
+
+export interface ComputePromptStateResult {
+  next: PromptState;
+  dismissedAt: number | null;
+}
+
+/**
+ * Pure state-machine step for the audio-only prompt.
+ *
+ *   hidden → suggested: fires when the downgrade ladder has held
+ *     `"video-paused"` for at least `PROMPT_TRIGGER_MS` without a
+ *     user-initiated restore (`lastRungTransitionAt` marks when the rung
+ *     was set, which the auto-downgrade hook owns).
+ *   suggested → accepted: terminal for the rest of the call.
+ *   suggested → dismissed: 60-second cooldown before `hidden → suggested`
+ *     can fire again.
+ *
+ * Any rung that is NOT `"video-paused"` forces the state back to
+ * `"hidden"` and clears any pending dismiss cooldown; the user resumed
+ * video one way or another and should not carry stale prompt state.
+ */
+export function computePromptState(
+  input: ComputePromptStateInput,
+): ComputePromptStateResult {
+  const { now, rung, lastRungTransitionAt, currentState, dismissedAt } = input;
+
+  if (rung !== "video-paused") {
+    return { next: "hidden", dismissedAt: null };
+  }
+
+  if (currentState === "accepted") {
+    return { next: "accepted", dismissedAt };
+  }
+
+  if (currentState === "dismissed") {
+    if (dismissedAt != null && now - dismissedAt >= DISMISS_COOLDOWN_MS) {
+      // Re-eligible; fall through to the "suggested" logic below.
+      return evaluateTrigger(now, lastRungTransitionAt, "hidden", null);
+    }
+    return { next: "dismissed", dismissedAt };
+  }
+
+  return evaluateTrigger(now, lastRungTransitionAt, currentState, dismissedAt);
+}
+
+function evaluateTrigger(
+  now: number,
+  lastRungTransitionAt: number,
+  currentState: PromptState,
+  dismissedAt: number | null,
+): ComputePromptStateResult {
+  const streak = now - lastRungTransitionAt;
+  if (streak >= PROMPT_TRIGGER_MS && currentState === "hidden") {
+    return { next: "suggested", dismissedAt: null };
+  }
+  return { next: currentState, dismissedAt };
+}
+
+export interface UseAudioOnlyPromptInput {
+  rung: DowngradeRung;
+  lastRungTransitionAt: number;
+  now?: () => number;
+  intervalMs?: number;
+}
+
+export interface UseAudioOnlyPromptState {
+  promptState: PromptState;
+  accept: () => void;
+  dismiss: () => void;
+}
+
+const DEFAULT_INTERVAL_MS = 3_000;
+
+export function useAudioOnlyPrompt(
+  input: UseAudioOnlyPromptInput,
+): UseAudioOnlyPromptState {
+  const now = input.now ?? (() => Date.now());
+  const intervalMs = input.intervalMs ?? DEFAULT_INTERVAL_MS;
+
+  const [promptState, setPromptState] = useState<PromptState>("hidden");
+  const [dismissedAt, setDismissedAt] = useState<number | null>(null);
+
+  const stateRef = useRef<PromptState>("hidden");
+  const dismissedAtRef = useRef<number | null>(null);
+  stateRef.current = promptState;
+  dismissedAtRef.current = dismissedAt;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const tick = () => {
+      if (cancelled) return;
+      const result = computePromptState({
+        now: now(),
+        rung: input.rung,
+        lastRungTransitionAt: input.lastRungTransitionAt,
+        currentState: stateRef.current,
+        dismissedAt: dismissedAtRef.current,
+      });
+      if (result.next !== stateRef.current) {
+        setPromptState(result.next);
+      }
+      if (result.dismissedAt !== dismissedAtRef.current) {
+        setDismissedAt(result.dismissedAt);
+      }
+    };
+
+    // Evaluate eagerly on any rung change; this covers the "leaves
+    // video-paused" reset without waiting for a tick.
+    tick();
+
+    if (input.rung !== "video-paused") {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const handle = setInterval(tick, intervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, [input.rung, input.lastRungTransitionAt, intervalMs, now]);
+
+  const accept = useCallback(() => {
+    setPromptState("accepted");
+    setDismissedAt(null);
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setPromptState("dismissed");
+    setDismissedAt(now());
+  }, [now]);
+
+  return { promptState, accept, dismiss };
+}

--- a/apps/web/src/auto-downgrade.ts
+++ b/apps/web/src/auto-downgrade.ts
@@ -165,6 +165,7 @@ export interface UseAutoDowngradeInput {
 
 export interface UseAutoDowngradeState {
   rung: DowngradeRung;
+  lastTransitionAt: number;
   restore: () => void;
 }
 
@@ -181,6 +182,7 @@ export function useAutoDowngrade(input: UseAutoDowngradeInput): UseAutoDowngrade
   const intervalMs = input.intervalMs ?? DEFAULT_INTERVAL_MS;
 
   const [rung, setRung] = useState<DowngradeRung>("none");
+  const [lastTransitionAt, setLastTransitionAt] = useState<number>(now());
   const rungRef = useRef<DowngradeRung>("none");
   const lastTransitionAtRef = useRef<number>(now());
 
@@ -191,6 +193,7 @@ export function useAutoDowngrade(input: UseAutoDowngradeInput): UseAutoDowngrade
       rungRef.current = "none";
       lastTransitionAtRef.current = now();
       setRung("none");
+      setLastTransitionAt(lastTransitionAtRef.current);
       return;
     }
 
@@ -208,6 +211,7 @@ export function useAutoDowngrade(input: UseAutoDowngradeInput): UseAutoDowngrade
         rungRef.current = result.next;
         lastTransitionAtRef.current = result.lastTransitionAt;
         setRung(result.next);
+        setLastTransitionAt(result.lastTransitionAt);
       }
     };
 
@@ -286,9 +290,10 @@ export function useAutoDowngrade(input: UseAutoDowngradeInput): UseAutoDowngrade
     rungRef.current = "none";
     lastTransitionAtRef.current = now();
     setRung("none");
+    setLastTransitionAt(lastTransitionAtRef.current);
   }, [now]);
 
-  return { rung, restore };
+  return { rung, lastTransitionAt, restore };
 }
 
 export function getRungLabel(rung: DowngradeRung): string {

--- a/apps/web/src/features/call/call-page.tsx
+++ b/apps/web/src/features/call/call-page.tsx
@@ -5,6 +5,7 @@ import type { NetworkHealth } from "../../network-health.js";
 import { getNetworkHealthLabel } from "../../network-health.js";
 import type { DowngradeRung } from "../../auto-downgrade.js";
 import { getRungLabel } from "../../auto-downgrade.js";
+import type { PromptState } from "../../audio-only-prompt.js";
 import {
   callFactsStyle,
   callHeaderBadgeRowStyle,
@@ -46,9 +47,12 @@ interface CallPageProps {
   remoteVideoRef: RefObject<HTMLVideoElement | null>;
   slug: string;
   downgradeRung: DowngradeRung;
+  audioOnlyPromptState: PromptState;
   onBackToJoin: () => void;
   onLeaveCall: () => void;
   onRestoreQuality: () => void;
+  onAcceptAudioOnly: () => void;
+  onDismissAudioOnly: () => void;
   onToggleCamera: () => Promise<void>;
   onToggleMicrophone: () => Promise<void>;
 }
@@ -78,6 +82,22 @@ export function CallPage(props: CallPageProps) {
           <button type="button" onClick={props.onRestoreQuality}>
             Restore video
           </button>
+        </section>
+      ) : null}
+      {props.audioOnlyPromptState === "suggested" ? (
+        <section role="dialog" aria-labelledby="audio-only-prompt-heading">
+          <h2 id="audio-only-prompt-heading">Network still unstable</h2>
+          <p style={mutedParagraphStyle}>
+            We had to pause your video because the network kept dropping. Would you like to continue audio-only, or keep retrying video?
+          </p>
+          <div>
+            <button type="button" onClick={props.onAcceptAudioOnly} autoFocus>
+              Continue audio-only
+            </button>{" "}
+            <button type="button" onClick={props.onDismissAudioOnly}>
+              Keep trying video
+            </button>
+          </div>
         </section>
       ) : null}
       {props.callSession ? (

--- a/docs/04-media-and-quality.md
+++ b/docs/04-media-and-quality.md
@@ -91,6 +91,8 @@ AudioOnlySuggested --> Healthy: network recovers and user re-enables video
 VideoPaused --> Healthy: network recovers and policy allows restore
 ```
 
+`VideoPaused → AudioOnlySuggested` is implemented by [`apps/web/src/audio-only-prompt.ts`](../apps/web/src/audio-only-prompt.ts). After 30 consecutive seconds at the `"video-paused"` downgrade rung, a `role="dialog"` banner on the call page offers "Continue audio-only" (locks the session into audio-only by flipping `advancedPrefs.audioOnly = true`) or "Keep trying video" (dismisses for a 60 second cooldown so the auto-downgrade hook can continue to walk the ladder if the network recovers).
+
 ## Screen Share Rules
 - Support desktop screen share in browsers that expose screen-capture APIs.
 - Hide the control on unsupported devices instead of blocking call entry.


### PR DESCRIPTION
## Summary
Implements issue #21 (Phase 3: Audio-only prompt flow).

- Pure `computePromptState({ now, rung, lastRungTransitionAt, currentState, dismissedAt })` state machine in `apps/web/src/audio-only-prompt.ts`.
- `useAudioOnlyPrompt` hook re-evaluates on rung changes and on a 3s timer while `rung === \"video-paused\"`. Fires `suggested` after 30 s at that rung; dismissals cooldown for 60 s before re-eligible.
- `useAutoDowngrade` now exposes `lastTransitionAt` alongside the rung so the prompt hook can read it without touching internals.
- Call page renders a `role=\"dialog\"` banner while the prompt is suggested. Accepting sets `advancedPrefs.audioOnly = true` on the stored session so the next `basePublishOptions` evaluation keeps the camera off. Dismissing starts the cooldown.

Closes #21.

## Out of scope (tracked separately)
- Server-side enforcement via signaling (#19)
- Telemetry on accept/dismiss rates (observability roadmap)

## Verification
    npm run lint        # all workspaces clean
    npm run typecheck   # all workspaces clean
    npm run test        # 152 server + 96 web + 8 shared = 256 tests, all pass
    npm run build       # succeeds