### PR TITLE
chore: add project-specific skill for LowTime development

### DIFF
--- a/.opencode/skills/lowtime-developing/SKILL.md
+++ b/.opencode/skills/lowtime-developing/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: lowtime-developing
-description: Use when working on LowTime ÔÇö a low-bandwidth FaceTime-like WebRTC app. Triggers on web/server code in apps/, packages/shared, docs/, TODO.md, call/room feature work, LiveKit, SFU/P2P fallback, quality presets, media adaptation, signaling, or PRs.
+description: Use when working on LowTime — a low-bandwidth FaceTime-like WebRTC app. Triggers on web/server code in apps/, packages/shared, docs/, TODO.md, call/room feature work, LiveKit, SFU/P2P fallback, quality presets, media adaptation, signaling, or PRs.
 ---
 
 # LowTime Developing
 
 ## What LowTime Is
 - Low-bandwidth WebRTC video call app: SFU-first, P2P fallback for 1:1, in-memory state.
-- User promise: stay on the call even when network is bad ÔÇö adapt before dropping.
+- User promise: stay on the call even when network is bad — adapt before dropping.
 
 ## Core Principle: Bandwidth Is Sacred
 Every new feature spends bytes. Default to the cheapest option that works.
 
 - New video/screen source: must justify bandwidth cost in `docs/04-media-and-quality.md`.
 - New toggle/control: prefer adding to existing `AdvancedMediaPrefs` shape, not inventing a new payload.
-- New signaling event: route through `WS /signal` and `SignalBus` (`apps/server/src/domain/signal-bus.ts`) ÔÇö do not add new HTTP routes for ephemeral state.
+- New signaling event: route through `WS /signal` and `SignalBus` (`apps/server/src/domain/signal-bus.ts`) — do not add new HTTP routes for ephemeral state.
 - Default to `Balanced` preset for any new publish path. Never `Best Quality` as default.
 
 ## Architecture Map (read before changing)
@@ -26,7 +26,7 @@ Every new feature spends bytes. Default to the cheapest option that works.
 | Server routes | `apps/server/src/routes/` | One file per route group (rooms, lobby, media, signal) |
 | Server domain | `apps/server/src/domain/` | Pure logic: room-store, room-cleanup, room-activity, signal-bus, validation |
 | Shared types | `packages/shared/src/index.ts` | Contract types consumed by both apps |
-| Docs | `docs/` | Source of truth ÔÇö update in same PR as code |
+| Docs | `docs/` | Source of truth — update in same PR as code |
 
 ## Mandatory Workflow (from `docs/13-issue-branch-pr-workflow.md`)
 1. Pick or open a GitHub issue first. Use `.github/ISSUE_TEMPLATE/feature.yml` or `bug.yml`.
@@ -38,16 +38,16 @@ Every new feature spends bytes. Default to the cheapest option that works.
 
 ## Test Conventions
 - Web unit tests: `apps/web/src/<file>.test.ts` using `node:test` + `node:assert/strict` (see `package.json` test script).
-- Pattern: pure helpers in their own `.ts` file with sibling `.test.ts`. No React Testing Library ÔÇö use a plain object mocking style (see `call-experience.test.ts`).
+- Pattern: pure helpers in their own `.ts` file with sibling `.test.ts`. No React Testing Library — use a plain object mocking style (see `call-experience.test.ts`).
 - Run: `npm test` (workspace) or `npm --workspace apps/web test`.
 - Lint: `npm run lint` (max-warnings 0).
 
 ## Source-Of-Truth Doc Rules
-- `docs/04-media-and-quality.md` ÔÇö any change to media transport, presets, downgrade, screen share, advanced controls.
-- `docs/05-api-and-realtime-contracts.md` ÔÇö any new endpoint, signaling event, or payload shape.
-- `docs/06-data-model-and-lifecycle.md` ÔÇö any change to session, room, or stored state.
-- `docs/09-security-and-abuse.md` ÔÇö any change to auth, rate limit, passcode, lobby.
-- `TODO.md` ÔÇö every status change.
+- `docs/04-media-and-quality.md` — any change to media transport, presets, downgrade, screen share, advanced controls.
+- `docs/05-api-and-realtime-contracts.md` — any new endpoint, signaling event, or payload shape.
+- `docs/06-data-model-and-lifecycle.md` — any change to session, room, or stored state.
+- `docs/09-security-and-abuse.md` — any change to auth, rate limit, passcode, lobby.
+- `TODO.md` — every status change.
 - ADR required when changing: default transport, access model, persistence model, install surface, or quality policy.
 
 ## Definition Of Done (from `CONTRIBUTING.md`)
@@ -62,14 +62,14 @@ Every new feature spends bytes. Default to the cheapest option that works.
 - **Preset** = `Data Saver` | `Balanced` | `Best Quality` (user choice).
 - **Quality cap** = host-imposed ceiling on preset. Always clamps before user.
 - **AdvancedMediaPrefs** = 6 user overrides; can only tighten, never loosen, the cap+preset baseline.
-- **Rung** = one step in the downgrade ladder (`bitrate ÔåÆ resolution ÔåÆ fps ÔåÆ video-paused`).
+- **Rung** = one step in the downgrade ladder (`bitrate → resolution → fps → video-paused`).
 - **Tile** = a `<video>` element in the call layout (remote + self).
 - **Session** = per-tab `StoredCallSession`; cleared on leave.
 
 ## Common Mistakes
-- Touching `App.tsx` directly ÔÇö page logic lives in `features/<area>/`.
-- Adding a new HTTP route for ephemeral state ÔÇö use `SignalBus` instead.
-- Forgetting `npm run lint` after edits ÔÇö CI fails on any warning.
+- Touching `App.tsx` directly — page logic lives in `features/<area>/`.
+- Adding a new HTTP route for ephemeral state — use `SignalBus` instead.
+- Forgetting `npm run lint` after edits — CI fails on any warning.
 - Marking a feature `done` in `TODO.md` before tests + docs land.
-- Skipping the issue/PR template ÔÇö `babico` and `codex` auto-review require the structured context.
-- Optimistic bandwidth defaults ÔÇö every new path must check `docs/04` for the right baseline.
+- Skipping the issue/PR template — `babico` and `codex` auto-review require the structured context.
+- Optimistic bandwidth defaults — every new path must check `docs/04` for the right baseline.


### PR DESCRIPTION
## Summary
Adds the project-specific skill that future agents should read before working on LowTime code, docs, or `TODO.md`.

## Why
A new contributor (human or agent) had no single entry point that combined:
- The bandwidth-first principle that drives every product decision in LowTime.
- The architecture map (web routes vs features vs shared helpers, server routes vs domain, shared types).
- The mandatory workflow (issue → branch → PR, TODO.md status flips, source-of-truth doc updates).
- Test, lint, and typecheck conventions.
- The exact project vocabulary (SFU vs P2P, preset vs cap, rung, tile, session).

That context is scattered across `CONTRIBUTING.md`, `docs/13-issue-branch-pr-workflow.md`, and the codebase. A skill at `.opencode/skills/lowtime-developing/SKILL.md` makes it discoverable.

## What changed
- New file: `.opencode/skills/lowtime-developing/SKILL.md` (75 lines).

## Notes
- Skill is descriptive, not executable. No behavior change in `apps/`, `packages/`, or `docs/`.
- Triggers on LowTime-specific paths and concepts (apps/, packages/shared, call/room, LiveKit, SFU/P2P, quality presets).
- Mirrors the language and structure used by other skills in the superpowers plugin so a future agent will recognize and load it.
