### PR TITLE
feat: Grafana dashboard JSON for the metrics endpoint (closes #36 slice 2)

### DIFF
--- a/apps/server/src/observability-dashboard.test.ts
+++ b/apps/server/src/observability-dashboard.test.ts
@@ -1,0 +1,60 @@
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dashboardPath = resolve(here, "../../../docs/observability/dashboards/lowtime-overview.json");
+
+function loadDashboard(): {
+  title: string;
+  uid: string;
+  panels: Array<{ id: number; type: string; title: string; targets: Array<{ expr: string }> }>;
+} {
+  const raw = readFileSync(dashboardPath, "utf-8");
+  return JSON.parse(raw);
+}
+
+describe("lowtime-overview dashboard", () => {
+  test("is valid JSON with a stable uid and the expected title", () => {
+    const dash = loadDashboard();
+    assert.equal(dash.title, "LowTime Overview");
+    assert.equal(dash.uid, "lowtime-overview");
+  });
+
+  test("has 9 panels covering the 4 phase-5 KPIs", () => {
+    const dash = loadDashboard();
+    assert.equal(dash.panels.length, 9);
+    const titles = dash.panels.map((panel) => panel.title);
+    assert.ok(titles.includes("Room creations (5m)"));
+    assert.ok(titles.includes("Join success (5m)"));
+    assert.ok(titles.includes("Join rejected (5m)"));
+    assert.ok(titles.includes("P2P fallback triggered (5m)"));
+  });
+
+  test("uses only counters the /metrics endpoint actually emits", () => {
+    const dash = loadDashboard();
+    const expected = new Set([
+      "room_created",
+      "join_succeeded",
+      "join_rejected",
+      "p2p_fallback_triggered",
+      "passcode_failure",
+      "lowtime_metrics_emitted_at_seconds",
+    ]);
+    for (const panel of dash.panels) {
+      for (const target of panel.targets) {
+        // Every metric name in the query should be in the set.
+        const usedNames = Array.from(target.expr.matchAll(/\b([a-z_]+)\b/g)).map((m) => m[1]);
+        for (const name of usedNames) {
+          if (name === "sum" || name === "rate" || name === "by" || name === "time" || name === "state" || name === "reason" || name === "accessMode") {
+            continue;
+          }
+          assert.ok(expected.has(name), `Unexpected metric ${name} in panel ${panel.title}`);
+        }
+      }
+    }
+  });
+});

--- a/docs/observability/dashboards/lowtime-overview.json
+++ b/docs/observability/dashboards/lowtime-overview.json
@@ -1,0 +1,151 @@
+{
+  "title": "LowTime Overview",
+  "uid": "lowtime-overview",
+  "schemaVersion": 38,
+  "version": 1,
+  "tags": ["lowtime"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": { "text": "Prometheus", "value": "Prometheus" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Room creations (5m)",
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "sum(rate(room_created[5m]))",
+          "legendFormat": "rooms/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Join success (5m)",
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "sum(rate(join_succeeded[5m]))",
+          "legendFormat": "joins/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Join rejected (5m)",
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "sum(rate(join_rejected[5m]))",
+          "legendFormat": "rejects/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "P2P fallback triggered (5m)",
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "sum(rate(p2p_fallback_triggered[5m]))",
+          "legendFormat": "fallbacks/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Join attempts by state (per minute)",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "sum by (state) (rate(join_succeeded[1m]))",
+          "legendFormat": "{{state}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Join rejects by reason (per minute)",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "sum by (reason) (rate(join_rejected[1m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "Passcode failures (5m)",
+      "gridPos": { "x": 0, "y": 12, "w": 8, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "sum(rate(passcode_failure[5m]))",
+          "legendFormat": "failures/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Room creations by accessMode (per minute)",
+      "gridPos": { "x": 8, "y": 12, "w": 16, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "sum by (accessMode) (rate(room_created[1m]))",
+          "legendFormat": "{{accessMode}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "lowtime_metrics_emitted_at_seconds (scrape liveness)",
+      "gridPos": { "x": 0, "y": 16, "w": 24, "h": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "expr": "time() - lowtime_metrics_emitted_at_seconds",
+          "legendFormat": "scrape lag (s)",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
The Prometheus `/metrics` endpoint from slice 1 emits counters but there was no place to chart them. Add a Grafana dashboard JSON that groups the 4 phase-5 KPIs (room creates, join success, join rejected, P2P fallback) and a few support panels (passcode failures, room creates by `accessMode`, and a scrape-liveness panel that watches `lowtime_metrics_emitted_at_seconds`).

## Why
Issue #36 slice 2 (closes #118). A counter module without a dashboard is just a JSON dump. The dashboard closes the loop with the team.

## What changed
- `docs/observability/dashboards/lowtime-overview.json` — 9 panels in a 4-row layout. Title and uid are stable so the dashboard can be imported once and version-bumped on every change. Uses only counters the slice-1 `/metrics` endpoint actually emits; the test enforces that allowlist.
- `apps/server/src/observability-dashboard.test.ts` — 3 new cases (JSON shape, panel-set coverage, metric-name allowlist). The test reads the file from disk so the dashboard and the test stay in sync.

## Tests
- 3/3 new tests pass. Server total: 199/199, lint clean, typecheck clean.

## Docs
- `TODO.md` moves the followup row to `in_progress`.

## Out of scope (deferred)
- Per-room drill-down panels. The `/metrics` endpoint does not currently tag by room slug; that is a follow-up.
- Alert rules. A separate `alerts.json` is a small follow-up.
- Import instructions for the Grafana side. The dashboard file is in the standard Grafana JSON model and a one-line "how to import" lives in the doc update for slice 3.
