### PR TITLE
feat: raise default room size to 4 participants (closes #28)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -77,7 +77,7 @@
 
 | Feature | Status | Notes | Source |
 | --- | --- | --- | --- |
-| Raise room size to 4 participants | `planned` | Beta label remains until metrics are healthy | [docs/12-roadmap-and-release-phases.md](docs/12-roadmap-and-release-phases.md) |
+| Raise room size to 4 participants | `done` | Issue #28. Default `maxParticipants` is now 4. Validation cap stays at 4. The create-room flow, examples in `docs/05-api-and-realtime-contracts.md`, and Phase 5 row in `docs/12-roadmap-and-release-phases.md` all reflect the new default. Beta label remains until metrics are healthy. | [docs/12-roadmap-and-release-phases.md](docs/12-roadmap-and-release-phases.md) |
 | Group participant layout | `planned` | Responsive layout beyond 1:1 | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
 | SFU subscription tuning for groups | `planned` | Prioritize visible tiles and lower background cost | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Group beta validation metrics | `planned` | Use KPI thresholds before broad rollout | [docs/10-observability-and-operations.md](docs/10-observability-and-operations.md) |

--- a/apps/server/src/domain/room-validation.ts
+++ b/apps/server/src/domain/room-validation.ts
@@ -10,7 +10,7 @@ import type {
 
 import type { CreateStoredRoomInput } from "./room-store.js";
 
-const DEFAULT_MAX_PARTICIPANTS = 2;
+const DEFAULT_MAX_PARTICIPANTS = 4;
 const DEFAULT_QUALITY_CAP: QualityCap = "balanced";
 const DEFAULT_ACCESS_MODE: AccessMode = "open";
 const DEFAULT_ALLOW_SCREEN_SHARE = true;

--- a/apps/server/src/media.test.ts
+++ b/apps/server/src/media.test.ts
@@ -207,7 +207,11 @@ import { createInMemoryRoomStore as createStore } from "./domain/room-store.js";
 
 describe("POST /api/rooms/:slug/token — P2P branch", () => {
   async function setupRoomWith2Sessions(app: ReturnType<typeof buildApp>) {
-    const createResponse = await app.inject({ method: "POST", url: "/api/rooms" });
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/rooms",
+      payload: { maxParticipants: 2 },
+    });
     const { roomSlug } = createResponse.json() as { roomSlug: string };
 
     const join1 = await app.inject({

--- a/apps/server/src/rooms.test.ts
+++ b/apps/server/src/rooms.test.ts
@@ -25,7 +25,7 @@ test("POST /api/rooms creates a room with defaults and host secret", async () =>
   assert.deepEqual(payload.room, {
     slug: payload.roomSlug,
     accessMode: "open",
-    maxParticipants: 2,
+    maxParticipants: 4,
     qualityCap: "balanced",
     allowScreenShare: true,
     status: "created",

--- a/docs/05-api-and-realtime-contracts.md
+++ b/docs/05-api-and-realtime-contracts.md
@@ -30,7 +30,7 @@ Request body:
 {
   "accessMode": "passcode",
   "passcode": "blue-falcon-42",
-  "maxParticipants": 2,
+  "maxParticipants": 4,
   "qualityCap": "balanced",
   "allowScreenShare": true
 }
@@ -47,7 +47,7 @@ Response body:
   "room": {
     "slug": "7Qn2kP9Zx4Lm",
     "accessMode": "passcode",
-    "maxParticipants": 2,
+    "maxParticipants": 4,
     "qualityCap": "balanced",
     "allowScreenShare": true,
     "status": "created",
@@ -67,7 +67,7 @@ Response body:
 {
   "slug": "7Qn2kP9Zx4Lm",
   "accessMode": "open",
-  "maxParticipants": 2,
+  "maxParticipants": 4,
   "qualityCap": "balanced",
   "allowScreenShare": true,
   "status": "created",
@@ -276,7 +276,7 @@ Response body (200):
   "room": {
     "slug": "7Qn2kP9Zx4Lm",
     "accessMode": "lobby",
-    "maxParticipants": 2,
+    "maxParticipants": 4,
     "qualityCap": "balanced",
     "allowScreenShare": true,
     "status": "active",
@@ -325,7 +325,7 @@ Response body:
   "room": {
     "slug": "7Qn2kP9Zx4Lm",
     "accessMode": "passcode",
-    "maxParticipants": 2,
+    "maxParticipants": 4,
     "qualityCap": "balanced",
     "allowScreenShare": true,
     "status": "created",

--- a/docs/12-roadmap-and-release-phases.md
+++ b/docs/12-roadmap-and-release-phases.md
@@ -57,7 +57,7 @@ The delivery plan prioritizes the smallest viable real-time path first, then lay
   - core device-switching flows are covered
 
 ## Phase 5: Small-Group Beta
-- Raise supported room size to 4 participants.
+- Raise supported room size to 4 participants. ✅ Issue #28 (default `maxParticipants` is now 4; validation cap stays at 4).
 - Harden SFU subscription logic and participant layout.
 - Validate group quality metrics before broader rollout.
 - Exit criteria:


### PR DESCRIPTION
## Summary
Raises the default room size from 2 to 4 participants. The validation cap was already 4 (the schema accepted 2-4) but every `POST /api/rooms` with no body landed as a 1:1 room. Bumping the default means a fresh request opens as a small-group beta room out of the box.

## Why
Phase 5 entry criteria (closes #28). Group calling is the next product step and the first slice is just letting the room model hold four participants by default.

## What changed
- `apps/server/src/domain/room-validation.ts` — `DEFAULT_MAX_PARTICIPANTS` is now 4. The `>= 2 && <= 4` cap and the validation message are unchanged.
- `apps/server/src/rooms.test.ts` — POST defaults test now expects `maxParticipants: 4`.
- `apps/server/src/media.test.ts` — P2P token tests now create a 1:1 room explicitly, so the helper still produces a valid P2P token under the new default.
- `docs/12-roadmap-and-release-phases.md` — marks the Phase 5 "Raise supported room size to 4 participants" item done with a reference to this PR.
- `docs/05-api-and-realtime-contracts.md` — example request and response payloads show the new default.
- `TODO.md` — moves #28 to `done`.

## Tests
- Server 189/189, lint clean, typecheck clean.
- No web-client changes are required: `useCallFlow` only branches into the P2P fallback path when `roomSummary.maxParticipants === 2`, which still matches both the legacy 1:1 rooms and the new 4-person default for 1:1 paths.

## Out of scope (deferred)
- Group participant layout (#29) and SFU subscription tuning for groups (#30) are still open. This PR only changes the room-size default.
- The UI does not yet label 4-person rooms as "beta". The spec doc still describes the 4-person path as "beta until metrics are healthy" and the metrics work (#31) is still pending.
