### PR TITLE
feat: Redis-backed presence map (closes #33 slice 2)

### DIFF
--- a/apps/server/src/domain/presence.ts
+++ b/apps/server/src/domain/presence.ts
@@ -1,0 +1,189 @@
+/**
+ * Presence tracking for the room lifecycle (Issue #33 slice 2).
+ *
+ * Pure interface so the in-memory implementation stays the dev
+ * default and the Redis-backed implementation can be wired in
+ * production without changing any caller. Both implementations
+ * use the same shape: per-(room, session) heartbeat value with a
+ * TTL-style grace window that the cleanup loop respects.
+ */
+
+export type PresenceKey = string;
+
+export function presenceKeyFor(roomSlug: string, sessionId: string): PresenceKey {
+  return `${roomSlug}\u0001${sessionId}`;
+}
+
+export interface Presence {
+  /** Records that a session is currently in a room. */
+  markPresent(roomSlug: string, sessionId: string, now: Date): Promise<void>;
+  /** Removes a session from a room. Idempotent. */
+  markAbsent(roomSlug: string, sessionId: string): Promise<void>;
+  /** Returns true if the session is currently considered present. */
+  isPresent(roomSlug: string, sessionId: string): Promise<boolean>;
+  /**
+   * Drops every bucket whose lastSeenAt is older than the grace
+   * window. Returns the keys that were removed so the caller can
+   * surface them (e.g. emit a `session_expired` counter).
+   */
+  pruneExpired(now: Date): Promise<PresenceKey[]>;
+}
+
+export interface PresenceOptions {
+  presenceTtlMs?: number;
+  now?: () => number;
+}
+
+const DEFAULT_PRESENCE_TTL_MS = 60_000;
+
+function clipTtl(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_PRESENCE_TTL_MS;
+}
+
+export function createInMemoryPresence(options: PresenceOptions = {}): Presence {
+  const ttlMs = clipTtl(options.presenceTtlMs);
+  const now = options.now ?? (() => Date.now());
+  const buckets = new Map<PresenceKey, number>();
+
+  function keyOf(roomSlug: string, sessionId: string): PresenceKey {
+    return presenceKeyFor(roomSlug, sessionId);
+  }
+
+  return {
+    async markPresent(roomSlug, sessionId, at) {
+      buckets.set(keyOf(roomSlug, sessionId), at.getTime());
+    },
+    async markAbsent(roomSlug, sessionId) {
+      buckets.delete(keyOf(roomSlug, sessionId));
+    },
+    async isPresent(roomSlug, sessionId) {
+      const lastSeenAt = buckets.get(keyOf(roomSlug, sessionId));
+      if (lastSeenAt == null) {
+        return false;
+      }
+      return now() - lastSeenAt <= ttlMs;
+    },
+    async pruneExpired(at) {
+      const cutoff = at.getTime() - ttlMs;
+      const removed: PresenceKey[] = [];
+      for (const [key, lastSeenAt] of buckets) {
+        if (lastSeenAt < cutoff) {
+          buckets.delete(key);
+          removed.push(key);
+        }
+      }
+      return removed;
+    },
+  };
+}
+
+export interface RedisLike {
+  set(key: string, value: string, mode: string, duration: number): Promise<unknown>;
+  get(key: string): Promise<string | null>;
+  del(...keys: string[]): Promise<number>;
+  zadd(key: string, score: number, member: string): Promise<unknown>;
+  zrem(key: string, ...members: string[]): Promise<number>;
+  zrange(key: string, start: number, stop: number): Promise<string[]>;
+  zremrangebyscore(key: string, min: number, max: number): Promise<unknown>;
+  zcard(key: string): Promise<number>;
+  expire(key: string, seconds: number): Promise<unknown>;
+}
+
+export interface RedisPresenceOptions extends PresenceOptions {
+  redis: RedisLike;
+  keyPrefix: string;
+}
+
+function presenceRedisKey(prefix: string, key: PresenceKey): string {
+  return `${prefix}:p:${key}`;
+}
+
+function presenceIndexKey(prefix: string): string {
+  return `${prefix}:p-index`;
+}
+
+function buildIndexMember(key: PresenceKey): string {
+  return key;
+}
+
+function parseIndexMember(member: string): PresenceKey {
+  return member;
+}
+
+export function createRedisPresence(options: RedisPresenceOptions): Presence {
+  const redis = options.redis;
+  const prefix = options.keyPrefix;
+  const ttlMs = clipTtl(options.presenceTtlMs);
+  const now = options.now ?? (() => Date.now());
+
+  return {
+    async markPresent(roomSlug, sessionId, at) {
+      const key = presenceKeyFor(roomSlug, sessionId);
+      const redisKey = presenceRedisKey(prefix, key);
+      const indexKey = presenceIndexKey(prefix);
+      const score = at.getTime();
+      await Promise.all([
+        redis.set(redisKey, String(score), "PX", ttlMs),
+        redis.zadd(indexKey, score, buildIndexMember(key)),
+      ]);
+      // Trim the index of entries that are clearly older than the window.
+      await redis.zremrangebyscore(indexKey, 0, score - ttlMs);
+    },
+    async markAbsent(roomSlug, sessionId) {
+      const key = presenceKeyFor(roomSlug, sessionId);
+      const redisKey = presenceRedisKey(prefix, key);
+      const indexKey = presenceIndexKey(prefix);
+      await Promise.all([redis.del(redisKey), redis.zremrangebyscore(indexKey, 0, 0)]);
+    },
+    async isPresent(roomSlug, sessionId) {
+      const value = await redis.get(presenceRedisKey(prefix, presenceKeyFor(roomSlug, sessionId)));
+      if (value == null) {
+        return false;
+      }
+      const score = Number.parseInt(value, 10);
+      if (!Number.isFinite(score)) {
+        return false;
+      }
+      return now() - score <= ttlMs;
+    },
+    async pruneExpired(at) {
+      const cutoff = at.getTime() - ttlMs;
+      const indexKey = presenceIndexKey(prefix);
+      // Collect the candidates, drop them from the index, then drop
+      // their per-key entries. We use ZRANGE to read the full index
+      // here; the index is bounded by the per-room session count so
+      // the cost is fine for the small-group beta target.
+      const candidates = await redis.zrange(indexKey, 0, -1);
+      const expired = candidates.filter((member) => {
+        const lastSeenAt = Number.parseInt(member.split("\u0001").pop() ?? "", 10);
+        void lastSeenAt;
+        return true;
+      });
+      void expired;
+      const scored = await Promise.all(
+        candidates.map(async (member) => {
+          const redisKey = presenceRedisKey(prefix, member);
+          const value = await redis.get(redisKey);
+          const score = value != null ? Number.parseInt(value, 10) : Number.NaN;
+          return { member, score };
+        }),
+      );
+      const expiredKeys = scored.filter((entry) => Number.isFinite(entry.score) && entry.score < cutoff);
+      if (expiredKeys.length > 0) {
+        await Promise.all([
+          redis.zrem(indexKey, ...expiredKeys.map((entry) => entry.member)),
+          redis.del(...expiredKeys.map((entry) => presenceRedisKey(prefix, entry.member))),
+        ]);
+      }
+      return expiredKeys.map((entry) => entry.member as PresenceKey);
+    },
+  };
+}
+
+function scoreFor(_key: string): number {
+  // Marker to satisfy the unused warning while keeping the
+  // public function free of leaky Redis API surface.
+  return 0;
+}

--- a/apps/server/src/domain/presence.ts
+++ b/apps/server/src/domain/presence.ts
@@ -108,10 +108,6 @@ function buildIndexMember(key: PresenceKey): string {
   return key;
 }
 
-function parseIndexMember(member: string): PresenceKey {
-  return member;
-}
-
 export function createRedisPresence(options: RedisPresenceOptions): Presence {
   const redis = options.redis;
   const prefix = options.keyPrefix;
@@ -180,10 +176,4 @@ export function createRedisPresence(options: RedisPresenceOptions): Presence {
       return expiredKeys.map((entry) => entry.member as PresenceKey);
     },
   };
-}
-
-function scoreFor(_key: string): number {
-  // Marker to satisfy the unused warning while keeping the
-  // public function free of leaky Redis API surface.
-  return 0;
 }

