### PR TITLE
chore: add project-local skill set (5 skills)

### DIFF
--- a/.opencode/skills/lowtime-developing/SKILL.md
+++ b/.opencode/skills/lowtime-developing/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: lowtime-developing
+description: Use when working on LowTime ÔÇö a low-bandwidth FaceTime-like WebRTC app. Triggers on web/server code in apps/, packages/shared, docs/, TODO.md, call/room feature work, LiveKit, SFU/P2P fallback, quality presets, media adaptation, signaling, or PRs.
+---
+
+# LowTime Developing
+
+## What LowTime Is
+- Low-bandwidth WebRTC video call app: SFU-first, P2P fallback for 1:1, in-memory state.
+- User promise: stay on the call even when network is bad ÔÇö adapt before dropping.
+
+## Core Principle: Bandwidth Is Sacred
+Every new feature spends bytes. Default to the cheapest option that works.
+
+- New video/screen source: must justify bandwidth cost in `docs/04-media-and-quality.md`.
+- New toggle/control: prefer adding to existing `AdvancedMediaPrefs` shape, not inventing a new payload.
+- New signaling event: route through `WS /signal` and `SignalBus` (`apps/server/src/domain/signal-bus.ts`) ÔÇö do not add new HTTP routes for ephemeral state.
+- Default to `Balanced` preset for any new publish path. Never `Best Quality` as default.
+
+## Architecture Map (read before changing)
+| Layer | Where | Notes |
+| --- | --- | --- |
+| Web routes | `apps/web/src/app/` | Routing + shell only |
+| Web features | `apps/web/src/features/<area>/` | One folder per page area (call, room, home, waiting) |
+| Web shared helpers | `apps/web/src/*.ts` (top level) | `call-experience.ts`, `media-controller.ts`, `auto-downgrade.ts`, `audio-only-prompt.ts`, `quality-presets.ts`, `room-entry.ts`, `network-health.ts`, `device-preview.ts` |
+| Server routes | `apps/server/src/routes/` | One file per route group (rooms, lobby, media, signal) |
+| Server domain | `apps/server/src/domain/` | Pure logic: room-store, room-cleanup, room-activity, signal-bus, validation |
+| Shared types | `packages/shared/src/index.ts` | Contract types consumed by both apps |
+| Docs | `docs/` | Source of truth ÔÇö update in same PR as code |
+
+## Mandatory Workflow (from `docs/13-issue-branch-pr-workflow.md`)
+1. Pick or open a GitHub issue first. Use `.github/ISSUE_TEMPLATE/feature.yml` or `bug.yml`.
+2. Branch from `main` named `feature/<topic>`, `fix/<topic>`, or `docs/<topic>`.
+3. Update `TODO.md` to `in_progress` before coding; mark `done` only when tests + docs land.
+4. Code + tests + docs land in the same PR.
+5. Push branch, open PR, link issue, request review.
+6. `babico` + `codex` reviewers via repo workflow. Manual `@codex review` only if auto-review skipped.
+
+## Test Conventions
+- Web unit tests: `apps/web/src/<file>.test.ts` using `node:test` + `node:assert/strict` (see `package.json` test script).
+- Pattern: pure helpers in their own `.ts` file with sibling `.test.ts`. No React Testing Library ÔÇö use a plain object mocking style (see `call-experience.test.ts`).
+- Run: `npm test` (workspace) or `npm --workspace apps/web test`.
+- Lint: `npm run lint` (max-warnings 0).
+
+## Source-Of-Truth Doc Rules
+- `docs/04-media-and-quality.md` ÔÇö any change to media transport, presets, downgrade, screen share, advanced controls.
+- `docs/05-api-and-realtime-contracts.md` ÔÇö any new endpoint, signaling event, or payload shape.
+- `docs/06-data-model-and-lifecycle.md` ÔÇö any change to session, room, or stored state.
+- `docs/09-security-and-abuse.md` ÔÇö any change to auth, rate limit, passcode, lobby.
+- `TODO.md` ÔÇö every status change.
+- ADR required when changing: default transport, access model, persistence model, install surface, or quality policy.
+
+## Definition Of Done (from `CONTRIBUTING.md`)
+- Tests added/updated.
+- `TODO.md` status correct.
+- Source-of-truth docs updated.
+- ADR added/revised if architecture changed.
+- `npm run lint` clean, `npm test` green, typecheck green.
+
+## Project Vocabulary (use exact terms)
+- **SFU** (default transport) vs **P2P fallback** (1:1 only, after SFU failure).
+- **Preset** = `Data Saver` | `Balanced` | `Best Quality` (user choice).
+- **Quality cap** = host-imposed ceiling on preset. Always clamps before user.
+- **AdvancedMediaPrefs** = 6 user overrides; can only tighten, never loosen, the cap+preset baseline.
+- **Rung** = one step in the downgrade ladder (`bitrate ÔåÆ resolution ÔåÆ fps ÔåÆ video-paused`).
+- **Tile** = a `<video>` element in the call layout (remote + self).
+- **Session** = per-tab `StoredCallSession`; cleared on leave.
+
+## Common Mistakes
+- Touching `App.tsx` directly ÔÇö page logic lives in `features/<area>/`.
+- Adding a new HTTP route for ephemeral state ÔÇö use `SignalBus` instead.
+- Forgetting `npm run lint` after edits ÔÇö CI fails on any warning.
+- Marking a feature `done` in `TODO.md` before tests + docs land.
+- Skipping the issue/PR template ÔÇö `babico` and `codex` auto-review require the structured context.
+- Optimistic bandwidth defaults ÔÇö every new path must check `docs/04` for the right baseline.

