### PR TITLE
feat: Redis-backed reconnect window (closes #33 slice 4)

### DIFF
--- a/apps/server/src/domain/reconnect-state.ts
+++ b/apps/server/src/domain/reconnect-state.ts
@@ -1,0 +1,148 @@
+/**
+ * Reconnect window state (Issue #33 slice 4).
+ *
+ * Pure interface so the in-memory implementation stays the dev
+ * default and the Redis-backed implementation can be wired in
+ * production. The room store already keeps the per-session
+ * lastSeenAt; this module adds the explicit "disconnected at"
+ * marker that the reconnect flow checks before the TTL elapses.
+ */
+
+export interface ReconnectState {
+  markDisconnected(sessionId: string, at: Date): Promise<void>;
+  isReconnectable(sessionId: string, now: Date): Promise<boolean>;
+  clear(sessionId: string): Promise<void>;
+  reapExpired(now: Date): Promise<string[]>;
+}
+
+export interface ReconnectStateOptions {
+  windowMs?: number;
+  now?: () => number;
+}
+
+const DEFAULT_WINDOW_MS = 5 * 60_000;
+
+function clipWindow(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_WINDOW_MS;
+}
+
+export function createInMemoryReconnectState(options: ReconnectStateOptions = {}): ReconnectState {
+  const windowMs = clipWindow(options.windowMs);
+  const now = options.now ?? (() => Date.now());
+  const buckets = new Map<string, number>();
+
+  return {
+    async markDisconnected(sessionId, at) {
+      buckets.set(sessionId, at.getTime());
+    },
+    async isReconnectable(sessionId, at) {
+      const disconnectedAt = buckets.get(sessionId);
+      if (disconnectedAt == null) {
+        return false;
+      }
+      return at.getTime() - disconnectedAt <= windowMs;
+    },
+    async clear(sessionId) {
+      buckets.delete(sessionId);
+    },
+    async reapExpired(at) {
+      const cutoff = at.getTime() - windowMs;
+      const removed: string[] = [];
+      for (const [sessionId, disconnectedAt] of buckets) {
+        if (disconnectedAt < cutoff) {
+          buckets.delete(sessionId);
+          removed.push(sessionId);
+        }
+      }
+      return removed;
+    },
+  };
+}
+
+export interface RedisLike {
+  set(key: string, value: string, mode: string, duration: number): Promise<unknown>;
+  get(key: string): Promise<string | null>;
+  del(...keys: string[]): Promise<number>;
+  zadd(key: string, score: number, member: string): Promise<unknown>;
+  zrem(key: string, ...members: string[]): Promise<number>;
+  zremrangebyscore(key: string, min: number, max: number): Promise<unknown>;
+  zrange(key: string, start: number, stop: number): Promise<string[]>;
+  zcard(key: string): Promise<number>;
+}
+
+export interface RedisReconnectStateOptions extends ReconnectStateOptions {
+  redis: RedisLike;
+  keyPrefix: string;
+}
+
+function keyFor(prefix: string, sessionId: string): string {
+  return `${prefix}:r:${sessionId}`;
+}
+
+function indexKey(prefix: string): string {
+  return `${prefix}:r-index`;
+}
+
+export function createRedisReconnectState(options: RedisReconnectStateOptions): ReconnectState {
+  const redis = options.redis;
+  const prefix = options.keyPrefix;
+  const windowMs = clipWindow(options.windowMs);
+  const now = options.now ?? (() => Date.now());
+
+  return {
+    async markDisconnected(sessionId, at) {
+      const score = at.getTime();
+      const k = keyFor(prefix, sessionId);
+      const idx = indexKey(prefix);
+      await Promise.all([
+        redis.set(k, String(score), "PX", windowMs),
+        redis.zadd(idx, score, sessionId),
+      ]);
+      await redis.zremrangebyscore(idx, 0, score - windowMs);
+    },
+    async isReconnectable(sessionId, at) {
+      const raw = await redis.get(keyFor(prefix, sessionId));
+      if (raw == null) {
+        return false;
+      }
+      const disconnectedAt = Number.parseInt(raw, 10);
+      if (!Number.isFinite(disconnectedAt)) {
+        return false;
+      }
+      return at.getTime() - disconnectedAt <= windowMs;
+    },
+    async clear(sessionId) {
+      await Promise.all([
+        redis.del(keyFor(prefix, sessionId)),
+        redis.zrem(indexKey(prefix), sessionId),
+      ]);
+    },
+    async reapExpired(at) {
+      const cutoff = at.getTime() - windowMs;
+      const idx = indexKey(prefix);
+      const candidates = await redis.zrange(idx, 0, -1);
+      const toRemove: string[] = [];
+      for (const sessionId of candidates) {
+        const value = await redis.get(keyFor(prefix, sessionId));
+        if (value == null) {
+          toRemove.push(sessionId);
+          continue;
+        }
+        const score = Number.parseInt(value, 10);
+        if (!Number.isFinite(score) || score < cutoff) {
+          toRemove.push(sessionId);
+        }
+      }
+      if (toRemove.length > 0) {
+        await Promise.all([
+          redis.zrem(idx, ...toRemove),
+          redis.del(...toRemove.map((sessionId) => keyFor(prefix, sessionId))),
+        ]);
+      }
+      void cutoff;
+      return toRemove;
+    },
+  };
+}

--- a/apps/server/src/domain/reconnect-state.ts
+++ b/apps/server/src/domain/reconnect-state.ts
@@ -30,7 +30,6 @@ function clipWindow(value: number | undefined): number {
 
 export function createInMemoryReconnectState(options: ReconnectStateOptions = {}): ReconnectState {
   const windowMs = clipWindow(options.windowMs);
-  const now = options.now ?? (() => Date.now());
   const buckets = new Map<string, number>();
 
   return {
@@ -89,7 +88,6 @@ export function createRedisReconnectState(options: RedisReconnectStateOptions): 
   const redis = options.redis;
   const prefix = options.keyPrefix;
   const windowMs = clipWindow(options.windowMs);
-  const now = options.now ?? (() => Date.now());
 
   return {
     async markDisconnected(sessionId, at) {

--- a/apps/server/src/reconnect-state.test.ts
+++ b/apps/server/src/reconnect-state.test.ts
@@ -1,0 +1,95 @@
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+
+import RedisMock from "ioredis-mock";
+
+import {
+  createInMemoryReconnectState,
+  createRedisReconnectState,
+  type RedisLike,
+} from "./domain/reconnect-state.js";
+
+function now(offsetMs: number = 0): Date {
+  return new Date(Date.UTC(2026, 5, 22, 12, 0, 0, offsetMs));
+}
+
+describe("createInMemoryReconnectState", () => {
+  test("markDisconnected then isReconnectable reports true within the window", async () => {
+    const state = createInMemoryReconnectState();
+    await state.markDisconnected("sess_1", now());
+    assert.equal(await state.isReconnectable("sess_1", now(10_000)), true);
+  });
+
+  test("isReconnectable returns false after the window expires", async () => {
+    const state = createInMemoryReconnectState({ windowMs: 60_000 });
+    await state.markDisconnected("sess_1", now());
+    assert.equal(await state.isReconnectable("sess_1", now(61_000)), false);
+  });
+
+  test("isReconnectable returns false for an unknown session", async () => {
+    const state = createInMemoryReconnectState();
+    assert.equal(await state.isReconnectable("sess_missing", now()), false);
+  });
+
+  test("clear marks the session as no longer reconnectable", async () => {
+    const state = createInMemoryReconnectState();
+    await state.markDisconnected("sess_1", now());
+    await state.clear("sess_1");
+    assert.equal(await state.isReconnectable("sess_1", now(1000)), false);
+  });
+
+  test("reapExpired drops buckets past the window", async () => {
+    const state = createInMemoryReconnectState({ windowMs: 60_000 });
+    await state.markDisconnected("sess_old", now());
+    await state.markDisconnected("sess_fresh", now(50_000));
+    const removed = await state.reapExpired(now(61_000));
+    assert.deepEqual(removed.sort(), ["sess_old"]);
+    assert.equal(await state.isReconnectable("sess_old", now(61_000)), false);
+    assert.equal(await state.isReconnectable("sess_fresh", now(61_000)), true);
+  });
+});
+
+describe("createRedisReconnectState", () => {
+  function makeRedis(): RedisLike {
+    return new RedisMock() as unknown as RedisLike;
+  }
+
+  function newState(suffix: string, opts: { windowMs?: number } = {}): ReturnType<typeof createRedisReconnectState> {
+    return createRedisReconnectState({
+      redis: makeRedis(),
+      keyPrefix: `lowtime-test-reconnect-${suffix}-${Math.random().toString(36).slice(2, 8)}`,
+      windowMs: opts.windowMs,
+    });
+  }
+
+  test("markDisconnected then isReconnectable reports true within the window", async () => {
+    const state = newState("basic");
+    await state.markDisconnected("sess_1", now());
+    assert.equal(await state.isReconnectable("sess_1", now(10_000)), true);
+  });
+
+  test("isReconnectable returns false after the window expires", async () => {
+    const state = newState("expire", { windowMs: 60_000 });
+    await state.markDisconnected("sess_1", now());
+    assert.equal(await state.isReconnectable("sess_1", now(61_000)), false);
+  });
+
+  test("clear marks the session as no longer reconnectable", async () => {
+    const state = newState("clear");
+    await state.markDisconnected("sess_1", now());
+    await state.clear("sess_1");
+    assert.equal(await state.isReconnectable("sess_1", now(1000)), false);
+  });
+
+  test("reapExpired drops buckets past the window", async () => {
+    const state = newState("reap", { windowMs: 60_000 });
+    await state.markDisconnected("sess_old", now());
+    await state.markDisconnected("sess_fresh", now(50_000));
+    const removed = await state.reapExpired(now(61_000));
+    assert.deepEqual(removed.sort(), ["sess_old"]);
+    assert.equal(await state.isReconnectable("sess_old", now(61_000)), false);
+    assert.equal(await state.isReconnectable("sess_fresh", now(61_000)), true);
+  });
+});
+
+void createInMemoryReconnectState;


### PR DESCRIPTION
## Summary
Add a pure ReconnectState interface for the per-session disconnect marker, with both an in-memory implementation and a Redis-backed implementation. Same pattern as presence + lobby so the production wiring is a one-line change.

## Why
Issue #33 slice 4 (closes #110). The room store already keeps `lastSeenAt`; this module adds the explicit "disconnected at" marker that the reconnect flow checks before the TTL elapses, so the data can live in Redis once a multi-instance deployment lands.

## What changed
- `apps/server/src/domain/reconnect-state.ts` — new pure ReconnectState interface (`markDisconnected`, `isReconnectable`, `clear`, `reapExpired`). `createInMemoryReconnectState` backs the dev path. `createRedisReconnectState` stores a per-session disconnect timestamp with a TTL plus a sorted index so `reapExpired` returns the removed session ids.
- The interface is async so the Redis implementation can use the network without surprising callers.

## Tests
- `apps/server/src/reconnect-state.test.ts` — 9 new cases (5 in-memory, 4 Redis via ioredis-mock). Cover mark, check, expiry, unknown session, clear, and the reap. Each Redis test uses a unique keyPrefix so the mock state is isolated.
- Server 198/198, lint clean, typecheck clean.

## Docs
- `TODO.md` moves the followup row to `done`.

## Out of scope (deferred)
- Wiring the Redis reconnect state into the room cleanup loop and the connect / disconnect path. The interface is drop-in; the wiring lands when the team is ready to run with a real Redis.
- Issue #33 slice 5 (chat buffer) still needs its own pure interface and Redis-backed implementation.
- The PG-backed room store (#32 slice 2) is the natural next migration target.
