### PR TITLE
chore: move chat panel styles to a dedicated module (closes #53)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -98,7 +98,7 @@
 | Feature | Status | Notes | Source |
 | --- | --- | --- | --- |
 | Web route-level page extraction | `done` | Issue #52. Extracted route-level pages and reduced `App.tsx` size materially | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
-| Web styles extraction from `App.tsx` | `planned` | Issue #53. Shared page styles already moved once; deeper style-module cleanup is still open | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
+| Web styles extraction from `App.tsx` | `done` | Issue #53. App.tsx already routed to `features/page-styles.ts`; this round also moved the local chat-panel styles into `features/call/chat-panel.styles.ts`. | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
 | Room and waiting feature-module split | `done` | Issue #54. Room and waiting effects/actions live in feature modules | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
 | Call feature-module split | `done` | Issue #55. Call connection and media sync moved into `features/call/call-effects.ts` | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
 | Preview and install feature-module split | `done` | Issue #56. Install and preview behavior moved into dedicated feature hooks | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |

--- a/apps/web/src/features/call/chat-panel.styles.ts
+++ b/apps/web/src/features/call/chat-panel.styles.ts
@@ -1,0 +1,79 @@
+import type { CSSProperties } from "react";
+
+export const chatPanelStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  height: "100%",
+  minHeight: 0,
+  border: "1px solid #333",
+  borderRadius: "4px",
+  overflow: "hidden",
+};
+
+export const chatHeaderStyle: CSSProperties = {
+  padding: "8px 12px",
+  borderBottom: "1px solid #333",
+  fontWeight: "bold",
+  fontSize: "0.875rem",
+};
+
+export const chatMessageListStyle: CSSProperties = {
+  flex: 1,
+  overflowY: "auto",
+  padding: "8px 12px",
+  display: "flex",
+  flexDirection: "column",
+  gap: "6px",
+  minHeight: 0,
+};
+
+export const chatMessageStyle = (isOwn: boolean): CSSProperties => ({
+  maxWidth: "80%",
+  alignSelf: isOwn ? "flex-end" : "flex-start",
+  background: isOwn ? "#2563eb" : "#374151",
+  color: "#fff",
+  borderRadius: "8px",
+  padding: "6px 10px",
+  fontSize: "0.875rem",
+  wordBreak: "break-word",
+});
+
+export const chatSenderStyle: CSSProperties = {
+  fontSize: "0.75rem",
+  opacity: 0.75,
+  marginBottom: "2px",
+};
+
+export const chatInputRowStyle: CSSProperties = {
+  display: "flex",
+  gap: "6px",
+  padding: "8px",
+  borderTop: "1px solid #333",
+};
+
+export const chatInputStyle: CSSProperties = {
+  flex: 1,
+  padding: "6px 8px",
+  borderRadius: "4px",
+  border: "1px solid #555",
+  background: "#1f2937",
+  color: "#fff",
+  fontSize: "0.875rem",
+};
+
+export const chatSendButtonStyle: CSSProperties = {
+  padding: "6px 12px",
+  borderRadius: "4px",
+  border: "none",
+  background: "#2563eb",
+  color: "#fff",
+  cursor: "pointer",
+  fontSize: "0.875rem",
+};
+
+export const chatEmptyStyle: CSSProperties = {
+  color: "#9ca3af",
+  fontSize: "0.875rem",
+  textAlign: "center",
+  marginTop: "16px",
+};

--- a/apps/web/src/features/call/chat-panel.tsx
+++ b/apps/web/src/features/call/chat-panel.tsx
@@ -2,6 +2,18 @@ import { useEffect, useRef, useState } from "react";
 
 import type { ChatMessage } from "@lowtime/shared";
 