--- a/.opencode/skills/lowtime-issue-picker/SKILL.md
+++ b/.opencode/skills/lowtime-issue-picker/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: lowtime-issue-picker
+description: Use when picking the next issue to work on in the LowTime repo. Triggers on requests like "what's next", "pick another issue", "next slice", or any "continue don't stop" follow-up. Reads the open issue list + PR list + memory notes + the size of each candidate's working set.
+---
+
+# LowTime Next-Issue Picker
+
+## Inputs
+- `gh issue list --state open --limit 30` (issues)
+- `gh pr list --state open` (PRs)
+- Memory note `lowtime_open_work` (carries the user's priorities from the last session)
+- Memory note `lowtime_followups` (small features that do not need their own issue)
+
+## Output
+A single recommendation: `<number>` `<slug>` (`<size>` slice `<n>`). Example: `32 pg-room-metadata-store (medium) slice 2`.
+
+## Algorithm
+1. Load the open issues via `gh issue list --state open --limit 30` and the open PRs via `gh pr list --state open`.
+2. Load the memory notes `lowtime_open_work` and `lowtime_followups`. These carry user-set priorities from earlier sessions.
+3. Filter to issues that are not already covered by an open PR:
+   - `gh pr list --state open --json number,title,body` and grep each PR's body for the issue number.
+   - Drop the issue if a PR's body lists `closes #N` or `issue: #N`.
+4. Order the remaining issues by user priority, then by size, then by phase:
+   - Phase 5 issues come before infrastructure issues when both are open.
+   - Smaller followups (already in memory) come before larger new issues.
+   - If a previously-started issue has a "slice 2+" row in `lowtime_followups`, prefer that next slice over a new issue.
+5. Pick the first item. If the user named a specific issue, override the ranking and use that one.
+
+## Size Heuristics
+- **tiny**: helper + 1 file, no schema change, no new dependency. Commit + PR in one cycle.
+- **small**: 1-3 files, no interface change, may need 5-10 test cases. Single PR.
+- **medium**: 4-8 files, may add a new dependency, may need an interface. Often 1 PR with a follow-up issue.
+- **large**: 8+ files or touches the public contract. Split into 2+ PRs.
+
+## Report
+Always report the picked issue number, slug, size, and slice (if any) in the first line of the response. The user reads that line first.
+
+## Memory
+After a session, store the picked issue + slice in `lowtime_open_work` with the next-slice pointer so the next session can pick up where this one left off.

--- a/.opencode/skills/lowtime-pr-tracker/SKILL.md
+++ b/.opencode/skills/lowtime-pr-tracker/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: lowtime-pr-tracker
+description: Use when the user asks "what's open", "which PRs are failing", "what's the PR status", or before picking the next issue. Triggers on the keyword "PR" combined with a state question. Reads the open PRs from `gh pr list --state open` and their CI status, then writes a compact summary the user can read in one screen.
+---
+
+# LowTime PR Tracker
+
+## Inputs
+- `gh pr list --state open --json number,title,statusCheckRollup,headRefName`
+- `gh pr view <number> --json statusCheckRollup` (only when the summary is ambiguous)
+
+## Output
+A compact table:
+
+```
+#   title                                     CI
+101 Redis-backed rate limiters                 SUCCESS
+106 PostgreSQL client + migration             FAILURE (lint: unused Pool import)
+...
+```
+
+## Algorithm
+1. `gh pr list --state open --json number,title,headRefName` to get the open list.
+2. For each PR, `gh pr checks <number>` (or the statusCheckRollup) to get the conclusion.
+3. Render one row per PR. Use `SUCCESS` / `FAILURE` / `PENDING` as the CI column. If FAILURE, include a one-line reason from `gh run view --log-failed` for the most recent failed run.
+4. Sort: failing first, then pending, then passing. Within each group, oldest first.
+
+## Memory
+At the end of a session, write the compact table to the `lowtime_open_prs` memory note so the next session can resume without re-running `gh`.

--- a/.opencode/skills/lowtime-unfinished/SKILL.md
+++ b/.opencode/skills/lowtime-unfinished/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: lowtime-unfinished
+description: Use when the user says "finish the unfinished first", "what's left from last time", or at the start of a session. Surfaces the in-flight TODO list, failing PRs, and small followups that did not earn their own issue.
+---
+
+# LowTime Unfinished
+
+## Inputs
+- The current `TODO.md` (in-progress rows)
+- `gh pr list --state open` (PRs whose checks are failing or still pending)
+- Memory note `lowtime_followups` (small features tracked locally, not in `TODO.md`)
+- Memory note `lowtime_open_work` (the slice-2 / slice-3 pointers for in-flight issues)
+
+## Output
+A grouped summary:
+
+```
+In-progress TODOs
+- #32 PostgreSQL room metadata (slice 2 of 3, sessions follow)
+- #34 coturn integration (slice 1 of 3, TURN wiring follows)
+- #36 metrics, logs, dashboards (slice 2 of 3 done, slice 3 follows)
+
+Failing PRs
+- #106 lint: unused Pool import
+- #109 / #113 / #117 similar lint issues
+
+Small followups
+- device-choice wiring (#97 lands the helper, the call-page wiring is a one-liner)
+- host-remove from room page UI (#99 lands the wrapper, the UI is a one-liner)
+- wire Redis limiters + presence + lobby + reconnect + chat into BuildAppOptions (one factory call each)
+- wire PG room metadata into BuildAppOptions (one factory call)
+```
+
+## Algorithm
+1. Read `TODO.md` and grep for `in_progress`.
+2. Read the PR list and pull the failing ones.
+3. Read the memory notes for the in-flight pointers.
+4. Order the output: TODOs first, then failing PRs, then small followups.
+
+## Memory
+At the end of a session, append the day's in-flight state to the `lowtime_open_work` note.

--- a/.opencode/skills/lowtime-workflow/SKILL.md
+++ b/.opencode/skills/lowtime-workflow/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: lowtime-workflow
+description: Use when implementing any feature or bugfix in the LowTime repo. The project follows a strict TDD + lint + push + PR + CI-check workflow. This skill is the canonical order of operations.
+---
+
+# LowTime Workflow
+
+## Inputs
+- The picked issue (from `lowtime-issue-picker` or user-specified)
+- The existing tests in the workspace (Vitest-style `node:test` for the web side, same runner for the server)
+
+## Order
+1. **Branch**. `git checkout -b feature/<slug>` (or `fix/<slug>`, `chore/<slug>`). One issue per branch.
+2. **TDD**. Write the failing test first. For web code, pure helpers in `apps/web/src/<file>.ts` with sibling `<file>.test.ts`. For server code, top-level test file in `apps/server/src/<file>.test.ts` because the test runner only matches `src/*.test.ts`.
+3. **GREEN**. Implement the smallest thing that makes the test pass.
+4. **LINT + TYPECHECK**. `npm run check` from the repo root. Fix every warning. The web side and the server side each have their own ESLint config.
+5. **COVERAGE**. Add more cases until the new behavior is fully covered.
+6. **DOCS**. Update the matching source-of-truth doc in `docs/`. Update `TODO.md` row for the issue.
+7. **COMMIT**. Conventional commits, one sentence, with the issue number at the end (e.g. `feat: short-lived TURN credentials (closes #116)`).
+8. **PUSH**. `git push -u origin feature/<slug>`. Confirm the push.
+9. **PR**. `gh pr create --base main --head feature/<slug> --title "..." --body-file <body.md>`. The body file describes the scope, the tests, and the out-of-scope items.
+10. **CI WATCH**. `gh pr checks <number>` immediately, then once more a minute later. If FAILURE, fix on the same branch and push again. Do not open a new PR.
+11. **MEMORY**. Append the in-flight state to `lowtime_open_work` so the next session can pick up.
+
+## Test Conventions
+- Web: pure helpers go in `apps/web/src/*.ts` with sibling `*.test.ts` using `node:test` + `node:assert/strict`. No React Testing Library. React components get covered by manual smoke tests.
+- Server: top-level `apps/server/src/<file>.test.ts` (the runner only matches `src/*.test.ts`, not `src/domain/*`). Use `node:test`.
+- Redis slices: ioredis-mock for tests, `ioredis` for live smoke tests.
+- PG slices: `pg` for live smoke tests against the real PG at `192.168.21.2:5432` (database `lowtime`, user `lowtime`, password `123456789bA+lowtime`).
+- Live tests auto-skip when the host is unreachable so `npm test` does not flake on offline machines.
+
+## PR Conventions
+- One issue per PR. The body uses `closes #N` so the issue closes on merge.
+- The body lists: Summary, Why, What changed, Tests, Docs, Out of scope (deferred).
+- Vendoring is OK when a PR would otherwise depend on a sibling PR that is still open. The dedup PR is a follow-up.
+
+## Anti-patterns
+- Do not use `any`. Do not use `// @ts-ignore` without a comment that explains the upstream type gap.
+- Do not skip the live smoke test even if the unit tests pass. The whole point of the live tests is to catch wiring bugs.
+- Do not add a new dep without first checking that a slice of the same dep already exists in the workspace. If the dep is already in `package.json` you can use it directly.
+- Do not open a PR with `--no-verify`. The local hooks and the CI checks both exist for a reason.


### PR DESCRIPTION
## Summary
Add a project-local skill set under `.opencode/skills/` so any future agent that opens the repo has the same onboarding context this session has been building. The set covers the project overview, the workflow, and three run-time helpers (next-issue picker, PR tracker, unfinished finder).

## Why
Until now, all of the project knowledge lived in this session's memory and the on-machine skill files. A fresh agent opening the repo had to start from `TODO.md` and `gh pr list`. The skill set gives the next agent a one-shot read that turns "what is this project" and "what do I do next" into a few hundred tokens.

## What changed
- `lowtime-developing/SKILL.md` — the project overview, architecture map, mandatory workflow, test conventions, source-of-truth doc rules, and project vocabulary. Restored from an earlier commit that was lost in a cleanup.
- `lowtime-workflow/SKILL.md` — the canonical order of operations for any feature or bugfix (TDD, lint, push, PR, CI watch, memory). Has anti-patterns and the test conventions for the web and server sides.
- `lowtime-issue-picker/SKILL.md` — the algorithm for choosing the next issue. Reads `gh issue list` + `gh pr list` + memory notes, filters out issues already covered by an open PR, ranks by user priority, and reports a single recommendation.
- `lowtime-pr-tracker/SKILL.md` — a compact table of open PRs and their CI status, sorted failing-first. Includes a one-line failure reason per row.
- `lowtime-unfinished/SKILL.md` — surfaces in-flight TODO rows, failing PRs, and small followups at the start of a session. Reads `TODO.md` + the PR list + the memory notes.

## Tests
- The skills are descriptive-only and never executed. CI passes trivially. Lint and typecheck clean.

## Docs
- No source-of-truth doc change yet. The skills themselves encode the docs. A future doc pass can copy the relevant sections into `docs/07-frontend-architecture.md` and `docs/08-backend-architecture.md` if the team prefers the docs as the canonical reference.

## Out of scope (deferred)
- Wiring the skills into a CI check that fails the build if any skill description goes stale.
- Skill tests. The skills are mostly algorithm specs, not executable code; the next-agent workflow is the real test.
- A `lowtime-replay` skill that re-creates this session's PR sequence from memory + `gh`. Tracked as a follow-up if the team wants a replay command.
