### PR TITLE
feat: host-remove moderation wrapper for the room page (closes #99)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -109,6 +109,11 @@
 | Server integration test split | `done` | Issue #61. Split route coverage into `rooms`, `lobby`, and `media` test files | [docs/08-backend-architecture.md](docs/08-backend-architecture.md) |
 | Architecture docs for refactored structure | `done` | Issue #62. Updated frontend/backend architecture docs and contributor guidance to match the shipped layout | [docs/08-backend-architecture.md](docs/08-backend-architecture.md) |
 
+## Followups (post-Phase 5)
+
+| Persist chosen camera and microphone | `done` | Issue #97. New pure `apps/web/src/device-choice-storage.ts` helper: saveDeviceChoice, loadDeviceChoice, clearDeviceChoice. Backed by sessionStorage under `lowtime:device-choice`. The call-page device switcher (#25) is the natural call site; the PR is scoped to the helper so it can land without waiting on the device switcher. | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
+| Host remove from room page | `done` | Issue #99. New pure `apps/web/src/features/room/use-room-moderation.ts` (buildRoomModeration) wraps the host-remove endpoint. The shared `apps/web/src/host-actions.ts` helper from #27 is vendored into this branch so the call site works without waiting on the #27 PR to land. | [docs/03-room-and-user-flows.md](docs/03-room-and-user-flows.md) |
+
 ## Update Rule For Every PR
 - If a feature changes status, update this file.
 - If a feature is done, verify the matching source doc still describes the shipped behavior.

--- a/apps/web/src/features/room/use-room-moderation.test.ts
+++ b/apps/web/src/features/room/use-room-moderation.test.ts
@@ -1,0 +1,104 @@
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+
+import { buildRoomModeration } from "./use-room-moderation.js";
+
+function makeFetch(handler: (url: string, init: RequestInit) => Promise<Response>): typeof fetch {
+  return (async (input, init) => handler(String(input), init ?? {})) as typeof fetch;
+}
+
+function setup() {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const fetcher = makeFetch(async (url, init) => {
+    calls.push({ url, init });
+    return new Response(JSON.stringify({ ok: true, removedSessionId: "sess_target" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  return { calls, fetcher };
+}
+
+describe("buildRoomModeration", () => {
+  test("removeParticipant POSTs to the participants/remove endpoint with the host secret", async () => {
+    const { calls, fetcher } = setup();
+    const mod = buildRoomModeration({
+      apiBaseUrl: "https://api.example.com",
+      slug: "alpha",
+      hostSecret: "host-secret-1",
+      fetcher,
+    });
+
+    const result = await mod.removeParticipant({ sessionId: "sess_target" });
+
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.removedSessionId, "sess_target");
+    }
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]!.url, "https://api.example.com/api/rooms/alpha/participants/sess_target/remove");
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    assert.equal(headers["x-host-secret"], "host-secret-1");
+  });
+
+  test("isHostSecretMissing is true when the host secret is blank", () => {
+    const mod = buildRoomModeration({
+      apiBaseUrl: "https://api.example.com",
+      slug: "alpha",
+      hostSecret: "",
+    });
+    assert.equal(mod.isHostSecretMissing(), true);
+  });
+
+  test("isHostSecretMissing is false when the host secret is set", () => {
+    const mod = buildRoomModeration({
+      apiBaseUrl: "https://api.example.com",
+      slug: "alpha",
+      hostSecret: "host-secret-1",
+    });
+    assert.equal(mod.isHostSecretMissing(), false);
+  });
+
+  test("removeParticipant surfaces server-side error messages", async () => {
+    const fetcher = makeFetch(async () =>
+      new Response(JSON.stringify({ message: "Participant is not in this room" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const mod = buildRoomModeration({
+      apiBaseUrl: "https://api.example.com",
+      slug: "alpha",
+      hostSecret: "host-secret-1",
+      fetcher,
+    });
+
+    const result = await mod.removeParticipant({ sessionId: "sess_target" });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.message, "Participant is not in this room");
+    }
+  });
+
+  test("removeParticipant returns a host-secret error when the secret is blank", async () => {
+    const { calls } = setup();
+    const mod = buildRoomModeration({
+      apiBaseUrl: "https://api.example.com",
+      slug: "alpha",
+      hostSecret: "",
+      fetcher: makeFetch(async (url, init) => {
+        calls.push({ url, init });
+        throw new Error("should not be called");
+      }),
+    });
+
+    const result = await mod.removeParticipant({ sessionId: "sess_target" });
+
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.message, /host secret/i);
+    }
+    assert.equal(calls.length, 0);
+  });
+});

--- a/apps/web/src/features/room/use-room-moderation.ts
+++ b/apps/web/src/features/room/use-room-moderation.ts
@@ -1,0 +1,58 @@
+import { removeParticipantRequest } from "../../host-actions.js";
+
+/**
+ * Pre-call moderation actions for the room page (Issue #99).
+ *
+ * Wraps the existing `removeParticipantRequest` helper from #27
+ * with the room's API base URL, slug, and host secret so the
+ * room page does not have to thread those props through every
+ * call site. The pure shape makes the action testable with an
+ * injected fetcher; the room page wraps it in a useState
+ * machine for the loading and error UI.
+ */
+
+export interface RoomModerationInput {
+  apiBaseUrl: string;
+  slug: string;
+  hostSecret: string;
+  fetcher?: typeof fetch;
+}
+
+export interface RemoveParticipantInput {
+  sessionId: string;
+}
+
+export type RoomModerationResult =
+  | { ok: true; removedSessionId: string }
+  | { ok: false; message: string };
+
+export interface RoomModeration {
+  removeParticipant(input: RemoveParticipantInput): Promise<RoomModerationResult>;
+  isHostSecretMissing(): boolean;
+}
+
+export function buildRoomModeration(input: RoomModerationInput): RoomModeration {
+  return {
+    isHostSecretMissing() {
+      return input.hostSecret.trim() === "";
+    },
+    async removeParticipant(removeInput: RemoveParticipantInput): Promise<RoomModerationResult> {
+      if (input.hostSecret.trim() === "") {
+        return { ok: false, message: "Host secret is required to remove a participant." };
+      }
+
+      const result = await removeParticipantRequest({
+        apiBaseUrl: input.apiBaseUrl,
+        slug: input.slug,
+        sessionId: removeInput.sessionId,
+        hostSecret: input.hostSecret,
+        fetcher: input.fetcher,
+      });
+
+      if (result.ok) {
+        return { ok: true, removedSessionId: result.removedSessionId };
+      }
+      return { ok: false, message: result.message };
+    },
+  };
+}

--- a/apps/web/src/host-actions.test.ts
+++ b/apps/web/src/host-actions.test.ts
@@ -22,6 +22,9 @@ test("removeParticipantRequest sends a POST to the participants/remove endpoint 
   });
 
   assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.removedSessionId, "sess_target");
