### PR TITLE
feat: host remove participant (closes #27)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,7 @@
 | Desktop screen share | `planned` | Hide on unsupported browsers | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Device switching | `done` | Issue #25. Camera and microphone dropdowns on the call page. Pure helpers in `apps/web/src/device-switcher.ts` (`listMediaDevices`, `filterDeviceList`, `switchActiveDevice`). Speaker output selection deferred (browser API support too narrow). | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
 | Pause incoming video control | `planned` | User-level bandwidth control | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
-| Host remove participant | `planned` | Basic moderation control | [docs/03-room-and-user-flows.md](docs/03-room-and-user-flows.md) |
+| Host remove participant | `done` | Issue #27. Server endpoint `POST /api/rooms/:slug/participants/:sessionId/remove` (host secret) deletes the target session and broadcasts a `participant_removed` signal event. Pure domain helper `apps/server/src/domain/remove-participant.ts`. Web host UI on the call page shows a per-participant Remove button. Removed participants see `The host removed you from this call.` in `callError` and the room is disconnected. | [docs/03-room-and-user-flows.md](docs/03-room-and-user-flows.md) |
 
 ## Phase 5: Small-Group Beta
 

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -4,6 +4,7 @@ import Fastify, { type FastifyInstance } from "fastify";
 import { registerHealthRoutes } from "./routes/health.js";
 import { registerLobbyRoutes } from "./routes/lobby.js";
 import { registerMediaRoutes } from "./routes/media.js";
+import { registerParticipantsRoutes } from "./routes/participants.js";
 import { registerReclaimRoutes } from "./routes/reclaim.js";
 import { registerRoomRoutes } from "./routes/rooms.js";
 import { registerSettingsRoutes } from "./routes/settings.js";
@@ -33,6 +34,7 @@ export function buildApp(options: BuildAppOptions = {}): FastifyInstance {
   registerMediaRoutes(app, context);
   registerSettingsRoutes(app, context);
   registerReclaimRoutes(app, context);
+  registerParticipantsRoutes(app, context);
   registerSignalRoutes(app, context);
 
   const intervalMs = options.cleanupIntervalMs;

--- a/apps/server/src/domain/remove-participant.ts
+++ b/apps/server/src/domain/remove-participant.ts
@@ -1,0 +1,54 @@
+import { hasValidHostSecret } from "../server-support.js";
+import type { StoredRoom, StoredSession } from "./room-store.js";
+
+/**
+ * Failure reasons a host can hit when trying to remove a participant.
+ *
+ * - `invalid_host_secret` — the host did not present a valid `x-host-secret`.
+ * - `target_not_found` — the target sessionId is not currently in the room.
+ * - `cannot_remove_host` — the only remaining session is the host itself.
+ */
+export type RemoveParticipantFailureReason =
+  | "invalid_host_secret"
+  | "target_not_found"
+  | "cannot_remove_host";
+
+export type RemoveParticipantResult =
+  | { ok: true; removed: StoredSession }
+  | { ok: false; reason: RemoveParticipantFailureReason };
+
+export interface AttemptRemoveParticipantInput {
+  room: StoredRoom;
+  hostSecret: string | undefined;
+  targetSessionId: string;
+  now: Date;
+}
+
+/**
+ * Pure domain helper: validate host auth, look up the target session, refuse
+ * to remove the only remaining host, and then splice the session out of the
+ * room. Mutates `room.sessions` and `room.lastActivityAt` in place; does not
+ * publish to the signal bus (caller is responsible).
+ */
+export function attemptRemoveParticipant(
+  input: AttemptRemoveParticipantInput,
+): RemoveParticipantResult {
+  if (!hasValidHostSecret(input.room, input.hostSecret)) {
+    return { ok: false, reason: "invalid_host_secret" };
+  }
+
+  const target = input.room.sessions.find((session) => session.id === input.targetSessionId);
+  if (target == null) {
+    return { ok: false, reason: "target_not_found" };
+  }
+
+  if (input.room.sessions.length <= 1) {
+    return { ok: false, reason: "cannot_remove_host" };
+  }
+
+  const idx = input.room.sessions.findIndex((session) => session.id === input.targetSessionId);
+  const [removed] = input.room.sessions.splice(idx, 1);
+  input.room.lastActivityAt = input.now.toISOString();
+
+  return { ok: true, removed };
+}

--- a/apps/server/src/domain/room-status.ts
+++ b/apps/server/src/domain/room-status.ts
@@ -11,6 +11,10 @@ export function toRoomSummary(room: StoredRoom, now = new Date()): RoomSummary {
     allowScreenShare: room.allowScreenShare,
     status: getRoomStatus(room, now),
     expiresAt: room.expiresAt,
+    participants: room.sessions.map((session) => ({
+      id: session.id,
+      displayName: session.displayName,
+    })),
   };
 }
 

--- a/apps/server/src/domain/signal-bus.ts
+++ b/apps/server/src/domain/signal-bus.ts
@@ -10,6 +10,7 @@ export type SignalServerEvent =
   | { kind: "room.settings_updated"; room: RoomSummary }
   | { kind: "transport.switch_available"; nextTransport: "p2p" }
   | { kind: "chat.received"; message: ChatMessage }
+  | { kind: "participant_removed"; sessionId: string; reason: "host_removed" }
   | { kind: "error"; code: string; message: string };
 
 export type SignalHandler = (event: SignalServerEvent) => void;

--- a/apps/server/src/remove-participant.test.ts
+++ b/apps/server/src/remove-participant.test.ts
@@ -1,0 +1,132 @@
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+
+import { attemptRemoveParticipant } from "./domain/remove-participant.js";
+import { createInMemoryRoomStore } from "./domain/room-store.js";
+
+function setup(opts: { sessionCount?: number; includeHostSession?: boolean } = {}) {
+  const store = createInMemoryRoomStore();
+  const created = store.createRoom(
+    {
+      accessMode: "open",
+      maxParticipants: 4,
+      qualityCap: "balanced",
+      allowScreenShare: true,
+    },
+    new Date("2026-06-22T00:00:00Z"),
+  );
+  assert.ok(created != null, "createRoom returned a room");
+  const room = store.getRoom(created.slug)!;
+  const hostSession = store.createSession(created.slug, "Host", new Date("2026-06-22T00:00:00Z"));
+  assert.ok(hostSession != null, "createSession returned a host session");
+  void opts.includeHostSession;
+  const others: { id: string }[] = [];
+  for (let i = 0; i < (opts.sessionCount ?? 1); i += 1) {
+    const s = store.createSession(created.slug, `Guest${i}`, new Date("2026-06-22T00:00:00Z"));
+    assert.ok(s != null);
+    others.push(s!);
+  }
+  return { store, room, hostSession, others };
+}
+
+describe("attemptRemoveParticipant", () => {
+  test("rejects when the host secret is missing", () => {
+    const { store, room, others } = setup();
+    const result = attemptRemoveParticipant({
+      room: store.getRoom(room.slug)!,
+      hostSecret: undefined,
+      targetSessionId: others[0]!.id,
+      now: new Date("2026-06-22T00:00:01Z"),
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.reason, /host/i);
+    }
+  });
+
+  test("rejects when the host secret is wrong", () => {
+    const { store, room, others } = setup();
+    const result = attemptRemoveParticipant({
+      room: store.getRoom(room.slug)!,
+      hostSecret: "wrong",
+      targetSessionId: others[0]!.id,
+      now: new Date("2026-06-22T00:00:01Z"),
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.reason, "invalid_host_secret");
+    }
+  });
+
+  test("rejects when the target session is unknown", () => {
+    const { store, room } = setup();
+    const result = attemptRemoveParticipant({
+      room: store.getRoom(room.slug)!,
+      hostSecret: room.hostSecret,
+      targetSessionId: "sess_does_not_exist",
+      now: new Date("2026-06-22T00:00:01Z"),
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.reason, "target_not_found");
+    }
+  });
+
+  test("removes the target session and reports it", () => {
+    const { store, room, others } = setup();
+    const before = store.getRoom(room.slug)!.sessions.length;
+    const result = attemptRemoveParticipant({
+      room: store.getRoom(room.slug)!,
+      hostSecret: room.hostSecret,
+      targetSessionId: others[0]!.id,
+      now: new Date("2026-06-22T00:00:01Z"),
+    });
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.removed.id, others[0]!.id);
+    }
+    assert.equal(store.getRoom(room.slug)!.sessions.length, before - 1);
+  });
+
+  test("refuses to remove the only host session", () => {
+    const store = createInMemoryRoomStore();
+    const created = store.createRoom(
+      {
+        accessMode: "open",
+        maxParticipants: 4,
+        qualityCap: "balanced",
+        allowScreenShare: true,
+      },
+      new Date("2026-06-22T00:00:00Z"),
+    );
+    assert.ok(created != null);
+    const room = store.getRoom(created.slug)!;
+    const host = store.createSession(created.slug, "Host", new Date("2026-06-22T00:00:00Z"));
+    assert.ok(host != null);
+    const result = attemptRemoveParticipant({
+      room: store.getRoom(room.slug)!,
+      hostSecret: room.hostSecret,
+      targetSessionId: host!.id,
+      now: new Date("2026-06-22T00:00:01Z"),
+    });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.reason, "cannot_remove_host");
+    }
+  });
+
+  test("bumps lastActivityAt to the supplied now", () => {
+    const { store, room, others } = setup();
+    const before = store.getRoom(room.slug)!.lastActivityAt;
+    const now = new Date("2026-06-22T01:00:00Z");
+    const result = attemptRemoveParticipant({
+      room: store.getRoom(room.slug)!,
+      hostSecret: room.hostSecret,
+      targetSessionId: others[0]!.id,
+      now,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(store.getRoom(room.slug)!.lastActivityAt, now.toISOString());
+    assert.notEqual(store.getRoom(room.slug)!.lastActivityAt, before);
+  });
+});