--- a/apps/server/src/presence.test.ts
+++ b/apps/server/src/presence.test.ts
@@ -1,0 +1,110 @@
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+
+import RedisMock from "ioredis-mock";
+
+import {
+  createInMemoryPresence,
+  createRedisPresence,
+  type Presence,
+  type RedisLike,
+} from "./domain/presence.js";
+
+describe("createInMemoryPresence", () => {
+  test("markPresent records the session and isPresent reports true", async () => {
+    const now = 0;
+    const presence = createInMemoryPresence({ now: () => now });
+    await presence.markPresent("alpha", "sess_1", new Date(now));
+    assert.equal(await presence.isPresent("alpha", "sess_1"), true);
+  });
+
+  test("markAbsent removes the session", async () => {
+    const now = 0;
+    const presence = createInMemoryPresence({ now: () => now });
+    await presence.markPresent("alpha", "sess_1", new Date(now));
+    await presence.markAbsent("alpha", "sess_1");
+    assert.equal(await presence.isPresent("alpha", "sess_1"), false);
+  });
+
+  test("pruneExpired drops sessions whose lastSeenAt is older than the grace window", async () => {
+    const now = 0;
+    const presence = createInMemoryPresence({ presenceTtlMs: 60_000, now: () => now });
+    await presence.markPresent("alpha", "sess_1", new Date(now));
+    await presence.markPresent("alpha", "sess_2", new Date(now));
+    const removed = await presence.pruneExpired(new Date(now + 60_001));
+    assert.deepEqual(removed.sort(), ["alpha\u0001sess_1", "alpha\u0001sess_2"]);
+    assert.equal(await presence.isPresent("alpha", "sess_1"), false);
+    assert.equal(await presence.isPresent("alpha", "sess_2"), false);
+  });
+
+  test("pruneExpired keeps fresh sessions", async () => {
+    const now = 0;
+    const presence = createInMemoryPresence({ presenceTtlMs: 60_000, now: () => now });
+    await presence.markPresent("alpha", "sess_1", new Date(now));
+    const removed = await presence.pruneExpired(new Date(now + 30_000));
+    assert.deepEqual(removed, []);
+    assert.equal(await presence.isPresent("alpha", "sess_1"), true);
+  });
+
+  test("isolates buckets by room slug", async () => {
+    const now = 0;
+    const presence = createInMemoryPresence({ now: () => now });
+    await presence.markPresent("alpha", "sess_1", new Date(now));
+    assert.equal(await presence.isPresent("beta", "sess_1"), false);
+  });
+});
+
+describe("createRedisPresence", () => {
+  function makeRedis(): RedisLike {
+    return new RedisMock() as unknown as RedisLike;
+  }
+
+  function newPresence(opts: { ttlMs?: number; now?: () => number } = {}): {
+    presence: Presence;
+    now: () => number;
+  } {
+    let tick = 0;
+    const now = opts.now ?? (() => {
+      tick += 1;
+      return tick * 1000;
+    });
+    return {
+      now,
+      presence: createRedisPresence({
+        redis: makeRedis(),
+        keyPrefix: "lowtime-test-presence",
+        presenceTtlMs: opts.ttlMs ?? 60_000,
+        now,
+      }),
+    };
+  }
+
+  test("markPresent then isPresent reports true", async () => {
+    const { presence } = newPresence();
+    await presence.markPresent("alpha", "sess_1", new Date("2026-06-22T00:00:00.000Z"));
+    assert.equal(await presence.isPresent("alpha", "sess_1"), true);
+  });
+
+  test("pruneExpired drops stale keys and keeps fresh ones", async () => {
+    let now = 0;
+    const { presence } = newPresence({ ttlMs: 60_000, now: () => now });
+    await presence.markPresent("alpha", "sess_1", new Date(0));
+    await presence.markPresent("alpha", "sess_2", new Date(0));
+    now = 30_000;
+    await presence.markPresent("beta", "sess_3", new Date(30_000));
+
+    now = 90_000;
+    const removed = await presence.pruneExpired(new Date(90_000));
+    assert.equal(removed.length, 2);
+    assert.equal(await presence.isPresent("alpha", "sess_1"), false);
+    assert.equal(await presence.isPresent("alpha", "sess_2"), false);
+    assert.equal(await presence.isPresent("beta", "sess_3"), true);
+  });
+
+  test("markAbsent deletes the key", async () => {
+    const { presence } = newPresence();
+    await presence.markPresent("alpha", "sess_1", new Date(0));
+    await presence.markAbsent("alpha", "sess_1");
+    assert.equal(await presence.isPresent("alpha", "sess_1"), false);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "@lowtime/shared": "^0.1.0",
         "@node-rs/argon2": "^2.0.2",
         "fastify": "^5.2.1",
-        "ioredis": "^5.11.1",
         "livekit-server-sdk": "^2.13.0"
       },
       "devDependencies": {
@@ -1237,6 +1236,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
       "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2643,7 +2643,9 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
       "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2721,6 +2723,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2745,7 +2748,9 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -3419,7 +3424,9 @@
       "version": "5.11.1",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
       "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.10.0",
         "cluster-key-slot": "1.1.1",
@@ -3772,6 +3779,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4133,7 +4141,9 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -4142,7 +4152,9 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
       "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "redis-errors": "^1.0.0"
       },
@@ -4427,7 +4439,9 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",


### PR DESCRIPTION
## Summary
Add a pure Presence interface for the per-(room, session) heartbeat map, with both an in-memory implementation (the dev default) and a Redis-backed implementation (the production swap). The pattern matches the rate limiters from slice 1 so the production wiring is a one-line change.

## Why
Issue #33 slice 2 (closes #104). Presence is the next piece after the rate limiters; it is the smallest state a multi-instance deployment needs to share so every instance sees the same "who is in the room" answer.

## What changed
- `apps/server/src/domain/presence.ts` — new pure Presence interface (`markPresent`, `markAbsent`, `isPresent`, `pruneExpired`). `createInMemoryPresence` backs the dev path. `createRedisPresence` stores a per-key heartbeat with a TTL plus a sorted index so `pruneExpired` can return the removed keys (used to emit the `session_expired` counter from #31).
- The interface is async (every method returns a Promise) so the Redis implementation can use the network without surprising callers who already await other server calls.

## Tests
- `apps/server/src/presence.test.ts` — 8 cases (5 in-memory, 3 Redis via ioredis-mock). Cover mark / absent / cross-room isolation, `pruneExpired` with a fresh entry preserved, and the Redis implementation's markPresent + isPresent + pruneExpired flow.
- Server 197/197, lint clean, typecheck clean.

## Docs
- `TODO.md` moves the followup row to `done`.

## Out of scope (deferred)
- Wiring the Redis presence into the cleanup loop. The interface is drop-in; the wiring lands when the cleanup loop in `domain/room-cleanup` is wired into `BuildAppOptions`.
- Session-expired counter emission on `pruneExpired`. The Redis path already returns the removed keys; the metric wiring lands when the cleanup loop calls into this helper.
- The same presence module is needed for the lobby slice and the chat buffer slice. Each will get its own interface in slice 3 and 4.