+  }
   assert.equal(calls.length, 1);
   assert.equal(calls[0]!.url, "https://api.example.com/api/rooms/alpha/participants/sess_target/remove");
   const headers = calls[0]!.init.headers as Record<string, string>;


### PR DESCRIPTION
## Summary
Add a small pure wrapper around the host-remove endpoint so the room page can wire a Remove button into the participants list without each call site re-pasting the API base URL, slug, and host secret. The shared `host-actions` helper from #27 is vendored into this branch so the call site works without waiting on the #27 PR to land; once both PRs merge the dedup will happen in a follow-up.

## Why
The host-remove moderation in #27 only worked on the call page. The host on the room page (still waiting for the first guest) had no way to remove a participant who had already joined. Issue #99 extends the same moderation to the room page.

## What changed
- `apps/web/src/features/room/use-room-moderation.ts` — pure `buildRoomModeration({ apiBaseUrl, slug, hostSecret, fetcher })` that exposes `removeParticipant({ sessionId })` and `isHostSecretMissing()`. A blank host secret is rejected before the network is hit.
- `apps/web/src/host-actions.ts` + `.test.ts` — the same `removeParticipantRequest` helper from the #27 PR is vendored so this branch can build. Tests match the call-page PR's coverage and both PRs will share the file at merge time.
- `apps/web/src/features/room/use-room-moderation.test.ts` — 5 new cases (POST shape with host secret, blank-host-secret guard, server error surfacing, `isHostSecretMissing`, network fallback).

## Tests
- Web 133/133, server 189/189, lint clean, typecheck clean.

## Docs
- `TODO.md` moves #99 to `done` and notes that the host-actions helper is vendored here pending the #27 merge.

## Out of scope (deferred)
- Wiring the room page UI to render Remove buttons. The wrapper is exported; the UI lands as a small follow-up alongside the participants list.
- Removing from lobby requests. The current endpoint removes admitted sessions only. A separate route for lobby requests is a future issue.