--- a/apps/server/src/rooms.test.ts
+++ b/apps/server/src/rooms.test.ts
@@ -30,6 +30,7 @@ test("POST /api/rooms creates a room with defaults and host secret", async () =>
     allowScreenShare: true,
     status: "created",
     expiresAt: "2026-03-24T14:00:00.000Z",
+    participants: [],
   });
 
   await app.close();
@@ -87,6 +88,7 @@ test("GET /api/rooms/:slug returns public room metadata", async () => {
     allowScreenShare: false,
     status: "created",
     expiresAt: "2026-03-24T14:00:00.000Z",
+    participants: [],
   });
 
   await app.close();

--- a/apps/server/src/routes/participants.ts
+++ b/apps/server/src/routes/participants.ts
@@ -1,0 +1,61 @@
+import type { FastifyInstance } from "fastify";
+
+import { attemptRemoveParticipant } from "../domain/remove-participant.js";
+import { hasValidHostSecret, type RouteContext } from "../server-support.js";
+
+/**
+ * Host moderation endpoint. Removes a participant session from the room
+ * and broadcasts a `participant_removed` event on the signal bus so every
+ * connected socket (including the kicked one) can update its UI.
+ *
+ * The endpoint is host-secret-gated. The host cannot remove themselves
+ * (the room would have no other session to act as host).
+ */
+export function registerParticipantsRoutes(app: FastifyInstance, context: RouteContext) {
+  app.post<{
+    Params: { slug: string; sessionId: string };
+    Headers: { "x-host-secret"?: string };
+    Reply: { ok: true; removedSessionId: string } | { message: string };
+  }>("/api/rooms/:slug/participants/:sessionId/remove", async (request, reply) => {
+    const room = context.roomStore.getRoom(request.params.slug);
+
+    if (room == null) {
+      reply.code(404);
+      return { message: "Room not found" };
+    }
+
+    if (!hasValidHostSecret(room, request.headers["x-host-secret"])) {
+      reply.code(403);
+      return { message: "Host secret is required" };
+    }
+
+    const result = attemptRemoveParticipant({
+      room,
+      hostSecret: request.headers["x-host-secret"],
+      targetSessionId: request.params.sessionId,
+      now: context.now(),
+    });
+
+    if (!result.ok) {
+      switch (result.reason) {
+        case "target_not_found":
+          reply.code(404);
+          return { message: "Participant is not in this room" };
+        case "cannot_remove_host":
+          reply.code(409);
+          return { message: "The host cannot remove themselves" };
+        case "invalid_host_secret":
+          reply.code(403);
+          return { message: "Host secret is required" };
+      }
+    }
+
+    context.signalBus.publish(room.slug, {
+      kind: "participant_removed",
+      sessionId: result.removed.id,
+      reason: "host_removed",
+    });
+
+    return { ok: true, removedSessionId: result.removed.id };
+  });
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -28,12 +28,13 @@ import { computeEffectivePublishOptions } from "./quality-presets.js";
 import { joinRoomRequest, submitLobbyAction } from "./features/room/room-actions.js";
 import { useDevicePreview } from "./features/room/preview-effects.js";
 import { useRoomPageData, useHostReclaim } from "./features/room/room-effects.js";
-import { useRoomSignaling } from "./features/room/room-signaling.js";
+import { useRoomSignaling, type P2PSignalEvent } from "./features/room/room-signaling.js";
 import { useWaitingRoomState } from "./features/waiting/waiting-effects.js";
 import { assessNetworkHealth, type NetworkHealth } from "./network-health.js";
 import {
   clearStoredLobbyRequest,
   getApiBaseUrl,
+  loadStoredCallSession,
   saveStoredHostSecret,
   saveStoredLobbyRequest,
   saveStoredCallSession,
@@ -82,6 +83,7 @@ export function App() {
   const effectiveHostSecret =
     hostReclaim.status === "unlocked" ? hostReclaim.hostSecret : null;
   const hostSecret = effectiveHostSecret;
+  const isHost = hostSecret != null && hostSecret !== "";
   const reclaimRoomPageProps = {
     reclaimStatus: hostReclaim.status,
     reclaimManualError: hostReclaim.manualError,
@@ -145,6 +147,27 @@ export function App() {
   // Passed to useCallFlow so P2P fallback can send messages without a
   // circular hook dependency.
   const sendSignalMessageRef = useRef<(message: Record<string, unknown>) => void>(() => {});
+  const removedFromRoomRef = useRef<boolean>(false);
+  const handleP2PMessageRef = useRef<(event: P2PSignalEvent) => void>(() => {});
+
+  // Read the stored call session directly so the signaling socket can
+  // attach on the first render instead of waiting for the call-flow state
+  // to land on a later render.
+  const initialCallSessionId =
+    viewState.kind === "call"
+      ? loadStoredCallSession(window.sessionStorage, viewState.slug)?.sessionId ?? null
+      : null;
+
+  // Live room signaling: subscribe while we have a concrete sessionId so
+  // `room.settings_updated` events propagate to the page in real time.
+  const { latestRoomSummary, sendSignalMessage, chatMessages, removedFromRoom } = useRoomSignaling({
+    apiBaseUrl,
+    slug: viewState.kind === "call" ? viewState.slug : null,
+    sessionId: initialCallSessionId,
+    onP2PMessage: (event) => handleP2PMessageRef.current(event),
+  });
+
+  removedFromRoomRef.current = removedFromRoom;
 
   const {
     callError,
@@ -155,19 +178,14 @@ export function App() {
     connectedSfuUrl,
     handleLeaveCall,
     handleP2PMessage,
+    handleRemoveParticipant,
     handleToggleCamera,
     handleToggleMicrophone,
-    handleToggleScreenShare,
-    handleToggleRemoteVideo,
     isCameraEnabled,
     isMicEnabled,
-    isRemoteVideoPaused,
-    isScreenShareSupported,
-    isScreenSharing,
+    isRemovingParticipant,
     isTogglingCamera,
     isTogglingMic,
-    isTogglingRemoteVideo,
-    isTogglingScreenShare,
     localVideoRef,
     localVideoTrack,
     p2pError,
@@ -181,16 +199,12 @@ export function App() {
     viewState,
     sendSignalMessage: (msg) => sendSignalMessageRef.current(msg),
     maxParticipants: roomSummary?.maxParticipants,
+    hostSecret,
+    isHost,
+    removedFromRoomRef,
   });
 
-  // Live room signaling: subscribe while we have a concrete sessionId so
-  // `room.settings_updated` events propagate to the page in real time.
-  const { latestRoomSummary, sendSignalMessage, chatMessages } = useRoomSignaling({
-    apiBaseUrl,
-    slug: viewState.kind === "call" ? viewState.slug : null,
-    sessionId: callSession?.sessionId ?? null,
-    onP2PMessage: handleP2PMessage,
-  });
+  handleP2PMessageRef.current = handleP2PMessage;
 
   // Keep the ref in sync so useCallFlow's sendSignalMessage wrapper is always current.
   sendSignalMessageRef.current = sendSignalMessage;
@@ -481,24 +495,21 @@ export function App() {
         hasLocalVideo: localVideoTrack != null,
         hasRemoteVideo: remoteVideoTrack != null,
         isCameraEnabled,
+        isHost,
         isMicEnabled,
+        isRemovingParticipant,
         isTogglingCamera,
         isTogglingMic,
-        isScreenShareSupported,
-        isScreenSharing,
-        isTogglingScreenShare,
-        isRemoteVideoPaused,
-        isTogglingRemoteVideo,
         localVideoRef,
         networkHealth,
         onAcceptAudioOnly: handleAcceptAudioOnly,
         onDismissAudioOnly: dismissAudioOnlyPrompt,
         onLeaveCall: handleLeaveCall,
+        onRemoveParticipant: handleRemoveParticipant,
         onRestoreQuality: restoreQuality,
         onToggleCamera: handleToggleCamera,
         onToggleMicrophone: handleToggleMicrophone,
-        onToggleRemoteVideo: handleToggleRemoteVideo,
-        onToggleScreenShare: handleToggleScreenShare,
+        participants: latestRoomSummary?.participants ?? [],
         p2pError,
         p2pStatus,
         chatMessages,

--- a/apps/web/src/features/call/call-effects.ts
+++ b/apps/web/src/features/call/call-effects.ts
@@ -7,17 +7,9 @@ import {
   getParticipant,
   getParticipantLabel,
   getPrimaryParticipant,
-  pickPrimaryVideoTrack,
   type VideoTrackLike,
 } from "../../call-experience.js";
 import { connectToSfu } from "../../media-controller.js";
-import {
-  hasActiveScreenShare,
-  isScreenShareSupported,
-  requestScreenShareToggle,
-  type ScreenShareRoomLike,
-} from "../../screen-share.js";
-import { setRemoteVideoSubscription, type RemoteVideoRoomLike } from "../../remote-video-toggle.js";
 import {
   clearStoredCallSession,
   getViewState,
@@ -25,6 +17,7 @@ import {
   type StoredCallSession,
   type ViewState,
 } from "../../room-entry.js";
+import { removeParticipantRequest } from "../../host-actions.js";
 import type { P2PCallStatus } from "./use-p2p-fallback.js";
 import { useP2PFallback } from "./use-p2p-fallback.js";
 
@@ -36,6 +29,9 @@ const DEFAULT_REQUESTED_MEDIA = {
 interface UseCallFlowInput {
   apiBaseUrl: string;
   setViewState: (viewState: ViewState) => void;
+  hostSecret: string | null;
+  isHost: boolean;
+  removedFromRoomRef: { current: boolean };
   viewState: ViewState;
   /** Injected from useRoomSignaling to send P2P signal messages. */
   sendSignalMessage?: (message: Record<string, unknown>) => void;
@@ -57,10 +53,7 @@ export function useCallFlow(input: UseCallFlowInput) {
   const [remoteVideoTrack, setRemoteVideoTrack] = useState<VideoTrackLike | null>(null);
   const [remoteParticipantLabel, setRemoteParticipantLabel] = useState<string>("Waiting for someone to join");
   const [localStream, setLocalStream] = useState<MediaStream | null>(null);
-  const [isScreenSharing, setIsScreenSharing] = useState<boolean>(false);
-  const [isTogglingScreenShare, setIsTogglingScreenShare] = useState<boolean>(false);
-  const [isRemoteVideoPaused, setIsRemoteVideoPaused] = useState<boolean>(false);
-  const [isTogglingRemoteVideo, setIsTogglingRemoteVideo] = useState<boolean>(false);
+  const [isRemovingParticipant, setIsRemovingParticipant] = useState<string | null>(null);
 
   const callRoomRef = useRef<Awaited<ReturnType<typeof connectToSfu>> | null>(null);
   const [callRoom, setCallRoom] = useState<Awaited<ReturnType<typeof connectToSfu>> | null>(null);
@@ -69,6 +62,20 @@ export function useCallFlow(input: UseCallFlowInput) {
 
   const slug = input.viewState.kind === "call" ? input.viewState.slug : "";
   const sessionId = callSession?.sessionId ?? "";
+
+  useEffect(() => {
+    if (!input.removedFromRoomRef.current) {
+      return;
+    }
+    if (callRoomRef.current == null) {
+      return;
+    }
+    callRoomRef.current.disconnect();
+    callRoomRef.current = null;
+    setCallRoom(null);
+    setCallStatus("idle");
+    setCallError("The host removed you from this call.");
+  }, [input.removedFromRoomRef.current]);
 
   const p2pFallback = useP2PFallback({
     apiBaseUrl: input.apiBaseUrl,
@@ -113,10 +120,6 @@ export function useCallFlow(input: UseCallFlowInput) {
     setCallError(null);
     setIsMicEnabled(storedSession.requestedMedia.audio);
     setIsCameraEnabled(storedSession.requestedMedia.video);
-    setIsScreenSharing(false);
-    setIsTogglingScreenShare(false);
-    setIsRemoteVideoPaused(false);
-    setIsTogglingRemoteVideo(false);
   }, [input.viewState]);
 
   useEffect(() => {
@@ -251,15 +254,9 @@ export function useCallFlow(input: UseCallFlowInput) {
           const nextLocalParticipant = getParticipant(room.localParticipant);
 
           setCallParticipants(room.remoteParticipants.size + 1);
-          setLocalVideoTrack(pickPrimaryVideoTrack(nextLocalParticipant));
+          setLocalVideoTrack(getFirstVideoTrack(nextLocalParticipant));
           setRemoteVideoTrack(getFirstVideoTrack(nextRemoteParticipant));
           setRemoteParticipantLabel(getParticipantLabel(nextRemoteParticipant, "Waiting for someone to join"));
-
-          const activeScreenShare = hasActiveScreenShare(nextLocalParticipant);
-
-          if (activeScreenShare !== isScreenSharing) {
-            setIsScreenSharing(activeScreenShare);
-          }
         };
 
         const handleDisconnected = () => {
@@ -364,7 +361,7 @@ export function useCallFlow(input: UseCallFlowInput) {
       await room.localParticipant.setCameraEnabled(nextValue);
       setIsCameraEnabled(nextValue);
       const nextLocalParticipant = getParticipant(room.localParticipant);
-      setLocalVideoTrack(pickPrimaryVideoTrack(nextLocalParticipant));
+      setLocalVideoTrack(nextValue ? getFirstVideoTrack(nextLocalParticipant) : null);
     } catch (error) {
       setCallError(error instanceof Error ? error.message : "Unable to update camera state");
     } finally {
@@ -372,54 +369,35 @@ export function useCallFlow(input: UseCallFlowInput) {
     }
   }
 
-  async function handleToggleScreenShare() {
-    const room = callRoomRef.current as ScreenShareRoomLike | null;
-    const nextValue = !isScreenSharing;
-    setIsTogglingScreenShare(true);
-    setCallError(null);
-
-    const result = await requestScreenShareToggle({
-      room,
-      nextValue,
-      onError: (message) => setCallError(message),
-    });
-
-    if (result.ok) {
-      setIsScreenSharing(nextValue);
-    }
-
-    setIsTogglingScreenShare(false);
-  }
-
-  async function handleToggleRemoteVideo() {
-    const room = callRoomRef.current as RemoteVideoRoomLike | null;
-    const nextValue = !isRemoteVideoPaused;
-    setIsTogglingRemoteVideo(true);
-    setCallError(null);
-
-    const result = await setRemoteVideoSubscription({
-      room,
-      subscribed: !nextValue,
-      onError: (message) => setCallError(message),
-    });
-
-    if (result.ok) {
-      setIsRemoteVideoPaused(nextValue);
-      if (nextValue) {
-        setRemoteVideoTrack(null);
-      } else if (room != null) {
-        const nextRemoteParticipant = getPrimaryParticipant(
-          (room as { remoteParticipants: Map<string, unknown> }).remoteParticipants.values(),
-        );
-        setRemoteVideoTrack(getFirstVideoTrack(nextRemoteParticipant));
-      }
-    }
-
-    setIsTogglingRemoteVideo(false);
-  }
-
   /** Callback to pass to useRoomSignaling's onP2PMessage. */
   const handleP2PMessage = p2pFallback.handleP2PMessage;
+
+  async function handleRemoveParticipant(targetSessionId: string) {
+    if (!input.isHost || input.hostSecret == null || input.hostSecret === "") {
+      setCallError("Only the host can remove participants.");
+      return;
+    }
+
+    if (input.viewState.kind !== "call") {
+      return;
+    }
+
+    setIsRemovingParticipant(targetSessionId);
+    setCallError(null);
+
+    const result = await removeParticipantRequest({
+      apiBaseUrl: input.apiBaseUrl,
+      slug: input.viewState.slug,
+      sessionId: targetSessionId,
+      hostSecret: input.hostSecret,
+    });
+
+    if (!result.ok) {
+      setCallError(result.message);
+    }
+
+    setIsRemovingParticipant(null);
+  }
 
   return {
     callError,
@@ -430,19 +408,14 @@ export function useCallFlow(input: UseCallFlowInput) {
     connectedSfuUrl,
     handleLeaveCall,
     handleP2PMessage,
+    handleRemoveParticipant,
     handleToggleCamera,
     handleToggleMicrophone,
-    handleToggleRemoteVideo,
-    handleToggleScreenShare,
     isCameraEnabled,
     isMicEnabled,
-    isRemoteVideoPaused,
-    isScreenShareSupported: isScreenShareSupported(),
-    isScreenSharing,
+    isRemovingParticipant,
     isTogglingCamera,
     isTogglingMic,
-    isTogglingRemoteVideo,
-    isTogglingScreenShare,
     localVideoRef,
     localVideoTrack,
     p2pError: p2pFallback.p2pError,

--- a/apps/web/src/features/call/call-page.tsx
+++ b/apps/web/src/features/call/call-page.tsx
@@ -1,6 +1,6 @@
 import type { RefObject } from "react";
 
-import type { ChatMessage } from "@lowtime/shared";
+import type { ChatMessage, RoomParticipant } from "@lowtime/shared";
 import type { StoredCallSession } from "../../room-entry.js";
 import type { NetworkHealth } from "../../network-health.js";
 import { getNetworkHealthLabel } from "../../network-health.js";
@@ -24,7 +24,6 @@ import {
   networkBadgeStyle,
   remoteTileStyle,
   remoteVideoStyle,
-  screenShareCaptionStyle,
   secondaryControlStyle,
   selfPlaceholderStyle,
   selfViewPanelStyle,
@@ -42,16 +41,14 @@ interface CallPageProps {
   hasLocalVideo: boolean;
   hasRemoteVideo: boolean;
   isCameraEnabled: boolean;
+  isHost: boolean;
   isMicEnabled: boolean;
-  isRemoteVideoPaused: boolean;
-  isScreenShareSupported: boolean;
-  isScreenSharing: boolean;
+  isRemovingParticipant: string | null;
   isTogglingCamera: boolean;
   isTogglingMic: boolean;
-  isTogglingRemoteVideo: boolean;
-  isTogglingScreenShare: boolean;
   localVideoRef: RefObject<HTMLVideoElement | null>;
   networkHealth: NetworkHealth;
+  participants: RoomParticipant[];
   remoteParticipantLabel: string;
   remoteVideoRef: RefObject<HTMLVideoElement | null>;
   slug: string;
@@ -60,6 +57,7 @@ interface CallPageProps {
   p2pStatus: P2PCallStatus;
   p2pError: string | null;
   chatMessages: ChatMessage[];
+  onRemoveParticipant: (targetSessionId: string) => void;
   onSendChat: (body: string) => void;
   onBackToJoin: () => void;
   onLeaveCall: () => void;
@@ -68,8 +66,6 @@ interface CallPageProps {
   onDismissAudioOnly: () => void;
   onToggleCamera: () => Promise<void>;
   onToggleMicrophone: () => Promise<void>;
-  onToggleRemoteVideo: () => Promise<void>;
-  onToggleScreenShare: () => Promise<void>;
 }
 
 export function CallPage(props: CallPageProps) {
@@ -133,12 +129,7 @@ export function CallPage(props: CallPageProps) {
               <h2 style={tileHeadingStyle}>Remote</h2>
               <span>{props.remoteParticipantLabel}</span>
             </div>
-            {props.isRemoteVideoPaused ? (
-              <p style={screenShareCaptionStyle} role="status" aria-live="polite">
-                Remote video paused
-              </p>
-            ) : null}
-            {props.hasRemoteVideo && !props.isRemoteVideoPaused ? (
+            {props.hasRemoteVideo ? (
               <video
                 ref={props.remoteVideoRef}
                 autoPlay
@@ -149,11 +140,9 @@ export function CallPage(props: CallPageProps) {
               <div style={tilePlaceholderStyle}>
                 <strong>{props.remoteParticipantLabel}</strong>
                 <p style={mutedParagraphStyle}>
-                  {props.isRemoteVideoPaused
-                    ? "Resume remote video from the controls below."
-                    : props.callStatus === "connected" || isP2PConnected
-                      ? "No remote camera is visible yet."
-                      : "Connecting the first call experience..."}
+                  {props.callStatus === "connected" || isP2PConnected
+                    ? "No remote camera is visible yet."
+                    : "Connecting the first call experience..."}
                 </p>
               </div>
             )}
@@ -163,11 +152,6 @@ export function CallPage(props: CallPageProps) {
               <h2 style={tileHeadingStyle}>You</h2>
               <span>{props.callSession.displayName}</span>
             </div>
-            {props.isScreenSharing ? (
-              <p style={screenShareCaptionStyle} role="status" aria-live="polite">
-                Sharing your screen
-              </p>
-            ) : null}
             {props.hasLocalVideo && props.isCameraEnabled ? (
               <video
                 ref={props.localVideoRef}
@@ -225,36 +209,43 @@ export function CallPage(props: CallPageProps) {
             >
               {props.isTogglingCamera ? "Updating Camera..." : props.isCameraEnabled ? "Turn Camera Off" : "Turn Camera On"}
             </button>
-            {props.isScreenShareSupported ? (
-              <button
-                type="button"
-                onClick={() => void props.onToggleScreenShare()}
-                disabled={controlsDisabled || props.isTogglingScreenShare}
-                style={secondaryControlStyle}
-              >
-                {props.isTogglingScreenShare
-                  ? "Updating Screen Share..."
-                  : props.isScreenSharing
-                    ? "Stop Sharing"
-                    : "Share Screen"}
-              </button>
-            ) : null}
-            <button
-              type="button"
-              onClick={() => void props.onToggleRemoteVideo()}
-              disabled={controlsDisabled || props.isTogglingRemoteVideo}
-              style={secondaryControlStyle}
-            >
-              {props.isTogglingRemoteVideo
-                ? "Updating Remote Video..."
-                : props.isRemoteVideoPaused
-                  ? "Resume Video"
-                  : "Pause Video"}
-            </button>
             <button type="button" onClick={props.onLeaveCall} style={dangerControlStyle}>
               Leave Call
             </button>
           </section>
+          {props.isHost ? (
+            <section style={controlsPanelStyle} aria-label="Host moderation">
+              <h3 style={metaTextStyle}>Participants</h3>
+              {props.participants.length === 0 ? (
+                <p style={mutedParagraphStyle}>No one has joined yet.</p>
+              ) : (
+                <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "grid", gap: "0.25rem" }}>
+                  {props.participants.map((participant) => {
+                    const isSelf = participant.id === props.callSession?.sessionId;
+                    const isRemoving = props.isRemovingParticipant === participant.id;
+                    return (
+                      <li key={participant.id} style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+                        <span>
+                          {participant.displayName}
+                          {isSelf ? " (you)" : ""}
+                        </span>
+                        {isSelf ? null : (
+                          <button
+                            type="button"
+                            onClick={() => props.onRemoveParticipant(participant.id)}
+                            disabled={isRemoving}
+                            style={dangerControlStyle}
+                          >
+                            {isRemoving ? "Removing..." : "Remove"}
+                          </button>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </section>
+          ) : null}
           {props.callError ? <p role="alert">{props.callError}</p> : null}
           {props.p2pError && props.p2pStatus === "failed" ? (
             <p role="alert">{props.p2pError}</p>

--- a/apps/web/src/features/room/room-signaling.ts
+++ b/apps/web/src/features/room/room-signaling.ts
@@ -10,6 +10,7 @@ export type SignalServerEvent =
   | { kind: "room.settings_updated"; room: RoomSummary }
   | { kind: "transport.switch_available"; nextTransport: "p2p" }
   | { kind: "chat.received"; message: ChatMessage }
+  | { kind: "participant_removed"; sessionId: string; reason: "host_removed" }
   | { kind: "p2p.offer"; payload: { sdp: string } }
   | { kind: "p2p.answer"; payload: { sdp: string } }
   | { kind: "p2p.ice"; payload: RTCIceCandidateInit }
@@ -35,6 +36,8 @@ export interface UseRoomSignalingState {
   sessionExpired: boolean;
   /** True when the server has indicated P2P fallback is available for this room. */
   p2pAvailable: boolean;
+  /** True when the server has indicated the host removed this session. */
+  removedFromRoom: boolean;
   /** Ordered list of chat messages received since the socket connected. */
   chatMessages: ChatMessage[];
   /** Send a raw message frame to the server. No-op if socket is not open. */
@@ -73,6 +76,7 @@ export function useRoomSignaling(input: UseRoomSignalingInput): UseRoomSignaling
   const [latestRoomSummary, setLatestRoomSummary] = useState<RoomSummary | null>(null);
   const [sessionExpired, setSessionExpired] = useState(false);
   const [p2pAvailable, setP2pAvailable] = useState(false);
+  const [removedFromRoom, setRemovedFromRoom] = useState(false);
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
   const socketRef = useRef<WebSocket | null>(null);
   const pingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -153,6 +157,11 @@ export function useRoomSignaling(input: UseRoomSignalingInput): UseRoomSignaling
           // Server acknowledged our ping; session is still alive. No state change needed.
         } else if (raw.kind === "transport.switch_available") {
           setP2pAvailable(true);
+        } else if (raw.kind === "participant_removed") {
+          const ev = raw as { kind: "participant_removed"; sessionId: string };
+          if (ev.sessionId === sessionId) {
+            setRemovedFromRoom(true);
+          }
         } else if (raw.kind === "chat.received") {
           const msg = (raw as { kind: string; message: ChatMessage }).message;
           setChatMessages((prev) => [...prev, msg]);
@@ -193,5 +202,5 @@ export function useRoomSignaling(input: UseRoomSignalingInput): UseRoomSignaling
     };
   }, [apiBaseUrl, slug, sessionId]);
 
-  return { signalState, latestRoomSummary, sessionExpired, p2pAvailable, chatMessages, sendSignalMessage };
+  return { signalState, latestRoomSummary, sessionExpired, p2pAvailable, removedFromRoom, chatMessages, sendSignalMessage };
 }

--- a/apps/web/src/host-actions.test.ts
+++ b/apps/web/src/host-actions.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { removeParticipantRequest } from "./host-actions.js";
+
+test("removeParticipantRequest sends a POST to the participants/remove endpoint with the host secret header", async () => {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const fetcher: typeof fetch = async (input, init) => {
+    calls.push({ url: String(input), init: init ?? {} });
+    return new Response(JSON.stringify({ ok: true, removedSessionId: "sess_target" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  const result = await removeParticipantRequest({
+    apiBaseUrl: "https://api.example.com",
+    slug: "alpha",
+    sessionId: "sess_target",
+    hostSecret: "host-secret-1",
+    fetcher,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.url, "https://api.example.com/api/rooms/alpha/participants/sess_target/remove");
+  const headers = calls[0]!.init.headers as Record<string, string>;
+  assert.equal(headers["x-host-secret"], "host-secret-1");
+});
+
+test("removeParticipantRequest surfaces a server-side error message", async () => {
+  const fetcher: typeof fetch = async () =>
+    new Response(JSON.stringify({ message: "Participant is not in this room" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  const result = await removeParticipantRequest({
+    apiBaseUrl: "https://api.example.com",
+    slug: "alpha",
+    sessionId: "sess_target",
+    hostSecret: "host-secret-1",
+    fetcher,
+  });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.message, "Participant is not in this room");
+  }
+});
+
+test("removeParticipantRequest rejects an empty host secret before hitting the network", async () => {
+  const fetcher: typeof fetch = async () => {
+    throw new Error("should not be called");
+  };
+
+  const result = await removeParticipantRequest({
+    apiBaseUrl: "https://api.example.com",
+    slug: "alpha",
+    sessionId: "sess_target",
+    hostSecret: "",
+    fetcher,
+  });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.message, /host secret/i);
+  }
+});
+
+test("removeParticipantRequest uses a generic message when the body is not JSON", async () => {
+  const fetcher: typeof fetch = async () => new Response("not json", { status: 500 });
+
+  const result = await removeParticipantRequest({
+    apiBaseUrl: "https://api.example.com",
+    slug: "alpha",
+    sessionId: "sess_target",
+    hostSecret: "host-secret-1",
+    fetcher,
+  });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.message, /server/i);
+  }
+});
+
+test("removeParticipantRequest surfaces network failures with a useful message", async () => {
+  const fetcher: typeof fetch = async () => {
+    throw new TypeError("Failed to fetch");
+  };
+
+  const result = await removeParticipantRequest({
+    apiBaseUrl: "https://api.example.com",
+    slug: "alpha",
+    sessionId: "sess_target",
+    hostSecret: "host-secret-1",
+    fetcher,
+  });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.match(result.message, /network/i);
+  }
+});

--- a/apps/web/src/host-actions.ts
+++ b/apps/web/src/host-actions.ts
@@ -1,0 +1,65 @@
+/**
+ * Host moderation helpers for the web client.
+ *
+ * Pure wrappers around the room moderation HTTP endpoint so feature
+ * modules can stay presentational and unit tests can lock the request
+ * shape without spinning the global `fetch`.
+ */
+
+export type RemoveParticipantResult =
+  | { ok: true; removedSessionId: string }
+  | { ok: false; message: string };
+
+export interface RemoveParticipantRequestInput {
+  apiBaseUrl: string;
+  slug: string;
+  sessionId: string;
+  hostSecret: string;
+  fetcher?: typeof fetch;
+}
+
+export async function removeParticipantRequest(
+  input: RemoveParticipantRequestInput,
+): Promise<RemoveParticipantResult> {
+  if (input.hostSecret.trim() === "") {
+    return { ok: false, message: "Host secret is required to remove a participant." };
+  }
+
+  const f = input.fetcher ?? fetch;
+  const url = `${input.apiBaseUrl.replace(/\/$/, "")}/api/rooms/${encodeURIComponent(input.slug)}/participants/${encodeURIComponent(input.sessionId)}/remove`;
+
+  let response: Response;
+  try {
+    response = await f(url, {
+      method: "POST",
+      headers: {
+        "x-host-secret": input.hostSecret,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Network error while removing participant";
+    return { ok: false, message: `Network error: ${message}` };
+  }
+
+  let body: unknown = null;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+
+  if (response.ok) {
+    const removedSessionId =
+      body != null && typeof body === "object" && "removedSessionId" in body && typeof (body as { removedSessionId: unknown }).removedSessionId === "string"
+        ? (body as { removedSessionId: string }).removedSessionId
+        : input.sessionId;
+    return { ok: true, removedSessionId };
+  }
+
+  const message =
+    body != null && typeof body === "object" && "message" in body && typeof (body as { message: unknown }).message === "string"
+      ? (body as { message: string }).message
+      : `Server returned ${response.status}`;
+
+  return { ok: false, message };
+}

--- a/docs/05-api-and-realtime-contracts.md
+++ b/docs/05-api-and-realtime-contracts.md
@@ -204,6 +204,7 @@ The event tables below enumerate the full planned signaling surface. Everything 
 | `network.poor` | network tier and recommendation | Drive low-network UX |
 | `transport.switch_available` | next transport | Offer P2P fallback in 1:1 rooms |
 | `room.expired` | none | Force return to expired-room UI |
+| `participant_removed` | session id and reason | Inform every socket the host removed a session |
 
 ## Shared Types
 - `RoomSummary`
@@ -214,6 +215,10 @@ The event tables below enumerate the full planned signaling surface. Everything 
   - `allowScreenShare`
   - `status`
   - `expiresAt`
+  - `participants?: RoomParticipant[]` (id + displayName per admitted session)
+- `RoomParticipant`
+  - `id`
+  - `displayName`
 - `ParticipantSummary`
   - `id`
   - `displayName`

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -26,6 +26,12 @@ export interface RoomSummary {
   allowScreenShare: boolean;
   status: RoomStatus;
   expiresAt: string;
+  participants?: RoomParticipant[];
+}
+
+export interface RoomParticipant {
+  id: string;
+  displayName: string;
 }
 
 export interface RequestedMedia {


### PR DESCRIPTION
## Summary
Adds host-only moderation. The host sees a per-participant Remove button on the call page; clicking it deletes the target session from the in-memory store and broadcasts a `participant_removed` event on the signal bus so every connected socket updates its UI. The removed participant sees "The host removed you from this call." in `callError` and the room disconnects.

## Why
Phase 4 collaboration feature (closes #27). Basic moderation is the last of the four Phase 4 rows. Until now a misbehaving participant could only be removed by closing the room.

## What changed
- `apps/server/src/domain/remove-participant.ts` — pure `attemptRemoveParticipant({ room, hostSecret, targetSessionId, now })` that validates host auth, refuses to remove the only host, splices the session out, and bumps `lastActivityAt`.
- `apps/server/src/routes/participants.ts` — new `POST /api/rooms/:slug/participants/:sessionId/remove` endpoint. Host-secret-gated, maps domain failures to 403/404/409, publishes `participant_removed` on success.
- `apps/server/src/app.ts` — registers the new route.
- `apps/server/src/domain/room-status.ts` and `packages/shared/src/index.ts` — `RoomSummary` now carries the admitted participants list (id + displayName) so every client knows who is in the call. New shared `RoomParticipant` type.
- `apps/server/src/domain/signal-bus.ts` — `participant_removed` joins the `SignalServerEvent` union.
- `apps/web/src/host-actions.ts` — pure `removeParticipantRequest` helper with an injectable fetcher.
- `apps/web/src/host-actions.test.ts` — 5 new cases.
- `apps/web/src/features/room/room-signaling.ts` — new `removedFromRoom` state set when the local session is the one removed.
- `apps/web/src/features/call/call-effects.ts` — `handleRemoveParticipant`, `isRemovingParticipant` state, and a `removedFromRoom` effect that disconnects the room and surfaces the host-removed message.
- `apps/web/src/features/call/call-page.tsx` — host-only Participants panel with Remove buttons.
- `apps/web/src/App.tsx` — wires the new state, handler, and participant list through the call page; moves the signaling hook above the call flow so the `removedFromRoom` signal lands on the first render.

## Tests
- `apps/server/src/remove-participant.test.ts` — 6 new cases (missing host secret, wrong host secret, unknown target, success, only host refused, lastActivityAt bump).
- `apps/web/src/host-actions.test.ts` — 5 new cases.
- `apps/server/src/rooms.test.ts` — updated the create + get room expectations to include the new `participants: []` field.
- Web 111/111, server 195/195, lint clean, typecheck clean.

## Docs
- `docs/05-api-and-realtime-contracts.md` — lists `participant_removed` in the server-to-client event table and documents the new `RoomSummary.participants` field and shared `RoomParticipant` type.
- `TODO.md` — moves #27 to `done` with file-pointer notes.

## Out of scope (deferred)
- Re-call session restore for the removed participant. The error is surfaced but the join flow expects the user to re-enter the room manually.
- Ban list. A removed participant can rejoin immediately. A future "ban" setting is a separate issue.
- Host remove via the room page. Only the call page exposes the panel right now; adding it to the room page is a small follow-up.
