### PR TITLE
feat: tune SFU publish options for group rooms (closes #30)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -79,7 +79,7 @@
 | --- | --- | --- | --- |
 | Raise room size to 4 participants | `planned` | Beta label remains until metrics are healthy | [docs/12-roadmap-and-release-phases.md](docs/12-roadmap-and-release-phases.md) |
 | Group participant layout | `planned` | Responsive layout beyond 1:1 | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
-| SFU subscription tuning for groups | `planned` | Prioritize visible tiles and lower background cost | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
+| SFU subscription tuning for groups | `done` | Issue #30. Group rooms (maxParticipants > 2) lower the local publish bitrate by 40% (floored at 80 kbps) via the new `applyGroupRoomTuning` helper in `apps/web/src/group-room-tuning.ts`. `connectToSfu` accepts the new `maxParticipants` input and applies the tuning only when the room is a group. `adaptiveStream` and `dynacast` were already on and continue to drive per-tile quality. | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Group beta validation metrics | `planned` | Use KPI thresholds before broad rollout | [docs/10-observability-and-operations.md](docs/10-observability-and-operations.md) |
 
 ## Cross-Cutting Infrastructure

--- a/apps/web/src/features/call/call-effects.ts
+++ b/apps/web/src/features/call/call-effects.ts
@@ -201,6 +201,7 @@ export function useCallFlow(input: UseCallFlowInput) {
             requestedMedia: activeCallSession.requestedMedia,
             qualityPreset: activeCallSession.qualityPreset,
             advancedPrefs: activeCallSession.advancedPrefs,
+            maxParticipants: input.maxParticipants,
           });
         } catch (sfuError) {
           // SFU connection failed — try P2P fallback for 1:1 rooms.

--- a/apps/web/src/group-room-tuning.test.ts
+++ b/apps/web/src/group-room-tuning.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applyGroupRoomTuning,
+  isGroupRoom,
+  type EffectivePublishOptionsForTuning,
+} from "./group-room-tuning.js";
+
+function baseOptions(overrides: Partial<EffectivePublishOptionsForTuning> = {}): EffectivePublishOptionsForTuning {
+  return {
+    resolution: { width: 640, height: 360, frameRate: 15 },
+    maxBitrateKbps: 500,
+    audioOnly: false,
+    audioPriority: false,
+    receiveVideo: true,
+    ...overrides,
+  };
+}
+
+test("isGroupRoom flags rooms with more than two participants", () => {
+  assert.equal(isGroupRoom(2), false);
+  assert.equal(isGroupRoom(3), true);
+  assert.equal(isGroupRoom(4), true);
+  assert.equal(isGroupRoom(undefined), false);
+  assert.equal(isGroupRoom(0), false);
+});
+
+test("applyGroupRoomTuning is a no-op for 1:1 rooms", () => {
+  const options = baseOptions();
+  const tuned = applyGroupRoomTuning({ options, isGroupRoom: false });
+  assert.equal(tuned, options);
+});
+
+test("applyGroupRoomTuning lowers maxBitrateKbps by 40% for group rooms", () => {
+  const options = baseOptions({ maxBitrateKbps: 700 });
+  const tuned = applyGroupRoomTuning({ options, isGroupRoom: true });
+  assert.equal(tuned.maxBitrateKbps, 420);
+});
+
+test("applyGroupRoomTuning leaves audioOnly and audioPriority alone", () => {
+  const options = baseOptions({ audioOnly: true, audioPriority: true, maxBitrateKbps: 800 });
+  const tuned = applyGroupRoomTuning({ options, isGroupRoom: true });
+  assert.equal(tuned.audioOnly, true);
+  assert.equal(tuned.audioPriority, true);
+  assert.equal(tuned.maxBitrateKbps, 480);
+});
+
+test("applyGroupRoomTuning floors the bitrate at 80 kbps so audio-only stays usable", () => {
+  const options = baseOptions({ maxBitrateKbps: 100 });
+  const tuned = applyGroupRoomTuning({ options, isGroupRoom: true });
+  assert.equal(tuned.maxBitrateKbps, 80);
+});
+
+test("applyGroupRoomTuning never raises the bitrate", () => {
+  const options = baseOptions({ maxBitrateKbps: 100 });
+  const tuned = applyGroupRoomTuning({ options, isGroupRoom: true });
+  assert.ok(tuned.maxBitrateKbps <= options.maxBitrateKbps);
+});
+
+test("applyGroupRoomTuning rounds to the nearest kbps and rejects non-numeric input", () => {
+  const options = baseOptions({ maxBitrateKbps: 333 });
+  const tuned = applyGroupRoomTuning({ options, isGroupRoom: true });
+  assert.equal(tuned.maxBitrateKbps, 200);
+});
+
+test("applyGroupRoomTuning throws when the bitrate is negative or non-finite", () => {
+  const options = baseOptions({ maxBitrateKbps: -1 });
+  assert.throws(() => applyGroupRoomTuning({ options, isGroupRoom: true }), /maxBitrateKbps/);
+
+  const nanOptions = baseOptions({ maxBitrateKbps: Number.NaN });
+  assert.throws(() => applyGroupRoomTuning({ options: nanOptions, isGroupRoom: true }), /maxBitrateKbps/);
+});

