### PR TITLE
feat: PG-backed room metadata store (closes #32 slice 2)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -86,7 +86,7 @@
 
 | Feature | Status | Notes | Source |
 | --- | --- | --- | --- |
-| PostgreSQL room metadata | `planned` | Durable room state and audit events | [docs/06-data-model-and-lifecycle.md](docs/06-data-model-and-lifecycle.md) |
+| PostgreSQL room metadata | `in_progress` | Durable room state and audit events. Slice 1 (client + migration) shipped in PR #106; slice 2 (room store) in progress. | [docs/06-data-model-and-lifecycle.md](docs/06-data-model-and-lifecycle.md) |
 | Redis live room state | `planned` | Presence, lobby, reconnect, rate limits, chat buffer | [docs/06-data-model-and-lifecycle.md](docs/06-data-model-and-lifecycle.md) |
 | coturn integration | `planned` | NAT traversal and relay support | [docs/02-system-architecture.md](docs/02-system-architecture.md) |
 | Docker-based deployment packaging | `done` | Compose now defines web, server, postgres, redis, coturn, and optional LiveKit services | [docs/02-system-architecture.md](docs/02-system-architecture.md) |

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -21,9 +21,12 @@
     "pg": "^8.22.0"
   },
   "devDependencies": {
+    "@types/ioredis-mock": "^8.2.7",
     "@types/node": "^22.15.30",
     "@types/pg": "^8.20.0",
     "fast-check": "^4.7.0",
+    "ioredis-mock": "^8.13.1",
+    "pg": "^8.22.0",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3"
   }

--- a/apps/server/src/domain/pg-room-metadata.ts
+++ b/apps/server/src/domain/pg-room-metadata.ts
@@ -1,0 +1,147 @@
+import type { AccessMode, QualityCap, RoomSlug } from "@lowtime/shared";
+
+import type { PgClient } from "./pg.js";
+
+/**
+ * PG-backed room metadata store (Issue #32 slice 2).
+ *
+ * The current RoomStore in `domain/room-store.ts` keeps every
+ * piece of state in process memory. This module adds the
+ * smallest durable piece: a `room_metadata` table that survives
+ * a process restart. Sessions, lobby requests, and rate
+ * limiter state still live in memory (or in Redis once the
+ * #33 wiring lands); this slice just makes the room-level
+ * metadata durable so the next slice can swap the in-memory
+ * store wholesale.
+ *
+ * The store is a small helper that matches the in-memory
+ * `RoomStore.createRoom` + `getRoom` shape closely, so the
+ * eventual swap is one factory call in `server-support.ts`.
+ */
+
+export interface RoomMetadataCreate {
+  slug: RoomSlug;
+  accessMode: AccessMode;
+  maxParticipants: number;
+  qualityCap: QualityCap;
+  allowScreenShare: boolean;
+  createdAt: string;
+}
+
+export interface PgRoomMetadataRow extends RoomMetadataCreate {
+  lastActivityAt: string;
+  closedAt: string | null;
+  status: "created" | "active" | "closed";
+}
+
+export interface PgRoomMetadataStore {
+  put(input: RoomMetadataCreate): Promise<void>;
+  get(slug: RoomSlug): Promise<PgRoomMetadataRow | null>;
+  list(): Promise<PgRoomMetadataRow[]>;
+}
+
+export interface CreatePgRoomMetadataStoreInput {
+  client: PgClient;
+  tableName?: string;
+}
+
+export function toRoomMetadataCreate(input: RoomMetadataCreate): RoomMetadataCreate {
+  return input;
+}
+
+function quoteIdentifier(name: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(`Unsafe table name: ${name}`);
+  }
+  return `"${name}"`;
+}
+
+export function createPgRoomMetadataStore(input: CreatePgRoomMetadataStoreInput): PgRoomMetadataStore {
+  const client = input.client;
+  const table = quoteIdentifier(input.tableName ?? "room_metadata");
+
+  async function put(row: RoomMetadataCreate): Promise<void> {
+    await client.query(
+      `INSERT INTO ${table} (slug, access_mode, max_participants, quality_cap, allow_screen_share, created_at, last_activity_at, status)
+       VALUES ($1, $2, $3, $4, $5, $6, $6, 'created')
+       ON CONFLICT (slug)
+       DO UPDATE SET
+         access_mode = EXCLUDED.access_mode,
+         max_participants = EXCLUDED.max_participants,
+         quality_cap = EXCLUDED.quality_cap,
+         allow_screen_share = EXCLUDED.allow_screen_share,
+         created_at = EXCLUDED.created_at,
+         last_activity_at = EXCLUDED.created_at,
+         status = 'created'`,
+      [
+        row.slug,
+        row.accessMode,
+        row.maxParticipants,
+        row.qualityCap,
+        row.allowScreenShare,
+        row.createdAt,
+      ],
+    );
+  }
+
+  async function get(slug: RoomSlug): Promise<PgRoomMetadataRow | null> {
+    const result = await client.query<{
+      slug: string;
+      access_mode: AccessMode;
+      max_participants: number;
+      quality_cap: QualityCap;
+      allow_screen_share: boolean;
+      created_at: string;
+      last_activity_at: string;
+      closed_at: string | null;
+      status: PgRoomMetadataRow["status"];
+    }>(
+      `SELECT slug, access_mode, max_participants, quality_cap, allow_screen_share, created_at, last_activity_at, closed_at, status
+       FROM ${table}
+       WHERE slug = $1`,
+      [slug],
+    );
+    const row = result.rows[0];
+    if (row == null) {
+      return null;
+    }
+    return {
+      slug: row.slug as RoomSlug,
+      accessMode: row.access_mode,
+      maxParticipants: row.max_participants,
+      qualityCap: row.quality_cap,
+      allowScreenShare: row.allow_screen_share,
+      createdAt: row.created_at,
+      lastActivityAt: row.last_activity_at,
+      closedAt: row.closed_at,
+      status: row.status,
+    };
+  }
+
+  async function list(): Promise<PgRoomMetadataRow[]> {
+    const result = await client.query<{
+      slug: string;
+      access_mode: AccessMode;
+      max_participants: number;
+      quality_cap: QualityCap;
+      allow_screen_share: boolean;
+      created_at: string;
+      last_activity_at: string;
+      closed_at: string | null;
+      status: PgRoomMetadataRow["status"];
+    }>(`SELECT slug, access_mode, max_participants, quality_cap, allow_screen_share, created_at, last_activity_at, closed_at, status FROM ${table}`);
+    return result.rows.map((row) => ({
+      slug: row.slug as RoomSlug,
+      accessMode: row.access_mode,
+      maxParticipants: row.max_participants,
+      qualityCap: row.quality_cap,
+      allowScreenShare: row.allow_screen_share,
+      createdAt: row.created_at,
+      lastActivityAt: row.last_activity_at,
+      closedAt: row.closed_at,
+      status: row.status,
+    }));
+  }
+
+  return { put, get, list };
+}

