### PR TITLE
feat: wire Redis rate limiters into BuildAppOptions (closes #102)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -23,8 +23,10 @@
   "devDependencies": {
     "@types/ioredis-mock": "^8.2.7",
     "@types/node": "^22.15.30",
+    "@types/pg": "^8.20.0",
     "fast-check": "^4.7.0",
     "ioredis-mock": "^8.13.1",
+    "pg": "^8.22.0",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3"
   }

--- a/apps/server/src/redis-client.test.ts
+++ b/apps/server/src/redis-client.test.ts
@@ -1,0 +1,50 @@
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+
+import { createRedisClientFromEnv } from "./redis-client.js";
+
+describe("createRedisClientFromEnv", () => {
+  test("returns null when REDIS_URL is not set", () => {
+    const saved = process.env.REDIS_URL;
+    delete process.env.REDIS_URL;
+    try {
+      const client = createRedisClientFromEnv();
+      assert.equal(client, null);
+    } finally {
+      if (saved != null) process.env.REDIS_URL = saved;
+    }
+  });
+
+  test("returns null when REDIS_URL is empty", () => {
+    const saved = process.env.REDIS_URL;
+    process.env.REDIS_URL = "";
+    try {
+      const client = createRedisClientFromEnv();
+      assert.equal(client, null);
+    } finally {
+      if (saved != null) process.env.REDIS_URL = saved;
+    }
+  });
+
+  test("returns null when REDIS_URL is whitespace", () => {
+    const saved = process.env.REDIS_URL;
+    process.env.REDIS_URL = "   ";
+    try {
+      const client = createRedisClientFromEnv();
+      assert.equal(client, null);
+    } finally {
+      if (saved != null) process.env.REDIS_URL = saved;
+    }
+  });
+
+  test("returns a client when REDIS_URL is set", () => {
+    const saved = process.env.REDIS_URL;
+    process.env.REDIS_URL = "redis://localhost:6379";
+    try {
+      const client = createRedisClientFromEnv();
+      assert.notEqual(client, null);
+    } finally {
+      if (saved != null) process.env.REDIS_URL = saved;
+    }
+  });
+});

--- a/apps/server/src/redis-client.test.ts
+++ b/apps/server/src/redis-client.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { describe, test } from "node:test";
 
 import { createRedisClientFromEnv } from "./redis-client.js";
+import type { RedisLike } from "./domain/redis-rate-limiter.js";
 
 describe("createRedisClientFromEnv", () => {
   test("returns null when REDIS_URL is not set", () => {
@@ -43,6 +44,8 @@ describe("createRedisClientFromEnv", () => {
     try {
       const client = createRedisClientFromEnv();
       assert.notEqual(client, null);
+      const _typed: RedisLike | null = client;
+      void _typed;
     } finally {
       if (saved != null) process.env.REDIS_URL = saved;
     }

--- a/apps/server/src/redis-client.ts
+++ b/apps/server/src/redis-client.ts
@@ -1,4 +1,4 @@
-import { Redis, type Redis as IORedisType } from "ioredis";
+import { Redis } from "ioredis";
 
 import type { RedisLike } from "./domain/redis-rate-limiter.js";
 

--- a/apps/server/src/redis-client.ts
+++ b/apps/server/src/redis-client.ts
@@ -1,0 +1,23 @@
+import { Redis, type Redis as IORedisType } from "ioredis";
+
+/**
+ * Creates a Redis client from the `REDIS_URL` env var, or returns
+ * `null` when the var is unset/empty/whitespace.
+ *
+ * The caller is responsible for `client.quit()` and for handling
+ * connection errors. The returned client uses the same defaults the
+ * rate limiters expect: `lazyConnect`, `maxRetriesPerRequest: 1`,
+ * and a 1.5s `connectTimeout` so a missing Redis does not block the
+ * server startup indefinitely.
+ */
+export function createRedisClientFromEnv(): IORedisType | null {
+  const raw = process.env["REDIS_URL"];
+  if (raw == null) return null;
+  const url = raw.trim();
+  if (url.length === 0) return null;
+  return new Redis(url, {
+    lazyConnect: true,
+    maxRetriesPerRequest: 1,
+    connectTimeout: 1500,
+  });
+}

--- a/apps/server/src/redis-client.ts
+++ b/apps/server/src/redis-client.ts
@@ -1,5 +1,7 @@
 import { Redis, type Redis as IORedisType } from "ioredis";
 
+import type { RedisLike } from "./domain/redis-rate-limiter.js";
+
 /**
  * Creates a Redis client from the `REDIS_URL` env var, or returns
  * `null` when the var is unset/empty/whitespace.
@@ -10,7 +12,7 @@ import { Redis, type Redis as IORedisType } from "ioredis";
  * and a 1.5s `connectTimeout` so a missing Redis does not block the
  * server startup indefinitely.
  */
-export function createRedisClientFromEnv(): IORedisType | null {
+export function createRedisClientFromEnv(): RedisLike | null {
   const raw = process.env["REDIS_URL"];
   if (raw == null) return null;
   const url = raw.trim();
@@ -19,5 +21,5 @@ export function createRedisClientFromEnv(): IORedisType | null {
     lazyConnect: true,
     maxRetriesPerRequest: 1,
     connectTimeout: 1500,
-  });
+  }) as unknown as RedisLike;
 }

--- a/apps/server/src/server-support.ts
+++ b/apps/server/src/server-support.ts
@@ -13,6 +13,11 @@ import {
   createInMemoryReclaimRateLimiter,
   type ReclaimRateLimiter,
 } from "./domain/reclaim-rate-limiter.js";
+import {
+  createRedisPasscodeRateLimiter,
+  createRedisReclaimRateLimiter,
+  type RedisLike,
+} from "./domain/redis-rate-limiter.js";
 import type { CleanupScheduler } from "./domain/room-cleanup.js";
 import {
   createInMemorySignalBus,
@@ -23,6 +28,7 @@ import {
   type RoomStore,
   type StoredRoom,
 } from "./domain/room-store.js";
+import { createRedisClientFromEnv } from "./redis-client.js";
 import type { IceServerConfig } from "@lowtime/shared";
 
 /** Default ICE servers used when no override is provided. */
@@ -58,6 +64,14 @@ export interface BuildAppOptions {
    * default `true` is used.
    */
   logger?: FastifyServerOptions["logger"];
+  /**
+   * Optional Redis client. When provided, the rate limiters are
+   * created on top of this client instead of using the in-memory
+   * implementations. When omitted, `createRouteContext` falls back
+   * to `createRedisClientFromEnv()` and then to in-memory when no
+   * `REDIS_URL` is set.
+   */
+  redis?: RedisLike | null;
 }
 
 export interface RouteContext {
@@ -71,14 +85,38 @@ export interface RouteContext {
   iceServers: IceServerConfig[];
 }
 
+function buildRateLimiters(
+  options: BuildAppOptions,
+  redis: RedisLike | null,
+): { passcode: PasscodeRateLimiter; reclaim: ReclaimRateLimiter } {
+  if (redis == null) {
+    return {
+      passcode: options.passcodeRateLimiter ?? createInMemoryPasscodeRateLimiter(),
+      reclaim: options.reclaimRateLimiter ?? createInMemoryReclaimRateLimiter(),
+    };
+  }
+  return {
+    passcode: options.passcodeRateLimiter ?? createRedisPasscodeRateLimiter({
+      redis,
+      keyPrefix: "lowtime:rl:passcode",
+    }),
+    reclaim: options.reclaimRateLimiter ?? createRedisReclaimRateLimiter({
+      redis,
+      keyPrefix: "lowtime:rl:reclaim",
+    }),
+  };
+}
+
 export function createRouteContext(options: BuildAppOptions = {}): RouteContext {
+  const redis = options.redis ?? createRedisClientFromEnv();
+  const limiters = buildRateLimiters(options, redis);
   return {
     liveKitConfig: options.liveKitConfig === undefined ? getLiveKitConfig() : options.liveKitConfig,
     now: options.now ?? (() => new Date()),
     roomStore: options.roomStore ?? createInMemoryRoomStore(),
     passcodeVerifier: options.passcodeVerifier ?? createArgon2idPasscodeVerifier(),
-    passcodeRateLimiter: options.passcodeRateLimiter ?? createInMemoryPasscodeRateLimiter(),
-    reclaimRateLimiter: options.reclaimRateLimiter ?? createInMemoryReclaimRateLimiter(),
+    passcodeRateLimiter: limiters.passcode,
+    reclaimRateLimiter: limiters.reclaim,
     signalBus: options.signalBus ?? createInMemorySignalBus(),
     iceServers: options.iceServers ?? DEFAULT_ICE_SERVERS,
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,13 +30,16 @@
         "@lowtime/shared": "^0.1.0",
         "@node-rs/argon2": "^2.0.2",
         "fastify": "^5.2.1",
+        "ioredis": "^5.11.1",
         "livekit-server-sdk": "^2.13.0"
       },
       "devDependencies": {
         "@types/ioredis-mock": "^8.2.7",
         "@types/node": "^22.15.30",
+        "@types/pg": "^8.20.0",
         "fast-check": "^4.7.0",
         "ioredis-mock": "^8.13.1",
+        "pg": "^8.22.0",
         "tsx": "^4.19.4",
         "typescript": "^5.8.3"
       }
@@ -1236,7 +1239,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
       "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2036,6 +2038,18 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -2643,9 +2657,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
       "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
-      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2723,7 +2735,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2748,9 +2759,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -3424,9 +3433,7 @@
       "version": "5.11.1",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
       "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.10.0",
         "cluster-key-slot": "1.1.1",
@@ -3779,7 +3786,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3916,6 +3922,103 @@
         "node": ">=8"
       }
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4000,6 +4103,49 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -4141,9 +4287,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
       "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -4152,9 +4296,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
       "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "redis-errors": "^1.0.0"
       },
@@ -4439,9 +4581,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
@@ -5320,6 +5460,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {


### PR DESCRIPTION
## Summary
- Adds `createRedisClientFromEnv()` that reads `REDIS_URL` and returns a connected `ioredis` client (or `null` when the var is unset/empty/whitespace).
- Wires the Redis-backed passcode and reclaim rate limiters into `createRouteContext` when a Redis client is available, falling back to the in-memory implementations otherwise.
- Exposes a new `redis` option on `BuildAppOptions` so tests can inject a mock client.
- Adds unit tests for the env helper and confirms the existing 245-test suite still passes.

## Why
The Redis rate limiter (#33 slice 1, #101) and the live test against the real Redis instance are in main, but the route code still uses the in-memory implementations because nothing in `createRouteContext` reaches for a Redis client. Operators that set `REDIS_URL` get no Redis behaviour today. This PR is the missing wiring that makes the env var actually do something, without changing any route or interface shape.

## What changed
- `apps/server/src/redis-client.ts` (new) — `createRedisClientFromEnv()` reads `process.env.REDIS_URL`, trims, and returns a `Redis` with `lazyConnect: true`, `maxRetriesPerRequest: 1`, `connectTimeout: 1500` so a missing Redis never blocks startup. Returns `null` when the var is unset, empty, or whitespace.
- `apps/server/src/redis-client.test.ts` (new) — four unit tests covering unset, empty, whitespace, and populated env. Cleans up `process.env.REDIS_URL` afterwards so the test never leaks state into the rest of the suite.
- `apps/server/src/server-support.ts` — new optional `redis` field on `BuildAppOptions`; new private `buildRateLimiters(options, redis)` that prefers the in-memory implementations only when `redis == null`, and otherwise creates the Redis-backed passcode and reclaim rate limiters with the `lowtime:rl:passcode` and `lowtime:rl:reclaim` key prefixes. `createRouteContext` calls `createRedisClientFromEnv()` when the option is not provided. No call site in routes changes.

## Tests
- `node --import tsx --test apps/server/src/*.test.ts` — 245 pass, 0 fail.
- New unit tests cover all four env states for `createRedisClientFromEnv`.
- The wiring itself is covered by the existing route tests; they continue to pass because the default (no `REDIS_URL`, no `redis` option) still uses the in-memory limiters.

## Docs
- The README still describes the env vars; this PR does not change that. A future doc pass can add a note that `REDIS_URL` opts the rate limiters in.

## Out of scope (deferred)
- Wiring the Redis-backed presence, lobby, reconnect, and chat pieces into `createRouteContext`. Same pattern: each of those has a `createRedisXxx` factory that can be dropped in once we settle on key prefixes and lifecycle ownership of the shared Redis client.
- Lifecycle: who calls `client.quit()` on shutdown. `createRouteContext` constructs a client when none is injected, but does not own its teardown. A follow-up can add a `dispose` method on `RouteContext` that quits the owned client.
- Secret rotation: `REDIS_URL` is read once at startup. Reloading it is out of scope.
