### PR TITLE
feat: Redis-backed chat buffer (closes #33 slice 5)

### DIFF
--- a/apps/server/src/chat-buffer.test.ts
+++ b/apps/server/src/chat-buffer.test.ts
@@ -19,7 +19,6 @@ function entry(text: string, offsetMs: number, senderId = "sess_1"): ChatEntry {
     senderName: "Alice",
     body: text,
     sentAt: new Date(Date.UTC(2026, 5, 22, 12, 0, 0, offsetMs)).toISOString(),
-    _baseMs: Date.UTC(2026, 5, 22, 12, 0, 0, offsetMs),
   };
 }
 

--- a/apps/server/src/chat-buffer.test.ts
+++ b/apps/server/src/chat-buffer.test.ts
@@ -11,10 +11,6 @@ import {
   type RedisLike,
 } from "./domain/chat-buffer.js";
 
-function now(offsetMs: number = 0): Date {
-  return new Date(Date.UTC(2026, 5, 22, 12, 0, 0, offsetMs));
-}
-
 function entry(text: string, offsetMs: number, senderId = "sess_1"): ChatEntry {
   return {
     id: `m_${offsetMs}_${text}`,
@@ -23,6 +19,7 @@ function entry(text: string, offsetMs: number, senderId = "sess_1"): ChatEntry {
     senderName: "Alice",
     body: text,
     sentAt: new Date(Date.UTC(2026, 5, 22, 12, 0, 0, offsetMs)).toISOString(),
+    _baseMs: Date.UTC(2026, 5, 22, 12, 0, 0, offsetMs),
   };
 }
 

--- a/apps/server/src/chat-buffer.test.ts
+++ b/apps/server/src/chat-buffer.test.ts
@@ -1,0 +1,101 @@
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+
+import RedisMock from "ioredis-mock";
+
+import {
+  createInMemoryChatBuffer,
+  createRedisChatBuffer,
+  type ChatBuffer,
+  type ChatEntry,
+  type RedisLike,
+} from "./domain/chat-buffer.js";
+
+function now(offsetMs: number = 0): Date {
+  return new Date(Date.UTC(2026, 5, 22, 12, 0, 0, offsetMs));
+}
+
+function entry(text: string, offsetMs: number, senderId = "sess_1"): ChatEntry {
+  return {
+    id: `m_${offsetMs}_${text}`,
+    roomSlug: "alpha",
+    senderId,
+    senderName: "Alice",
+    body: text,
+    sentAt: new Date(Date.UTC(2026, 5, 22, 12, 0, 0, offsetMs)).toISOString(),
+  };
+}
+
+describe("createInMemoryChatBuffer", () => {
+  test("append then list returns the messages in order", async () => {
+    const buffer = createInMemoryChatBuffer();
+    await buffer.append("alpha", entry("hi", 0));
+    await buffer.append("alpha", entry("there", 1));
+    const messages = await buffer.list("alpha");
+    assert.equal(messages.length, 2);
+    assert.equal(messages[0]?.body, "hi");
+    assert.equal(messages[1]?.body, "there");
+  });
+
+  test("the buffer is bounded by the cap and drops the oldest first", async () => {
+    const buffer = createInMemoryChatBuffer({ capacity: 2 });
+    await buffer.append("alpha", entry("first", 0));
+    await buffer.append("alpha", entry("second", 1));
+    await buffer.append("alpha", entry("third", 2));
+    const messages = await buffer.list("alpha");
+    assert.equal(messages.length, 2);
+    assert.equal(messages[0]?.body, "second");
+    assert.equal(messages[1]?.body, "third");
+  });
+
+  test("list returns only messages for the given room", async () => {
+    const buffer = createInMemoryChatBuffer();
+    await buffer.append("alpha", entry("a", 0));
+    await buffer.append("beta", entry("b", 1));
+    assert.equal((await buffer.list("alpha")).length, 1);
+    assert.equal((await buffer.list("beta")).length, 1);
+  });
+});
+
+describe("createRedisChatBuffer", () => {
+  function makeRedis(): RedisLike {
+    return new RedisMock() as unknown as RedisLike;
+  }
+
+  function newBuffer(suffix: string, capacity?: number): ChatBuffer {
+    return createRedisChatBuffer({
+      redis: makeRedis(),
+      keyPrefix: `lowtime-test-chat-${suffix}-${Math.random().toString(36).slice(2, 8)}`,
+      capacity,
+    });
+  }
+
+  test("append then list returns the messages in order", async () => {
+    const buffer = newBuffer("order");
+    await buffer.append("alpha", entry("hi", 0));
+    await buffer.append("alpha", entry("there", 1));
+    const messages = await buffer.list("alpha");
+    assert.equal(messages.length, 2);
+    assert.equal(messages[0]?.body, "hi");
+    assert.equal(messages[1]?.body, "there");
+  });
+
+  test("the buffer is bounded by the cap and drops the oldest first", async () => {
+    const buffer = newBuffer("cap", 2);
+    await buffer.append("alpha", entry("first", 0));
+    await buffer.append("alpha", entry("second", 1));
+    await buffer.append("alpha", entry("third", 2));
+    const messages = await buffer.list("alpha");
+    assert.equal(messages.length, 2);
+    assert.equal(messages[0]?.body, "second");
+    assert.equal(messages[1]?.body, "third");
+  });
+
+  test("list returns only messages for the given room", async () => {
+    const buffer = newBuffer("rooms");
+    await buffer.append("alpha", entry("a", 0));
+    await buffer.append("beta", entry("b", 1));
+    assert.equal((await buffer.list("alpha")).length, 1);
+    assert.equal((await buffer.list("beta")).length, 1);
+  });
+});

--- a/apps/server/src/domain/chat-buffer.ts
+++ b/apps/server/src/domain/chat-buffer.ts
@@ -1,0 +1,97 @@
+/**
+ * Bounded per-room chat history (Issue #33 slice 5).
+ *
+ * Pure interface so the in-memory implementation stays the dev
+ * default and the Redis-backed implementation can be wired in
+ * production. The signal bus already broadcasts new messages;
+ * this module adds the bounded history the chat panel can
+ * rehydrate after a refresh.
+ */
+
+export interface ChatEntry {
+  id: string;
+  roomSlug: string;
+  senderId: string;
+  senderName: string;
+  body: string;
+  sentAt: string;
+}
+
+export interface ChatBuffer {
+  append(roomSlug: string, entry: ChatEntry): Promise<void>;
+  list(roomSlug: string): Promise<ChatEntry[]>;
+}
+
+export interface ChatBufferOptions {
+  capacity?: number;
+}
+
+const DEFAULT_CAPACITY = 100;
+
+function clipCapacity(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_CAPACITY;
+}
+
+export function createInMemoryChatBuffer(options: ChatBufferOptions = {}): ChatBuffer {
+  const capacity = clipCapacity(options.capacity);
+  const buffers = new Map<string, ChatEntry[]>();
+
+  return {
+    async append(roomSlug, entry) {
+      const list = buffers.get(roomSlug) ?? [];
+      list.push(entry);
+      if (list.length > capacity) {
+        list.splice(0, list.length - capacity);
+      }
+      buffers.set(roomSlug, list);
+    },
+    async list(roomSlug) {
+      return [...(buffers.get(roomSlug) ?? [])];
+    },
+  };
+}
+
+export interface RedisLike {
+  lpush(key: string, ...values: string[]): Promise<number>;
+  lrange(key: string, start: number, stop: number): Promise<string[]>;
+  ltrim(key: string, start: number, stop: number): Promise<unknown>;
+  del(...keys: string[]): Promise<number>;
+}
+
+export interface RedisChatBufferOptions extends ChatBufferOptions {
+  redis: RedisLike;
+  keyPrefix: string;
+}
+
+function keyFor(prefix: string, roomSlug: string): string {
+  return `${prefix}:chat:${roomSlug}`;
+}
+
+export function createRedisChatBuffer(options: RedisChatBufferOptions): ChatBuffer {
+  const redis = options.redis;
+  const prefix = options.keyPrefix;
+  const capacity = clipCapacity(options.capacity);
+
+  return {
+    async append(roomSlug, entry) {
+      const k = keyFor(prefix, roomSlug);
+      await redis.lpush(k, JSON.stringify(entry));
+      await redis.ltrim(k, 0, capacity - 1);
+    },
+    async list(roomSlug) {
+      const raws = await redis.lrange(keyFor(prefix, roomSlug), 0, capacity - 1);
+      const items = raws
+        .map((raw) => {
+          try {
+            return JSON.parse(raw) as ChatEntry;
+          } catch {
+            return null;
+          }
+        })
+        .filter((entry): entry is ChatEntry => entry != null);
+      return items.reverse();
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Add a pure ChatBuffer interface for the bounded per-room chat history, with both an in-memory implementation and a Redis-backed implementation. Same pattern as presence + lobby + reconnect so the production wiring is a one-line change.

## Why
Issue #33 slice 5 (closes #112). The signal bus already broadcasts new messages; this module adds the bounded history the chat panel can rehydrate after a refresh.

## What changed
- `apps/server/src/domain/chat-buffer.ts` — new pure ChatBuffer interface (`append`, `list`). `createInMemoryChatBuffer` backs the dev path. `createRedisChatBuffer` stores the last N messages per room as a Redis list, trimmed to the configured capacity.
- The interface is async so the Redis implementation can use the network without surprising callers.
- `list()` returns the messages in chronological order; the Redis path reverses the result because `LPUSH` + `LRANGE 0 N` returns newest-first.

## Tests
- `apps/server/src/chat-buffer.test.ts` — 6 new cases (3 in-memory, 3 Redis via ioredis-mock). Cover append + order, the capacity cap, and the per-room split. Each Redis test uses a unique keyPrefix so the mock state is isolated.
- Server 204/204, lint clean, typecheck clean.

## Docs
- `TODO.md` moves the followup row to `done`.

## Out of scope (deferred)
- Wiring the chat buffer into the `chat.send` path so the history is hydrated when a session joins. The interface is drop-in; the wiring lands when the team is ready to run with a real Redis.
- The PG-backed room store (#32 slice 2) is the natural next migration target for the durable state.
- PG-backed chat history (durable across restarts) is a separate follow-up. The Redis buffer is a short-window cache; PG is the source of truth for older messages.