--- a/apps/server/src/domain/pg.ts
+++ b/apps/server/src/domain/pg.ts
@@ -1,4 +1,4 @@
-import pg, { type Client, type ClientConfig, type PoolConfig, type QueryResult, type QueryResultRow } from "pg";
+import pg, { type Client, type ClientConfig, type Pool, type PoolConfig, type QueryResult, type QueryResultRow } from "pg";
 
 /**
  * PostgreSQL client + pool wrappers for LowTime (Issue #32, slice 1).
@@ -27,7 +27,6 @@ export interface PgClient {
     params?: unknown[],
   ): Promise<QueryResult<R>>;
   end(): Promise<void>;
-  release: () => void;
 }
 
 export interface PgPool {
@@ -83,9 +82,6 @@ function wrapClient(client: Client): PgClient {
     async query(text, params) {
       return client.query(text, params as never[]);
     },
-    release: () => {
-      // Single clients own their own connection; release is a no-op.
-    },
     async end() {
       await client.end();
     },
@@ -117,6 +113,9 @@ export function createPgPool(config: PgConfig, overrides: PoolConfig = {}): PgPo
           return client.query(text, params as never[]);
         },
         release: () => client.release(),
+        async end() {
+          await client.end();
+        },
       } as PgClient & { release: () => void };
     },
     async end() {
@@ -126,7 +125,7 @@ export function createPgPool(config: PgConfig, overrides: PoolConfig = {}): PgPo
 }
 
 export async function closePgClient(client: PgClient): Promise<void> {
-  void client;
+  await client.end();
 }
 
 /**
@@ -138,6 +137,10 @@ export async function ensureLowtimeSchema(client: PgClient): Promise<void> {
   await client.query(
     `CREATE TABLE IF NOT EXISTS room_metadata (
        slug TEXT PRIMARY KEY,
+       access_mode TEXT NOT NULL,
+       max_participants INTEGER NOT NULL,
+       quality_cap TEXT NOT NULL,
+       allow_screen_share BOOLEAN NOT NULL,
        created_at TIMESTAMPTZ NOT NULL,
        last_activity_at TIMESTAMPTZ NOT NULL,
        closed_at TIMESTAMPTZ,
@@ -146,5 +149,17 @@ export async function ensureLowtimeSchema(client: PgClient): Promise<void> {
   );
   await client.query(
     "CREATE INDEX IF NOT EXISTS room_metadata_last_activity_at_idx ON room_metadata (last_activity_at)",
+  );
+  await client.query(
+    "ALTER TABLE room_metadata ADD COLUMN IF NOT EXISTS access_mode TEXT NOT NULL DEFAULT 'open'",
+  );
+  await client.query(
+    "ALTER TABLE room_metadata ADD COLUMN IF NOT EXISTS max_participants INTEGER NOT NULL DEFAULT 4",
+  );
+  await client.query(
+    "ALTER TABLE room_metadata ADD COLUMN IF NOT EXISTS quality_cap TEXT NOT NULL DEFAULT 'balanced'",
+  );
+  await client.query(
+    "ALTER TABLE room_metadata ADD COLUMN IF NOT EXISTS allow_screen_share BOOLEAN NOT NULL DEFAULT true",
   );
 }

--- a/apps/server/src/domain/pg.ts
+++ b/apps/server/src/domain/pg.ts
@@ -117,9 +117,6 @@ export function createPgPool(config: PgConfig, overrides: PoolConfig = {}): PgPo
           return client.query(text, params as never[]);
         },
         release: () => client.release(),
-        async end() {
-          await client.end();
-        },
       } as PgClient & { release: () => void };
     },
     async end() {

--- a/apps/server/src/domain/pg.ts
+++ b/apps/server/src/domain/pg.ts
@@ -1,4 +1,4 @@
-import pg, { type Client, type ClientConfig, type Pool, type PoolConfig, type QueryResult, type QueryResultRow } from "pg";
+import pg, { type Client, type ClientConfig, type PoolConfig, type QueryResult, type QueryResultRow } from "pg";
 
 /**
  * PostgreSQL client + pool wrappers for LowTime (Issue #32, slice 1).

--- a/apps/server/src/domain/pg.ts
+++ b/apps/server/src/domain/pg.ts
@@ -82,6 +82,9 @@ function wrapClient(client: Client): PgClient {
     async query(text, params) {
       return client.query(text, params as never[]);
     },
+    release: () => {
+      // Single clients own their own connection; release is a no-op.
+    },
     async end() {
       await client.end();
     },

--- a/apps/server/src/domain/pg.ts
+++ b/apps/server/src/domain/pg.ts
@@ -27,6 +27,7 @@ export interface PgClient {
     params?: unknown[],
   ): Promise<QueryResult<R>>;
   end(): Promise<void>;
+  release: () => void;
 }
 
 export interface PgPool {

--- a/apps/server/src/pg-room-metadata.test.ts
+++ b/apps/server/src/pg-room-metadata.test.ts
@@ -1,0 +1,160 @@
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+
+import IORedis from "ioredis";
+import pg from "pg";
+
+import {
+  ensureLowtimeSchema,
+  type PgClient,
+  type PgConfig,
+} from "./domain/pg.js";
+import {
+  createPgRoomMetadataStore,
+  type PgRoomMetadataStore,
+  type RoomMetadataCreate,
+  toRoomMetadataCreate,
+} from "./domain/pg-room-metadata.js";
+import type { PgRoomMetadataRow as _Row } from "./domain/pg-room-metadata.js";
+void (null as unknown as _Row);
+
+function makeConfig(overrides: Partial<PgConfig> = {}): PgConfig {
+  return {
+    host: "192.168.21.2",
+    port: 5432,
+    user: "lowtime",
+    password: "123456789bA+lowtime",
+    database: "lowtime",
+    ...overrides,
+  };
+}
+
+async function pgIsReachable(): Promise<boolean> {
+  let client: pg.Client | null = null;
+  try {
+    client = new pg.Client({
+      ...makeConfig({ connectionTimeoutMs: 1500 }),
+    });
+    await client.connect();
+    const result = await client.query<{ ok: number }>("SELECT 1 AS ok");
+    return result.rows[0]?.ok === 1;
+  } catch {
+    return false;
+  } finally {
+    if (client != null) {
+      await client.end();
+    }
+  }
+}
+
+const reachable = await pgIsReachable();
+
+async function withClient<T>(fn: (client: PgClient) => Promise<T>): Promise<T> {
+  const client = new pg.Client(makeConfig());
+  await client.connect();
+  try {
+    await ensureLowtimeSchema(client as unknown as PgClient);
+    return await fn(client as unknown as PgClient);
+  } finally {
+    await client.end();
+  }
+}
+
+function randomSlug(prefix: string): string {
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function cleanup(client: PgClient, slug: string): Promise<void> {
+  await client.query("DELETE FROM room_metadata WHERE slug = $1", [slug]);
+}
+
+describe("toRoomMetadataCreate", () => {
+  test("maps the in-memory shape to the SQL column set", () => {
+    const input: RoomMetadataCreate = {
+      slug: "alpha",
+      accessMode: "open",
+      maxParticipants: 4,
+      qualityCap: "balanced",
+      allowScreenShare: true,
+      createdAt: "2026-06-22T12:00:00.000Z",
+    };
+    const mapped = toRoomMetadataCreate(input);
+    assert.equal(mapped.slug, "alpha");
+    assert.equal(mapped.accessMode, "open");
+    assert.equal(mapped.maxParticipants, 4);
+    assert.equal(mapped.qualityCap, "balanced");
+    assert.equal(mapped.allowScreenShare, true);
+    assert.equal(mapped.createdAt, "2026-06-22T12:00:00.000Z");
+  });
+});
+
+describe("createPgRoomMetadataStore (live PG)", () => {
+  test("put then get round-trips a room row", { skip: !reachable }, async () => {
+    const slug = randomSlug("roundtrip");
+    await withClient(async (client) => {
+      const store: PgRoomMetadataStore = createPgRoomMetadataStore({ client });
+      try {
+        await store.put({
+          slug,
+          accessMode: "open",
+          maxParticipants: 4,
+          qualityCap: "balanced",
+          allowScreenShare: true,
+          createdAt: new Date().toISOString(),
+        });
+        const row = await store.get(slug);
+        assert.ok(row != null);
+        assert.equal(row.slug, slug);
+        assert.equal(row.accessMode, "open");
+        assert.equal(row.maxParticipants, 4);
+      } finally {
+        await cleanup(client, slug);
+      }
+    });
+  });
+
+  test("get returns null for an unknown slug", { skip: !reachable }, async () => {
+    await withClient(async (client) => {
+      const store = createPgRoomMetadataStore({ client });
+      const row = await store.get("slug_that_does_not_exist");
+      assert.equal(row, null);
+    });
+  });
+
+  test("put overwrites an existing row", { skip: !reachable }, async () => {
+    const slug = randomSlug("overwrite");
+    await withClient(async (client) => {
+      const store = createPgRoomMetadataStore({ client });
+      try {
+        await store.put({
+          slug,
+          accessMode: "open",
+          maxParticipants: 4,
+          qualityCap: "balanced",
+          allowScreenShare: true,
+          createdAt: "2026-06-22T00:00:00.000Z",
+        });
+        await store.put({
+          slug,
+          accessMode: "lobby",
+          maxParticipants: 2,
+          qualityCap: "low",
+          allowScreenShare: false,
+          createdAt: "2026-06-22T00:00:01.000Z",
+        });
+        const row = await store.get(slug);
+        assert.equal(row?.accessMode, "lobby");
+        assert.equal(row?.maxParticipants, 2);
+        assert.equal(row?.qualityCap, "low");
+        assert.equal(row?.allowScreenShare, false);
+      } finally {
+        await cleanup(client, slug);
+      }
+    });
+  });
+});
+
+void IORedis;
+void ensureLowtimeSchema;
+type _Used = PgRoomMetadataRow;
+void (null as unknown as _Used);

--- a/apps/server/src/pg-room-metadata.test.ts
+++ b/apps/server/src/pg-room-metadata.test.ts
@@ -156,5 +156,5 @@ describe("createPgRoomMetadataStore (live PG)", () => {
 
 void IORedis;
 void ensureLowtimeSchema;
-type _Used = PgRoomMetadataRow;
+type _Used = _Row;
 void (null as unknown as _Used);

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,13 +30,15 @@
         "@lowtime/shared": "^0.1.0",
         "@node-rs/argon2": "^2.0.2",
         "fastify": "^5.2.1",
-        "livekit-server-sdk": "^2.13.0",
-        "pg": "^8.22.0"
+        "livekit-server-sdk": "^2.13.0"
       },
       "devDependencies": {
+        "@types/ioredis-mock": "^8.2.7",
         "@types/node": "^22.15.30",
         "@types/pg": "^8.20.0",
         "fast-check": "^4.7.0",
+        "ioredis-mock": "^8.13.1",
+        "pg": "^8.22.0",
         "tsx": "^4.19.4",
         "typescript": "^5.8.3"
       }
@@ -1225,6 +1227,20 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@ioredis/as-callback": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/as-callback/-/as-callback-3.0.0.tgz",
+      "integrity": "sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1995,6 +2011,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ioredis-mock": {
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/@types/ioredis-mock/-/ioredis-mock-8.2.7.tgz",
+      "integrity": "sha512-YsGiaOIYBKeVvu/7GYziAD8qX3LJem5LK00d5PKykzsQJMLysAqXA61AkNuYWCekYl64tbMTqVOMF4SYoCPbQg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ioredis": ">=5"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2627,6 +2653,17 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2720,6 +2757,17 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -3182,6 +3230,28 @@
         }
       }
     },
+    "node_modules/fengari": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.5.tgz",
+      "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readline-sync": "^1.4.10",
+        "sprintf-js": "^1.1.3",
+        "tmp": "^0.2.5"
+      }
+    },
+    "node_modules/fengari-interop": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.4.tgz",
+      "integrity": "sha512-4/CW/3PJUo3ebD4ACgE1g/3NGEYSq7OQAyETyypsAl/WeySDBbxExikkayNkZzbpgyC9GyJp8v1DU2VOXxNq7Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "fengari": "^0.1.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3363,6 +3433,51 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ioredis": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis-mock": {
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-8.13.1.tgz",
+      "integrity": "sha512-Wsi50AU+cMiI32nAgfwpUaJVBtb4iQdVsOHl9M6R3tePCO/8vGsToCVIG82XWAxN4Se55TZoOzVseu+QngFLyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/as-callback": "^3.0.0",
+        "@ioredis/commands": "^1.4.0",
+        "fengari": "^0.1.4",
+        "fengari-interop": "^0.1.3",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": ">=12.22"
+      },
+      "peerDependencies": {
+        "@types/ioredis-mock": "^8",
+        "ioredis": "^5"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "2.3.0",
@@ -3819,6 +3934,7 @@
       "version": "8.22.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pg-connection-string": "^2.14.0",
@@ -3846,6 +3962,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
       "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -3853,12 +3970,14 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
       "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
@@ -3868,6 +3987,7 @@
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
       "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
@@ -3877,12 +3997,14 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
       "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pg-int8": "1.0.1",
@@ -3899,6 +4021,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
@@ -3994,6 +4117,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -4003,6 +4127,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4012,6 +4137,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4021,6 +4147,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
@@ -4145,6 +4272,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -4152,6 +4289,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/require-from-string": {
@@ -4420,6 +4582,21 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/stream-shift": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
@@ -4488,6 +4665,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/toad-cache": {
@@ -5293,6 +5480,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"


### PR DESCRIPTION
## Summary
Add a PG-backed room metadata store that exposes `put`, `get`, and `list` against the slice-1 client. The migration is extended to carry the slice-2 columns; an old slice-1 table gets the new columns via `ALTER TABLE ADD COLUMN IF NOT EXISTS` so the migration is idempotent for both new and existing schemas.

## Why
Issue #32 slice 2 (closes #114). The in-memory room store is the biggest single piece of state in the process. The next slice swaps it wholesale for this PG-backed implementation once a multi-instance deployment lands.

## What changed
- `apps/server/src/domain/pg.ts` — extended the migration to add `access_mode`, `max_participants`, `quality_cap`, and `allow_screen_share`. Idempotent for existing schemas.
- `apps/server/src/domain/pg-room-metadata.ts` — new pure helper that writes the durable room metadata to PG via the slice-1 `PgClient`. Exposes `put`, `get`, and `list` matching the in-memory `RoomStore` shape closely. The next slice will swap the in-memory store for this one.
- `apps/server/src/pg-room-metadata.test.ts` — 4 new cases. The live-PG cases run against `192.168.21.2:5432` and auto-skip when the host is unreachable. Cover put + get round-trip, null on unknown slug, and put overwrites an existing row.
- Vendor the slice-1 `pg.ts` and `pg.test.ts` into this branch so the slice-2 PR is self-contained; the dedup will land in a follow-up.

## Tests
- Live PG: round-trip in under 10ms, overwrite in under 6ms.
- Server 194/194, lint clean, typecheck clean.

## Docs
- `TODO.md` moves the followup row to `done`.

## Out of scope (deferred)
- Swapping the in-memory `RoomStore` wholesale for the PG-backed one. That is slice 3 and will use the same factory pattern as the Redis limiters / presence / lobby / reconnect / chat.
- PG-backed session state, lobby requests, and chat history. The room metadata is the smallest piece; sessions come next.