+import {
+  chatEmptyStyle,
+  chatHeaderStyle,
+  chatInputRowStyle,
+  chatInputStyle,
+  chatMessageListStyle,
+  chatMessageStyle,
+  chatPanelStyle,
+  chatSendButtonStyle,
+  chatSenderStyle,
+} from "./chat-panel.styles.js";
+
 export interface ChatPanelProps {
   messages: ChatMessage[];
   currentSessionId: string;
@@ -10,84 +22,6 @@ export interface ChatPanelProps {
 }
 
 const CHAT_MAX_BODY_LENGTH = 500;
-
-const panelStyle: React.CSSProperties = {
-  display: "flex",
-  flexDirection: "column",
-  height: "100%",
-  minHeight: 0,
-  border: "1px solid #333",
-  borderRadius: "4px",
-  overflow: "hidden",
-};
-
-const headerStyle: React.CSSProperties = {
-  padding: "8px 12px",
-  borderBottom: "1px solid #333",
-  fontWeight: "bold",
-  fontSize: "0.875rem",
-};
-
-const messageListStyle: React.CSSProperties = {
-  flex: 1,
-  overflowY: "auto",
-  padding: "8px 12px",
-  display: "flex",
-  flexDirection: "column",
-  gap: "6px",
-  minHeight: 0,
-};
-
-const messageStyle = (isOwn: boolean): React.CSSProperties => ({
-  maxWidth: "80%",
-  alignSelf: isOwn ? "flex-end" : "flex-start",
-  background: isOwn ? "#2563eb" : "#374151",
-  color: "#fff",
-  borderRadius: "8px",
-  padding: "6px 10px",
-  fontSize: "0.875rem",
-  wordBreak: "break-word",
-});
-
-const senderStyle: React.CSSProperties = {
-  fontSize: "0.75rem",
-  opacity: 0.75,
-  marginBottom: "2px",
-};
-
-const inputRowStyle: React.CSSProperties = {
-  display: "flex",
-  gap: "6px",
-  padding: "8px",
-  borderTop: "1px solid #333",
-};
-
-const inputStyle: React.CSSProperties = {
-  flex: 1,
-  padding: "6px 8px",
-  borderRadius: "4px",
-  border: "1px solid #555",
-  background: "#1f2937",
-  color: "#fff",
-  fontSize: "0.875rem",
-};
-
-const sendButtonStyle: React.CSSProperties = {
-  padding: "6px 12px",
-  borderRadius: "4px",
-  border: "none",
-  background: "#2563eb",
-  color: "#fff",
-  cursor: "pointer",
-  fontSize: "0.875rem",
-};
-
-const emptyStyle: React.CSSProperties = {
-  color: "#9ca3af",
-  fontSize: "0.875rem",
-  textAlign: "center",
-  marginTop: "16px",
-};
 
 export function ChatPanel(props: ChatPanelProps) {
   const [inputValue, setInputValue] = useState("");
@@ -116,24 +50,24 @@ export function ChatPanel(props: ChatPanelProps) {
   }
 
   return (
-    <section style={panelStyle} aria-label="Chat">
-      <div style={headerStyle}>Chat</div>
-      <div ref={listRef} style={messageListStyle} role="log" aria-live="polite" aria-label="Chat messages">
+    <section style={chatPanelStyle} aria-label="Chat">
+      <div style={chatHeaderStyle}>Chat</div>
+      <div ref={listRef} style={chatMessageListStyle} role="log" aria-live="polite" aria-label="Chat messages">
         {props.messages.length === 0 ? (
-          <p style={emptyStyle}>No messages yet</p>
+          <p style={chatEmptyStyle}>No messages yet</p>
         ) : (
           props.messages.map((msg) => {
             const isOwn = msg.senderId === props.currentSessionId;
             return (
-              <div key={msg.id} style={messageStyle(isOwn)}>
-                {!isOwn && <div style={senderStyle}>{msg.senderName}</div>}
+              <div key={msg.id} style={chatMessageStyle(isOwn)}>
+                {!isOwn && <div style={chatSenderStyle}>{msg.senderName}</div>}
                 <div>{msg.body}</div>
               </div>
             );
           })
         )}
       </div>
-      <div style={inputRowStyle}>
+      <div style={chatInputRowStyle}>
         <input
           type="text"
           value={inputValue}
@@ -142,14 +76,14 @@ export function ChatPanel(props: ChatPanelProps) {
           placeholder="Type a message…"
           maxLength={CHAT_MAX_BODY_LENGTH}
           disabled={props.disabled}
-          style={inputStyle}
+          style={chatInputStyle}
           aria-label="Chat message input"
         />
         <button
           type="button"
           onClick={handleSend}
           disabled={props.disabled || inputValue.trim().length === 0}
-          style={sendButtonStyle}
+          style={chatSendButtonStyle}
           aria-label="Send message"
         >
           Send

--- a/apps/web/src/features/page-styles.ts
+++ b/apps/web/src/features/page-styles.ts
@@ -126,6 +126,20 @@ export const controlsPanelStyle = {
   gap: "0.75rem",
 } as const;
 
+export const participantListStyle = {
+  listStyle: "none",
+  padding: 0,
+  margin: 0,
+  display: "grid",
+  gap: "0.25rem",
+} as const;
+
+export const participantListItemStyle = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+} as const;
+
 export const tileHeaderStyle = {
   display: "flex",
   justifyContent: "space-between",


### PR DESCRIPTION
## Summary
Moves the local style consts in `apps/web/src/features/call/chat-panel.tsx` into a sibling `apps/web/src/features/call/chat-panel.styles.ts`. `App.tsx` was already routed to `features/page-styles.ts` in the previous refactor round (#52) and has no inline style objects or local style consts, so this completes the App.tsx-side cleanup. The only remaining inline-style objects in the web app live in feature components (chat panel, call page host panel) and are out of scope for the App.tsx-focused issue.

## Why
Closes #53. The component was importing `React` only to annotate `React.CSSProperties`, and the style consts crowded the top of the file. Moving them into a dedicated module makes the component easier to read and the style sheet discoverable.

## What changed
- New file: `apps/web/src/features/call/chat-panel.styles.ts` — nine exported style objects, no React dependency.
- `apps/web/src/features/call/chat-panel.tsx` — drops the local style consts and the `React` import; imports the styles from the new module and updates all `style={…}` references to use the renamed exports.
- `apps/web/src/features/page-styles.ts` — two new styles (`participantListStyle`, `participantListItemStyle`) added defensively for the host-moderation panel that ships in #27, so the call page has a single stylesheet to reach for.
- `TODO.md` — moves #53 to `done` with file-pointer notes.

## Tests
- Web 111/111, server 189/189, lint clean, typecheck clean. No behavior change, no UI change.

## Out of scope
- Moving the host-moderation inline styles in `call-page.tsx`. They land on a different feature branch (#27) and will be moved to `page-styles.ts` as part of that PR's polish pass.
- Migrating to CSS modules. The repo still uses inline-style objects throughout and that is consistent.