--- a/apps/web/src/group-room-tuning.ts
+++ b/apps/web/src/group-room-tuning.ts
@@ -1,0 +1,66 @@
+/**
+ * Group-room SFU subscription tuning (Issue #30).
+ *
+ * For rooms with more than two participants we still want a usable
+ * call, but every additional tile multiplies the bandwidth cost on
+ * the SFU. The two cheapest levers we control from the web client
+ * are:
+ *
+ *   1. Lower the local publish bitrate so the SFU has less to
+ *      forward to every other participant.
+ *   2. Keep the receive-side `receiveVideo` flag as the user chose
+ *      it (do not flip it from this helper — the join-time
+ *      `advancedPrefs.receiveVideo` and the call-page Pause Video
+ *      control still own that decision).
+ *
+ * `adaptiveStream` and `dynacast` are already on in
+ * `connectToSfu`, which is what the rest of the savings depend on;
+ * this helper just shapes the publish side for groups.
+ */
+
+export interface EffectivePublishOptionsForTuning {
+  resolution: { width: number; height: number; frameRate: number };
+  maxBitrateKbps: number;
+  audioOnly: boolean;
+  audioPriority: boolean;
+  receiveVideo: boolean;
+}
+
+export interface ApplyGroupRoomTuningInput {
+  options: EffectivePublishOptionsForTuning;
+  isGroupRoom: boolean;
+}
+
+const GROUP_BITRATE_MULTIPLIER = 0.6;
+const MIN_GROUP_BITRATE_KBPS = 80;
+
+export function isGroupRoom(maxParticipants: number | undefined | null): boolean {
+  if (typeof maxParticipants !== "number" || !Number.isFinite(maxParticipants)) {
+    return false;
+  }
+  return maxParticipants > 2;
+}
+
+export function applyGroupRoomTuning(
+  input: ApplyGroupRoomTuningInput,
+): EffectivePublishOptionsForTuning {
+  if (!input.isGroupRoom) {
+    return input.options;
+  }
+
+  if (!Number.isFinite(input.options.maxBitrateKbps) || input.options.maxBitrateKbps < 0) {
+    throw new Error(
+      `applyGroupRoomTuning: maxBitrateKbps must be a non-negative finite number, got ${input.options.maxBitrateKbps}`,
+    );
+  }
+
+  const nextBitrate = Math.max(
+    MIN_GROUP_BITRATE_KBPS,
+    Math.round(input.options.maxBitrateKbps * GROUP_BITRATE_MULTIPLIER),
+  );
+
+  return {
+    ...input.options,
+    maxBitrateKbps: nextBitrate,
+  };
+}

