### PR TITLE
feat: per-participant tiles on the call page (closes #29)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -78,7 +78,7 @@
 | Feature | Status | Notes | Source |
 | --- | --- | --- | --- |
 | Raise room size to 4 participants | `planned` | Beta label remains until metrics are healthy | [docs/12-roadmap-and-release-phases.md](docs/12-roadmap-and-release-phases.md) |
-| Group participant layout | `planned` | Responsive layout beyond 1:1 | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
+| Group participant layout | `done` | Issue #29. The call page now renders one tile per remote participant in a CSS grid that scales from 1:1 to 4-participant rooms. Pure helpers `getAllVideoParticipants` and `getParticipantVideoTrack` in `apps/web/src/call-experience.ts`; `RemoteVideoTile` array drives the new layout in `call-effects.ts`. | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
 | SFU subscription tuning for groups | `planned` | Prioritize visible tiles and lower background cost | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Group beta validation metrics | `planned` | Use KPI thresholds before broad rollout | [docs/10-observability-and-operations.md](docs/10-observability-and-operations.md) |
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -166,7 +166,6 @@ export function App() {
     p2pError,
     p2pStatus,
     remoteParticipantLabel,
-    remoteVideoRef,
     remoteVideoRefMap,
     remoteVideoTiles,
   } = useCallFlow({

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -167,7 +167,8 @@ export function App() {
     p2pStatus,
     remoteParticipantLabel,
     remoteVideoRef,
-    remoteVideoTrack,
+    remoteVideoRefMap,
+    remoteVideoTiles,
   } = useCallFlow({
     apiBaseUrl,
     setViewState,
@@ -472,7 +473,7 @@ export function App() {
         connectedSfuUrl,
         downgradeRung,
         hasLocalVideo: localVideoTrack != null,
-        hasRemoteVideo: remoteVideoTrack != null,
+        hasRemoteVideo: remoteVideoTiles.length > 0,
         isCameraEnabled,
         isMicEnabled,
         isTogglingCamera,
@@ -490,7 +491,8 @@ export function App() {
         chatMessages,
         onSendChat: handleSendChat,
         remoteParticipantLabel,
-        remoteVideoRef,
+        remoteVideoRefMap,
+        remoteVideoTiles: remoteVideoTiles.map((tile) => ({ id: tile.id, label: tile.label })),
         slug: viewState.kind === "call" ? viewState.slug : "",
       }}
       homePageProps={{

--- a/apps/web/src/call-experience.test.ts
+++ b/apps/web/src/call-experience.test.ts
@@ -2,18 +2,21 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  getAllVideoParticipants,
   getFirstVideoTrack,
   getParticipant,
   getParticipantLabel,
+  getParticipantVideoTrack,
   getPrimaryParticipant,
   type ParticipantLike,
   type VideoTrackLike,
 } from "./call-experience.js";
 
-function createTrack(kind: string, isMuted = false): VideoTrackLike {
+function createTrack(kind: string, isMuted = false, source?: string): VideoTrackLike {
   return {
     kind,
     isMuted,
+    source,
     attach(element) {
       return element;
     },
@@ -87,4 +90,91 @@ test("getFirstVideoTrack ignores muted video tracks", () => {
   };
 
   assert.equal(getFirstVideoTrack(participant), null);
+});
+
+test("getAllVideoParticipants returns every remote participant that has a video track", () => {
+  const camera1 = createTrack("video", false, "camera");
+  const camera2 = createTrack("video", false, "camera");
+  const audioOnly = createTrack("audio");
+
+  const p1: ParticipantLike = {
+    identity: "sess_1",
+    name: "Alice",
+    trackPublications: new Map([["camera", { track: camera1 }]]),
+  };
+  const p2: ParticipantLike = {
+    identity: "sess_2",
+    name: "Bob",
+    trackPublications: new Map([["camera", { track: camera2 }]]),
+  };
+  const p3: ParticipantLike = {
+    identity: "sess_3",
+    name: "Carol",
+    trackPublications: new Map([["audio", { track: audioOnly }]]),
+  };
+
+  const result = getAllVideoParticipants([p1, p2, p3]);
+
+  assert.deepEqual(
+    result.map((p) => p.identity),
+    ["sess_1", "sess_2"],
+  );
+});
+
+test("getAllVideoParticipants returns an empty array when the iterable is empty or all audio-only", () => {
+  assert.deepEqual(getAllVideoParticipants([]), []);
+  const audio: ParticipantLike = {
+    identity: "sess_1",
+    trackPublications: new Map([["audio", { track: createTrack("audio") }]]),
+  };
+  assert.deepEqual(getAllVideoParticipants([audio]), []);
+});
+
+test("getAllVideoParticipants tolerates invalid entries", () => {
+  const camera = createTrack("video", false, "camera");
+  const valid: ParticipantLike = {
+    identity: "sess_1",
+    trackPublications: new Map([["camera", { track: camera }]]),
+  };
+  const result = getAllVideoParticipants([null, { nope: true }, valid]);
+  assert.equal(result.length, 1);
+  assert.equal(result[0]!.identity, "sess_1");
+});
+
+test("getParticipantVideoTrack returns the first attached track for the requested source", () => {
+  const camera = createTrack("video", false, "camera");
+  const screen = createTrack("video", false, "screen_share");
+  const audio = createTrack("audio");
+
+  const participant: ParticipantLike = {
+    identity: "sess_1",
+    trackPublications: new Map([
+      ["audio", { track: audio }],
+      ["camera", { track: camera }],
+      ["screen", { track: screen }],
+    ]),
+  };
+
+  assert.equal(getParticipantVideoTrack(participant, "camera"), camera);
+  assert.equal(getParticipantVideoTrack(participant, "screen_share"), screen);
+});
+
+test("getParticipantVideoTrack returns null when the source is missing or muted", () => {
+  const camera = createTrack("video", false, "camera");
+  const mutedScreen = createTrack("video", true, "screen_share");
+
+  const participant: ParticipantLike = {
+    identity: "sess_1",
+    trackPublications: new Map([
+      ["camera", { track: camera }],
+      ["screen", { track: mutedScreen }],
+    ]),
+  };
+
+  assert.equal(getParticipantVideoTrack(participant, "screen_share"), null);
+  assert.equal(getParticipantVideoTrack(participant, "microphone"), null);
+});
+
+test("getParticipantVideoTrack handles a null participant", () => {
+  assert.equal(getParticipantVideoTrack(null, "camera"), null);
 });

--- a/apps/web/src/call-experience.ts
+++ b/apps/web/src/call-experience.ts
@@ -1,6 +1,13 @@
 export interface VideoTrackLike {
   kind: string;
   isMuted?: boolean;
+  /**
+   * LiveKit track source identifier (`"camera"`, `"screen_share"`, …).
+   * Optional so non-LiveKit test mocks can omit it; production code
+   * populates it via the `trackPublished` / `localTrackPublished`
+   * event payload.
+   */
+  source?: string;
   attach(element: HTMLMediaElement): HTMLMediaElement;
   detach(element?: HTMLMediaElement): HTMLMediaElement[];
 }
@@ -64,4 +71,63 @@ function isParticipantLike(value: unknown): value is ParticipantLike {
 
   const candidate = value as Partial<ParticipantLike>;
   return typeof candidate.identity === "string" && candidate.trackPublications instanceof Map;
+}
+
+/**
+ * Returns every participant in the iterable that publishes at least one
+ * attached (non-muted) video track. Audio-only and muted-video
+ * participants are dropped. Order is preserved.
+ *
+ * Used by the call page to render one tile per remote participant in
+ * group rooms (Issue #29).
+ */
+export function getAllVideoParticipants(
+  participants: Iterable<unknown>,
+): ParticipantLike[] {
+  const result: ParticipantLike[] = [];
+
+  for (const candidate of participants) {
+    if (!isParticipantLike(candidate)) {
+      continue;
+    }
+
+    const hasVideo = Array.from(candidate.trackPublications.values()).some((publication) => {
+      const track = publication.track;
+      return track != null && track.kind === "video" && track.isMuted !== true;
+    });
+
+    if (hasVideo) {
+      result.push(candidate);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Returns the first attached track on a participant whose `source`
+ * matches the requested value, or `null` when no matching track is
+ * published or the only matching track is muted.
+ */
+export function getParticipantVideoTrack(
+  participant: ParticipantLike | null,
+  source: string,
+): VideoTrackLike | null {
+  if (participant == null) {
+    return null;
+  }
+
+  for (const publication of participant.trackPublications.values()) {
+    const track = publication.track;
+
+    if (track == null || track.kind !== "video" || track.isMuted === true) {
+      continue;
+    }
+
+    if (track.source === source) {
+      return track;
+    }
+  }
+
+  return null;
 }

--- a/apps/web/src/features/call/call-effects.ts
+++ b/apps/web/src/features/call/call-effects.ts
@@ -3,10 +3,11 @@ import { useEffect, useRef, useState } from "react";
 import type { MediaTokenResponse } from "@lowtime/shared";
 
 import {
+  getAllVideoParticipants,
   getFirstVideoTrack,
   getParticipant,
   getParticipantLabel,
-  getPrimaryParticipant,
+  type ParticipantLike,
   type VideoTrackLike,
 } from "../../call-experience.js";
 import { connectToSfu } from "../../media-controller.js";
@@ -24,6 +25,30 @@ const DEFAULT_REQUESTED_MEDIA = {
   audio: true,
   video: true,
 } as const;
+
+export interface RemoteVideoTile {
+  id: string;
+  label: string;
+  track: VideoTrackLike;
+}
+
+function buildRemoteTiles(participants: ParticipantLike[]): RemoteVideoTile[] {
+  const tiles: RemoteVideoTile[] = [];
+
+  for (const participant of participants) {
+    const track = getFirstVideoTrack(participant);
+    if (track == null) {
+      continue;
+    }
+    tiles.push({
+      id: participant.identity,
+      label: getParticipantLabel(participant, "Remote"),
+      track,
+    });
+  }
+
+  return tiles;
+}
 
 interface UseCallFlowInput {
   apiBaseUrl: string;
@@ -46,7 +71,7 @@ export function useCallFlow(input: UseCallFlowInput) {
   const [isTogglingMic, setIsTogglingMic] = useState(false);
   const [isTogglingCamera, setIsTogglingCamera] = useState(false);
   const [localVideoTrack, setLocalVideoTrack] = useState<VideoTrackLike | null>(null);
-  const [remoteVideoTrack, setRemoteVideoTrack] = useState<VideoTrackLike | null>(null);
+  const [remoteVideoTiles, setRemoteVideoTiles] = useState<RemoteVideoTile[]>([]);
   const [remoteParticipantLabel, setRemoteParticipantLabel] = useState<string>("Waiting for someone to join");
   const [localStream, setLocalStream] = useState<MediaStream | null>(null);
 
@@ -54,6 +79,7 @@ export function useCallFlow(input: UseCallFlowInput) {
   const [callRoom, setCallRoom] = useState<Awaited<ReturnType<typeof connectToSfu>> | null>(null);
   const localVideoRef = useRef<HTMLVideoElement | null>(null);
   const remoteVideoRef = useRef<HTMLVideoElement | null>(null);
+  const remoteVideoRefMap = useRef<Map<string, HTMLVideoElement | null>>(new Map());
 
   const slug = input.viewState.kind === "call" ? input.viewState.slug : "";
   const sessionId = callSession?.sessionId ?? "";
@@ -79,7 +105,7 @@ export function useCallFlow(input: UseCallFlowInput) {
       setIsTogglingMic(false);
       setIsTogglingCamera(false);
       setLocalVideoTrack(null);
-      setRemoteVideoTrack(null);
+      setRemoteVideoTiles([]);
       setRemoteParticipantLabel("Waiting for someone to join");
       setLocalStream(null);
       callRoomRef.current?.disconnect();
@@ -119,19 +145,23 @@ export function useCallFlow(input: UseCallFlowInput) {
   }, [localVideoTrack]);
 
   useEffect(() => {
-    const videoElement = remoteVideoRef.current;
+    const attached: Array<{ track: VideoTrackLike; element: HTMLVideoElement }> = [];
 
-    if (videoElement == null || remoteVideoTrack == null) {
-      return;
+    for (const tile of remoteVideoTiles) {
+      const element = remoteVideoRefMap.current.get(tile.id);
+      if (element == null) {
+        continue;
+      }
+      tile.track.attach(element);
+      attached.push({ track: tile.track, element });
     }
 
-    const attachedTrack = remoteVideoTrack;
-    attachedTrack.attach(videoElement);
-
     return () => {
-      attachedTrack.detach(videoElement);
+      for (const entry of attached) {
+        entry.track.detach(entry.element);
+      }
     };
-  }, [remoteVideoTrack]);
+  }, [remoteVideoTiles]);
 
   useEffect(() => {
     if (input.viewState.kind !== "call" || callSession == null) {
@@ -231,18 +261,20 @@ export function useCallFlow(input: UseCallFlowInput) {
         }
 
         const syncCallPresentation = () => {
-          const nextRemoteParticipant = getPrimaryParticipant(room.remoteParticipants.values());
-          const nextLocalParticipant = getParticipant(room.localParticipant);
+          const remoteParticipants = Array.from(room.remoteParticipants.values()) as ParticipantLike[];
+          const remoteVideoList = getAllVideoParticipants(remoteParticipants);
+          const nextRemoteParticipant = remoteVideoList[0] ?? null;
+          const nextLocalParticipant = getParticipant(room.localParticipant) as ParticipantLike | null;
 
           setCallParticipants(room.remoteParticipants.size + 1);
           setLocalVideoTrack(getFirstVideoTrack(nextLocalParticipant));
-          setRemoteVideoTrack(getFirstVideoTrack(nextRemoteParticipant));
+          setRemoteVideoTiles(buildRemoteTiles(remoteVideoList));
           setRemoteParticipantLabel(getParticipantLabel(nextRemoteParticipant, "Waiting for someone to join"));
         };
 
         const handleDisconnected = () => {
           setCallStatus("idle");
-          setRemoteVideoTrack(null);
+          setRemoteVideoTiles([]);
           setLocalVideoTrack(null);
           setRemoteParticipantLabel("Waiting for someone to join");
         };
@@ -374,7 +406,8 @@ export function useCallFlow(input: UseCallFlowInput) {
     p2pStatus: p2pFallback.p2pStatus,
     remoteParticipantLabel,
     remoteVideoRef,
-    remoteVideoTrack,
+    remoteVideoRefMap,
+    remoteVideoTiles,
   };
 }
 

--- a/apps/web/src/features/call/call-page.tsx
+++ b/apps/web/src/features/call/call-page.tsx
@@ -47,7 +47,8 @@ interface CallPageProps {
   localVideoRef: RefObject<HTMLVideoElement | null>;
   networkHealth: NetworkHealth;
   remoteParticipantLabel: string;
-  remoteVideoRef: RefObject<HTMLVideoElement | null>;
+  remoteVideoRefMap: RefObject<Map<string, HTMLVideoElement | null>>;
+  remoteVideoTiles: { id: string; label: string }[];
   slug: string;
   downgradeRung: DowngradeRung;
   audioOnlyPromptState: PromptState;
@@ -122,24 +123,67 @@ export function CallPage(props: CallPageProps) {
         <section style={callLayoutStyle}>
           <section style={remoteTileStyle}>
             <div style={tileHeaderStyle}>
-              <h2 style={tileHeadingStyle}>Remote</h2>
-              <span>{props.remoteParticipantLabel}</span>
+              <h2 style={tileHeadingStyle}>
+                {props.remoteVideoTiles.length > 1 ? "Remotes" : "Remote"}
+              </h2>
+              <span>
+                {props.remoteVideoTiles.length > 0
+                  ? `${props.remoteVideoTiles.length} ${
+                      props.remoteVideoTiles.length === 1 ? "camera" : "cameras"
+                    } • ${props.remoteParticipantLabel}`
+                  : props.remoteParticipantLabel}
+              </span>
             </div>
-            {props.hasRemoteVideo ? (
-              <video
-                ref={props.remoteVideoRef}
-                autoPlay
-                playsInline
-                style={remoteVideoStyle}
-              />
-            ) : (
+            {props.remoteVideoTiles.length === 0 ? (
               <div style={tilePlaceholderStyle}>
                 <strong>{props.remoteParticipantLabel}</strong>
                 <p style={mutedParagraphStyle}>
                   {props.callStatus === "connected" || isP2PConnected
-                    ? "No remote camera is visible yet."
+                    ? props.callParticipants > 1
+                      ? "Other participants have not turned their cameras on yet."
+                      : "No remote camera is visible yet."
                     : "Connecting the first call experience..."}
                 </p>
+              </div>
+            ) : (
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns:
+                    props.remoteVideoTiles.length === 1
+                      ? "1fr"
+                      : props.remoteVideoTiles.length === 2
+                        ? "repeat(2, 1fr)"
+                        : "repeat(auto-fit, minmax(12rem, 1fr))",
+                  gap: "0.5rem",
+                  width: "100%",
+                }}
+              >
+                {props.remoteVideoTiles.map((tile) => (
+                  <figure
+                    key={tile.id}
+                    style={{
+                      margin: 0,
+                      display: "grid",
+                      gap: "0.25rem",
+                    }}
+                  >
+                    <video
+                      ref={(element) => {
+                        const map = props.remoteVideoRefMap.current;
+                        if (element == null) {
+                          map.delete(tile.id);
+                        } else {
+                          map.set(tile.id, element);
+                        }
+                      }}
+                      autoPlay
+                      playsInline
+                      style={remoteVideoStyle}
+                    />
+                    <figcaption style={mutedParagraphStyle}>{tile.label}</figcaption>
+                  </figure>
+                ))}
               </div>
             )}
           </section>


### PR DESCRIPTION
## Summary
The call page used to render a single remote tile plus the local self-view. That works for 1:1 but does not scale to 4-person rooms where the host defaults to since #28.

This PR replaces the single remote tile with a CSS grid that renders one `<video>` per remote participant that publishes an attached, non-muted video track. The grid switches between 1, 2, and auto-fit columns based on the tile count so the layout stays usable on phones and on desktop.

## Why
Phase 5 entry criteria (closes #29). Group calling is meaningless without a layout that actually shows the participants.

## What changed
- `apps/web/src/call-experience.ts` — new pure helpers `getAllVideoParticipants(participants)` and `getParticipantVideoTrack(participant, source)`. `VideoTrackLike` now carries an optional `source` field so the helpers can target a specific LiveKit track source (camera vs screen share) without reaching into `livekit-client` types.
- `apps/web/src/features/call/call-effects.ts` — new `RemoteVideoTile[]` state replaces the single `remoteVideoTrack`. The sync listener walks every remote participant and builds a tile per `has-video`. Attach/detach happens through a `Map<id, ref>` ref so adding or removing a participant reattaches the right tracks. The single-element `remoteVideoRef` is preserved for the P2P fallback hook, which only ever sees a 1:1 room.
- `apps/web/src/features/call/call-page.tsx` — renders the tile grid, updates the header copy ("Remote" vs "Remotes" and the camera count), and wires each `<video>` through a callback ref into the Map.
- `apps/web/src/App.tsx` — drops the unused `remoteVideoTrack` plumbing and forwards the new `remoteVideoTiles` and `remoteVideoRefMap` props to the call page.

## Tests
- `apps/web/src/call-experience.test.ts` — 6 new cases for `getAllVideoParticipants` and `getParticipantVideoTrack` (every video participant, empty iterable, all audio-only, invalid entries, source match, source miss / muted, null participant).
- Web 117/117, server 189/189, lint clean, typecheck clean.

## Docs
- `TODO.md` moves #29 to `done` with file-pointer notes.
- No new source-of-truth doc updates are needed: the layout is pure UI, the data model did not change, and the API contract is unchanged.

## Out of scope (deferred)
- Active-speaker highlighting. Group rooms still render every remote video at the same size.
- Per-tile mute/leave buttons on the call page. The host moderation panel still uses the room summary list from #27.
- Resizable tile layout. The CSS grid is responsive but not draggable.