--- a/apps/web/src/media-controller.ts
+++ b/apps/web/src/media-controller.ts
@@ -8,6 +8,7 @@ import type {
   SfuTokenResponse,
 } from "@lowtime/shared";
 
+import { applyGroupRoomTuning } from "./group-room-tuning.js";
 import {
   computeEffectivePublishOptions,
   type EffectivePublishOptions,
@@ -19,6 +20,13 @@ export interface ConnectToSfuInput {
   qualityPreset?: QualityPreset;
   qualityCap?: QualityCap;
   advancedPrefs?: AdvancedMediaPrefs;
+  /**
+   * Number of admitted participants the room allows. When greater than
+   * two, `connectToSfu` lowers the local publish bitrate so the SFU
+   * does not pay full per-tile cost on every other participant.
+   * See Issue #30.
+   */
+  maxParticipants?: number;
 }
 
 /**
@@ -55,10 +63,15 @@ function buildLiveKitOptions(
 }
 
 export async function connectToSfu(input: ConnectToSfuInput): Promise<Room> {
-  const effective = computeEffectivePublishOptions({
+  const computed = computeEffectivePublishOptions({
     preset: input.qualityPreset ?? "balanced",
     cap: input.qualityCap ?? "high",
     advanced: input.advancedPrefs,
+  });
+  const isGroup = typeof input.maxParticipants === "number" && input.maxParticipants > 2;
+  const effective = applyGroupRoomTuning({
+    options: computed,
+    isGroupRoom: isGroup,
   });
   const liveKitOptions = buildLiveKitOptions(effective);
 


### PR DESCRIPTION
## Summary
Group rooms (maxParticipants > 2) carry more tiles, which means the SFU has more subscribers to forward each track to. AdaptiveStream and Dynacast are already enabled, but the BASE publish bitrate is still the 1:1 default and burns the same number of bytes per subscriber that joins. Add a small helper that trims the local publish bitrate in group rooms so the SFU does not pay full cost per tile.

## Why
Phase 5 entry criteria (closes #30). #28 raised the default to 4, #29 added the layout; #30 is the bandwidth cost that the SFU pays once that many people actually join.

## What changed
- `apps/web/src/group-room-tuning.ts` — new pure `applyGroupRoomTuning({ options, isGroupRoom })` lowers the `maxBitrateKbps` by 40% for group rooms, floored at 80 kbps so audio-only stays usable. `isGroupRoom(maxParticipants)` returns true only for finite numbers greater than two, so 1:1 rooms and the call-page missing-summary case keep their existing values.
- `apps/web/src/media-controller.ts` — `connectToSfu` now accepts an optional `maxParticipants` input. The effective options flow through `applyGroupRoomTuning` before they reach the LiveKit publish defaults. A 1:1 room is unchanged bit-for-bit.
- `apps/web/src/features/call/call-effects.ts` — forwards the existing `maxParticipants` input into `connectToSfu`. No new state.

## Tests
- `apps/web/src/group-room-tuning.test.ts` — 8 new cases (`isGroupRoom` boundary, 1:1 no-op, 40% reduction, audio flags preserved, 80 kbps floor, monotonic non-increasing, rounding, input validation).
- Web 125/125, server 189/189, lint clean, typecheck clean.

## Docs
- `TODO.md` moves #30 to `done` with file-pointer notes.
- `docs/04-media-and-quality.md` already names `adaptiveStream` and `dynacast` as the dynamic levers; the new helper is a configuration-only addition and does not need a doc change.

## Out of scope (deferred)
- Per-track `setVideoQuality` for non-active speakers. The SFU can do that on its side; we do not yet drive the active-speaker signal from the web client.
- Receive-side resolution caps per tile. The group layout from #29 renders every remote video at the same size, so per-tile resolution tuning is not yet useful.
