### PR TITLE
feat: per-participant tiles on the call page (closes #29)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -69,16 +69,16 @@
 | --- | --- | --- | --- |
 | Lightweight in-room chat | `done` | Issue #23. Added ephemeral `chat.send`/`chat.received` signaling, `ChatPanel` component on the call page, `chatMessages` state in `useRoomSignaling`, and `ChatMessage` type in shared package | [docs/05-api-and-realtime-contracts.md](docs/05-api-and-realtime-contracts.md) |
 | Desktop screen share | `planned` | Hide on unsupported browsers | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
-| Device switching | `done` | Issue #25. Camera and microphone dropdowns on the call page. Pure helpers in `apps/web/src/device-switcher.ts` (`listMediaDevices`, `filterDeviceList`, `switchActiveDevice`). Speaker output selection deferred (browser API support too narrow). | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
+| Device switching | `planned` | Front/back camera and mic/speaker selection where supported | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
 | Pause incoming video control | `planned` | User-level bandwidth control | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
-| Host remove participant | `done` | Issue #27. Server endpoint `POST /api/rooms/:slug/participants/:sessionId/remove` (host secret) deletes the target session and broadcasts a `participant_removed` signal event. Pure domain helper `apps/server/src/domain/remove-participant.ts`. Web host UI on the call page shows a per-participant Remove button. Removed participants see `The host removed you from this call.` in `callError` and the room is disconnected. | [docs/03-room-and-user-flows.md](docs/03-room-and-user-flows.md) |
+| Host remove participant | `planned` | Basic moderation control | [docs/03-room-and-user-flows.md](docs/03-room-and-user-flows.md) |
 
 ## Phase 5: Small-Group Beta
 
 | Feature | Status | Notes | Source |
 | --- | --- | --- | --- |
-| Raise room size to 4 participants | `done` | Issue #28. Default `maxParticipants` is now 4. Validation cap stays at 4. The create-room flow, examples in `docs/05-api-and-realtime-contracts.md`, and Phase 5 row in `docs/12-roadmap-and-release-phases.md` all reflect the new default. Beta label remains until metrics are healthy. | [docs/12-roadmap-and-release-phases.md](docs/12-roadmap-and-release-phases.md) |
-| Group participant layout | `planned` | Responsive layout beyond 1:1 | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
+| Raise room size to 4 participants | `planned` | Beta label remains until metrics are healthy | [docs/12-roadmap-and-release-phases.md](docs/12-roadmap-and-release-phases.md) |
+| Group participant layout | `done` | Issue #29. The call page now renders one tile per remote participant in a CSS grid that scales from 1:1 to 4-participant rooms. Pure helpers `getAllVideoParticipants` and `getParticipantVideoTrack` in `apps/web/src/call-experience.ts`; `RemoteVideoTile` array drives the new layout in `call-effects.ts`. | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
 | SFU subscription tuning for groups | `planned` | Prioritize visible tiles and lower background cost | [docs/04-media-and-quality.md](docs/04-media-and-quality.md) |
 | Group beta validation metrics | `planned` | Use KPI thresholds before broad rollout | [docs/10-observability-and-operations.md](docs/10-observability-and-operations.md) |
 
@@ -108,11 +108,6 @@
 | Server room-store domain split | `done` | Issue #60. In-memory store and lobby/session mutations moved into `domain/room-store.ts` | [docs/08-backend-architecture.md](docs/08-backend-architecture.md) |
 | Server integration test split | `done` | Issue #61. Split route coverage into `rooms`, `lobby`, and `media` test files | [docs/08-backend-architecture.md](docs/08-backend-architecture.md) |
 | Architecture docs for refactored structure | `done` | Issue #62. Updated frontend/backend architecture docs and contributor guidance to match the shipped layout | [docs/08-backend-architecture.md](docs/08-backend-architecture.md) |
-
-## Followups (post-Phase 5)
-
-| Persist chosen camera and microphone | `done` | Issue #97. New pure `apps/web/src/device-choice-storage.ts` helper: saveDeviceChoice, loadDeviceChoice, clearDeviceChoice. Backed by sessionStorage under `lowtime:device-choice`. The call-page device switcher (#25) is the natural call site; the PR is scoped to the helper so it can land without waiting on the device switcher. | [docs/07-frontend-architecture.md](docs/07-frontend-architecture.md) |
-| Host remove from room page | `done` | Issue #99. New pure `apps/web/src/features/room/use-room-moderation.ts` (buildRoomModeration) wraps the host-remove endpoint. The shared `apps/web/src/host-actions.ts` helper from #27 is vendored into this branch so the call site works without waiting on the #27 PR to land. | [docs/03-room-and-user-flows.md](docs/03-room-and-user-flows.md) |
 
 ## Update Rule For Every PR
 - If a feature changes status, update this file.

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -191,7 +191,6 @@ export function App() {
     p2pError,
     p2pStatus,
     remoteParticipantLabel,
-    remoteVideoRef,
     remoteVideoRefMap,
     remoteVideoTiles,
   } = useCallFlow({

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -192,7 +192,8 @@ export function App() {
     p2pStatus,
     remoteParticipantLabel,
     remoteVideoRef,
-    remoteVideoTrack,
+    remoteVideoRefMap,
+    remoteVideoTiles,
   } = useCallFlow({
     apiBaseUrl,
     setViewState,
@@ -493,7 +494,7 @@ export function App() {
         connectedSfuUrl,
         downgradeRung,
         hasLocalVideo: localVideoTrack != null,
-        hasRemoteVideo: remoteVideoTrack != null,
+        hasRemoteVideo: remoteVideoTiles.length > 0,
         isCameraEnabled,
         isHost,
         isMicEnabled,
@@ -515,7 +516,8 @@ export function App() {
         chatMessages,
         onSendChat: handleSendChat,
         remoteParticipantLabel,
-        remoteVideoRef,
+        remoteVideoRefMap,
+        remoteVideoTiles: remoteVideoTiles.map((tile) => ({ id: tile.id, label: tile.label })),
         slug: viewState.kind === "call" ? viewState.slug : "",
       }}
       homePageProps={{

--- a/apps/web/src/call-experience.test.ts
+++ b/apps/web/src/call-experience.test.ts
@@ -2,12 +2,12 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
-  getActiveScreenShareTrack,
+  getAllVideoParticipants,
   getFirstVideoTrack,
   getParticipant,
   getParticipantLabel,
+  getParticipantVideoTrack,
   getPrimaryParticipant,
-  pickPrimaryVideoTrack,
   type ParticipantLike,
   type VideoTrackLike,
 } from "./call-experience.js";
@@ -92,80 +92,74 @@ test("getFirstVideoTrack ignores muted video tracks", () => {
   assert.equal(getFirstVideoTrack(participant), null);
 });
 
-test("getActiveScreenShareTrack returns null when no screen source is present", () => {
-  const participant: ParticipantLike = {
+test("getAllVideoParticipants returns every remote participant that has a video track", () => {
+  const camera1 = createTrack("video", false, "camera");
+  const camera2 = createTrack("video", false, "camera");
+  const audioOnly = createTrack("audio");
+
+  const p1: ParticipantLike = {
     identity: "sess_1",
-    trackPublications: new Map([
-      ["camera", { track: createTrack("video", false, "camera") }],
-      ["audio", { track: createTrack("audio") }],
-    ]),
+    name: "Alice",
+    trackPublications: new Map([["camera", { track: camera1 }]]),
+  };
+  const p2: ParticipantLike = {
+    identity: "sess_2",
+    name: "Bob",
+    trackPublications: new Map([["camera", { track: camera2 }]]),
+  };
+  const p3: ParticipantLike = {
+    identity: "sess_3",
+    name: "Carol",
+    trackPublications: new Map([["audio", { track: audioOnly }]]),
   };
 
-  assert.equal(getActiveScreenShareTrack(participant), null);
+  const result = getAllVideoParticipants([p1, p2, p3]);
+
+  assert.deepEqual(
+    result.map((p) => p.identity),
+    ["sess_1", "sess_2"],
+  );
 });
 
-test("getActiveScreenShareTrack returns the screen track when present alongside camera", () => {
-  const camera = createTrack("video", false, "camera");
-  const screen = createTrack("video", false, "screen_share");
-
-  const participant: ParticipantLike = {
-    identity: "sess_1",
-    trackPublications: new Map([
-      ["camera", { track: camera }],
-      ["screen", { track: screen }],
-    ]),
-  };
-
-  assert.equal(getActiveScreenShareTrack(participant), screen);
-});
-
-test("getActiveScreenShareTrack ignores muted screen tracks", () => {
-  const mutedScreen = createTrack("video", true, "screen_share");
-
-  const participant: ParticipantLike = {
-    identity: "sess_1",
-    trackPublications: new Map([["screen", { track: mutedScreen }]]),
-  };
-
-  assert.equal(getActiveScreenShareTrack(participant), null);
-});
-
-test("pickPrimaryVideoTrack prefers the screen share over the camera", () => {
-  const camera = createTrack("video", false, "camera");
-  const screen = createTrack("video", false, "screen_share");
-
-  const participant: ParticipantLike = {
-    identity: "sess_1",
-    trackPublications: new Map([
-      ["camera", { track: camera }],
-      ["screen", { track: screen }],
-    ]),
-  };
-
-  assert.equal(pickPrimaryVideoTrack(participant), screen);
-});
-
-test("pickPrimaryVideoTrack falls back to the camera when no screen is active", () => {
-  const camera = createTrack("video", false, "camera");
-
-  const participant: ParticipantLike = {
-    identity: "sess_1",
-    trackPublications: new Map([["camera", { track: camera }]]),
-  };
-
-  assert.equal(pickPrimaryVideoTrack(participant), camera);
-});
-
-test("pickPrimaryVideoTrack returns null when neither screen nor camera is available", () => {
-  const participant: ParticipantLike = {
+test("getAllVideoParticipants returns an empty array when the iterable is empty or all audio-only", () => {
+  assert.deepEqual(getAllVideoParticipants([]), []);
+  const audio: ParticipantLike = {
     identity: "sess_1",
     trackPublications: new Map([["audio", { track: createTrack("audio") }]]),
   };
-
-  assert.equal(pickPrimaryVideoTrack(participant), null);
+  assert.deepEqual(getAllVideoParticipants([audio]), []);
 });
 
-test("pickPrimaryVideoTrack ignores a muted screen share and returns the camera", () => {
+test("getAllVideoParticipants tolerates invalid entries", () => {
+  const camera = createTrack("video", false, "camera");
+  const valid: ParticipantLike = {
+    identity: "sess_1",
+    trackPublications: new Map([["camera", { track: camera }]]),
+  };
+  const result = getAllVideoParticipants([null, { nope: true }, valid]);
+  assert.equal(result.length, 1);
+  assert.equal(result[0]!.identity, "sess_1");
+});
+
+test("getParticipantVideoTrack returns the first attached track for the requested source", () => {
+  const camera = createTrack("video", false, "camera");
+  const screen = createTrack("video", false, "screen_share");
+  const audio = createTrack("audio");
+
+  const participant: ParticipantLike = {
+    identity: "sess_1",
+    trackPublications: new Map([
+      ["audio", { track: audio }],
+      ["camera", { track: camera }],
+      ["screen", { track: screen }],
+    ]),
+  };
+
+  assert.equal(getParticipantVideoTrack(participant, "camera"), camera);
+  assert.equal(getParticipantVideoTrack(participant, "screen_share"), screen);
+});
+
+test("getParticipantVideoTrack returns null when the source is missing or muted", () => {
   const camera = createTrack("video", false, "camera");
   const mutedScreen = createTrack("video", true, "screen_share");
 
@@ -177,9 +171,10 @@ test("pickPrimaryVideoTrack ignores a muted screen share and returns the camera"
     ]),
   };
 
-  assert.equal(pickPrimaryVideoTrack(participant), camera);
+  assert.equal(getParticipantVideoTrack(participant, "screen_share"), null);
+  assert.equal(getParticipantVideoTrack(participant, "microphone"), null);
 });
 
-test("pickPrimaryVideoTrack handles a null participant", () => {
-  assert.equal(pickPrimaryVideoTrack(null), null);
+test("getParticipantVideoTrack handles a null participant", () => {
+  assert.equal(getParticipantVideoTrack(null, "camera"), null);
 });

--- a/apps/web/src/call-experience.ts
+++ b/apps/web/src/call-experience.ts
@@ -3,8 +3,9 @@ export interface VideoTrackLike {
   isMuted?: boolean;
   /**
    * LiveKit track source identifier (`"camera"`, `"screen_share"`, …).
-   * Optional so non-LiveKit test mocks can omit it; production code always
-   * populates it via the `trackPublished` / `localTrackPublished` event payload.
+   * Optional so non-LiveKit test mocks can omit it; production code
+   * populates it via the `trackPublished` / `localTrackPublished`
+   * event payload.
    */
   source?: string;
   attach(element: HTMLMediaElement): HTMLMediaElement;
@@ -63,57 +64,6 @@ export function getFirstVideoTrack(participant: ParticipantLike | null): VideoTr
   return null;
 }
 
-const SCREEN_SHARE_SOURCES = new Set([
-  "screen_share",
-  "screenShare",
-  "screen-share",
-  "screen_video",
-]);
-
-/**
- * Returns the local participant's active screen share video track, or
- * `null` when no screen share is published. Mirrors `getFirstVideoTrack`
- * but filters on the track source so camera and screen share stay
- * distinguishable in the call UI.
- */
-export function getActiveScreenShareTrack(participant: ParticipantLike | null): VideoTrackLike | null {
-  if (participant == null) {
-    return null;
-  }
-
-  for (const publication of participant.trackPublications.values()) {
-    const track = publication.track;
-
-    if (track == null) {
-      continue;
-    }
-
-    if (track.kind !== "video" || track.isMuted === true) {
-      continue;
-    }
-
-    if (track.source != null && SCREEN_SHARE_SOURCES.has(track.source)) {
-      return track;
-    }
-  }
-
-  return null;
-}
-
-/**
- * Returns the track the self-tile should render: the active screen share
- * when present (and not muted), otherwise the camera, otherwise `null`.
- */
-export function pickPrimaryVideoTrack(participant: ParticipantLike | null): VideoTrackLike | null {
-  const screenShare = getActiveScreenShareTrack(participant);
-
-  if (screenShare != null) {
-    return screenShare;
-  }
-
-  return getFirstVideoTrack(participant);
-}
-
 function isParticipantLike(value: unknown): value is ParticipantLike {
   if (typeof value !== "object" || value == null) {
     return false;
@@ -121,4 +71,63 @@ function isParticipantLike(value: unknown): value is ParticipantLike {
 
   const candidate = value as Partial<ParticipantLike>;
   return typeof candidate.identity === "string" && candidate.trackPublications instanceof Map;
+}
+
+/**
+ * Returns every participant in the iterable that publishes at least one
+ * attached (non-muted) video track. Audio-only and muted-video
+ * participants are dropped. Order is preserved.
+ *
+ * Used by the call page to render one tile per remote participant in
+ * group rooms (Issue #29).
+ */
+export function getAllVideoParticipants(
+  participants: Iterable<unknown>,
+): ParticipantLike[] {
+  const result: ParticipantLike[] = [];
+
+  for (const candidate of participants) {
+    if (!isParticipantLike(candidate)) {
+      continue;
+    }
+
+    const hasVideo = Array.from(candidate.trackPublications.values()).some((publication) => {
+      const track = publication.track;
+      return track != null && track.kind === "video" && track.isMuted !== true;
+    });
+
+    if (hasVideo) {
+      result.push(candidate);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Returns the first attached track on a participant whose `source`
+ * matches the requested value, or `null` when no matching track is
+ * published or the only matching track is muted.
+ */
+export function getParticipantVideoTrack(
+  participant: ParticipantLike | null,
+  source: string,
+): VideoTrackLike | null {
+  if (participant == null) {
+    return null;
+  }
+
+  for (const publication of participant.trackPublications.values()) {
+    const track = publication.track;
+
+    if (track == null || track.kind !== "video" || track.isMuted === true) {
+      continue;
+    }
+
+    if (track.source === source) {
+      return track;
+    }
+  }
+
+  return null;
 }

--- a/apps/web/src/features/call/call-effects.ts
+++ b/apps/web/src/features/call/call-effects.ts
@@ -3,10 +3,11 @@ import { useEffect, useRef, useState } from "react";
 import type { MediaTokenResponse } from "@lowtime/shared";
 
 import {
+  getAllVideoParticipants,
   getFirstVideoTrack,
   getParticipant,
   getParticipantLabel,
-  getPrimaryParticipant,
+  type ParticipantLike,
   type VideoTrackLike,
 } from "../../call-experience.js";
 import { connectToSfu } from "../../media-controller.js";
@@ -25,6 +26,30 @@ const DEFAULT_REQUESTED_MEDIA = {
   audio: true,
   video: true,
 } as const;
+
+export interface RemoteVideoTile {
+  id: string;
+  label: string;
+  track: VideoTrackLike;
+}
+
+function buildRemoteTiles(participants: ParticipantLike[]): RemoteVideoTile[] {
+  const tiles: RemoteVideoTile[] = [];
+
+  for (const participant of participants) {
+    const track = getFirstVideoTrack(participant);
+    if (track == null) {
+      continue;
+    }
+    tiles.push({
+      id: participant.identity,
+      label: getParticipantLabel(participant, "Remote"),
+      track,
+    });
+  }
+
+  return tiles;
+}
 
 interface UseCallFlowInput {
   apiBaseUrl: string;
@@ -50,7 +75,7 @@ export function useCallFlow(input: UseCallFlowInput) {
   const [isTogglingMic, setIsTogglingMic] = useState(false);
   const [isTogglingCamera, setIsTogglingCamera] = useState(false);
   const [localVideoTrack, setLocalVideoTrack] = useState<VideoTrackLike | null>(null);
-  const [remoteVideoTrack, setRemoteVideoTrack] = useState<VideoTrackLike | null>(null);
+  const [remoteVideoTiles, setRemoteVideoTiles] = useState<RemoteVideoTile[]>([]);
   const [remoteParticipantLabel, setRemoteParticipantLabel] = useState<string>("Waiting for someone to join");
   const [localStream, setLocalStream] = useState<MediaStream | null>(null);
   const [isRemovingParticipant, setIsRemovingParticipant] = useState<string | null>(null);
@@ -59,6 +84,7 @@ export function useCallFlow(input: UseCallFlowInput) {
   const [callRoom, setCallRoom] = useState<Awaited<ReturnType<typeof connectToSfu>> | null>(null);
   const localVideoRef = useRef<HTMLVideoElement | null>(null);
   const remoteVideoRef = useRef<HTMLVideoElement | null>(null);
+  const remoteVideoRefMap = useRef<Map<string, HTMLVideoElement | null>>(new Map());
 
   const slug = input.viewState.kind === "call" ? input.viewState.slug : "";
   const sessionId = callSession?.sessionId ?? "";
@@ -98,7 +124,7 @@ export function useCallFlow(input: UseCallFlowInput) {
       setIsTogglingMic(false);
       setIsTogglingCamera(false);
       setLocalVideoTrack(null);
-      setRemoteVideoTrack(null);
+      setRemoteVideoTiles([]);
       setRemoteParticipantLabel("Waiting for someone to join");
       setLocalStream(null);
       callRoomRef.current?.disconnect();
@@ -138,19 +164,23 @@ export function useCallFlow(input: UseCallFlowInput) {
   }, [localVideoTrack]);
 
   useEffect(() => {
-    const videoElement = remoteVideoRef.current;
+    const attached: Array<{ track: VideoTrackLike; element: HTMLVideoElement }> = [];
 
-    if (videoElement == null || remoteVideoTrack == null) {
-      return;
+    for (const tile of remoteVideoTiles) {
+      const element = remoteVideoRefMap.current.get(tile.id);
+      if (element == null) {
+        continue;
+      }
+      tile.track.attach(element);
+      attached.push({ track: tile.track, element });
     }
 
-    const attachedTrack = remoteVideoTrack;
-    attachedTrack.attach(videoElement);
-
     return () => {
-      attachedTrack.detach(videoElement);
+      for (const entry of attached) {
+        entry.track.detach(entry.element);
+      }
     };
-  }, [remoteVideoTrack]);
+  }, [remoteVideoTiles]);
 
   useEffect(() => {
     if (input.viewState.kind !== "call" || callSession == null) {
@@ -250,18 +280,20 @@ export function useCallFlow(input: UseCallFlowInput) {
         }
 
         const syncCallPresentation = () => {
-          const nextRemoteParticipant = getPrimaryParticipant(room.remoteParticipants.values());
-          const nextLocalParticipant = getParticipant(room.localParticipant);
+          const remoteParticipants = Array.from(room.remoteParticipants.values()) as ParticipantLike[];
+          const remoteVideoList = getAllVideoParticipants(remoteParticipants);
+          const nextRemoteParticipant = remoteVideoList[0] ?? null;
+          const nextLocalParticipant = getParticipant(room.localParticipant) as ParticipantLike | null;
 
           setCallParticipants(room.remoteParticipants.size + 1);
           setLocalVideoTrack(getFirstVideoTrack(nextLocalParticipant));
-          setRemoteVideoTrack(getFirstVideoTrack(nextRemoteParticipant));
+          setRemoteVideoTiles(buildRemoteTiles(remoteVideoList));
           setRemoteParticipantLabel(getParticipantLabel(nextRemoteParticipant, "Waiting for someone to join"));
         };
 
         const handleDisconnected = () => {
           setCallStatus("idle");
-          setRemoteVideoTrack(null);
+          setRemoteVideoTiles([]);
           setLocalVideoTrack(null);
           setRemoteParticipantLabel("Waiting for someone to join");
         };
@@ -422,7 +454,8 @@ export function useCallFlow(input: UseCallFlowInput) {
     p2pStatus: p2pFallback.p2pStatus,
     remoteParticipantLabel,
     remoteVideoRef,
-    remoteVideoTrack,
+    remoteVideoRefMap,
+    remoteVideoTiles,
   };
 }
 

--- a/apps/web/src/features/call/call-page.tsx
+++ b/apps/web/src/features/call/call-page.tsx
@@ -50,7 +50,8 @@ interface CallPageProps {
   networkHealth: NetworkHealth;
   participants: RoomParticipant[];
   remoteParticipantLabel: string;
-  remoteVideoRef: RefObject<HTMLVideoElement | null>;
+  remoteVideoRefMap: RefObject<Map<string, HTMLVideoElement | null>>;
+  remoteVideoTiles: { id: string; label: string }[];
   slug: string;
   downgradeRung: DowngradeRung;
   audioOnlyPromptState: PromptState;
@@ -126,24 +127,67 @@ export function CallPage(props: CallPageProps) {
         <section style={callLayoutStyle}>
           <section style={remoteTileStyle}>
             <div style={tileHeaderStyle}>
-              <h2 style={tileHeadingStyle}>Remote</h2>
-              <span>{props.remoteParticipantLabel}</span>
+              <h2 style={tileHeadingStyle}>
+                {props.remoteVideoTiles.length > 1 ? "Remotes" : "Remote"}
+              </h2>
+              <span>
+                {props.remoteVideoTiles.length > 0
+                  ? `${props.remoteVideoTiles.length} ${
+                      props.remoteVideoTiles.length === 1 ? "camera" : "cameras"
+                    } • ${props.remoteParticipantLabel}`
+                  : props.remoteParticipantLabel}
+              </span>
             </div>
-            {props.hasRemoteVideo ? (
-              <video
-                ref={props.remoteVideoRef}
-                autoPlay
-                playsInline
-                style={remoteVideoStyle}
-              />
-            ) : (
+            {props.remoteVideoTiles.length === 0 ? (
               <div style={tilePlaceholderStyle}>
                 <strong>{props.remoteParticipantLabel}</strong>
                 <p style={mutedParagraphStyle}>
                   {props.callStatus === "connected" || isP2PConnected
-                    ? "No remote camera is visible yet."
+                    ? props.callParticipants > 1
+                      ? "Other participants have not turned their cameras on yet."
+                      : "No remote camera is visible yet."
                     : "Connecting the first call experience..."}
                 </p>
+              </div>
+            ) : (
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns:
+                    props.remoteVideoTiles.length === 1
+                      ? "1fr"
+                      : props.remoteVideoTiles.length === 2
+                        ? "repeat(2, 1fr)"
+                        : "repeat(auto-fit, minmax(12rem, 1fr))",
+                  gap: "0.5rem",
+                  width: "100%",
+                }}
+              >
+                {props.remoteVideoTiles.map((tile) => (
+                  <figure
+                    key={tile.id}
+                    style={{
+                      margin: 0,
+                      display: "grid",
+                      gap: "0.25rem",
+                    }}
+                  >
+                    <video
+                      ref={(element) => {
+                        const map = props.remoteVideoRefMap.current;
+                        if (element == null) {
+                          map.delete(tile.id);
+                        } else {
+                          map.set(tile.id, element);
+                        }
+                      }}
+                      autoPlay
+                      playsInline
+                      style={remoteVideoStyle}
+                    />
+                    <figcaption style={mutedParagraphStyle}>{tile.label}</figcaption>
+                  </figure>
+                ))}
               </div>
             )}
           </section>


### PR DESCRIPTION
Cherry-picks the #93 commits onto clean main. Local lint+typecheck+tests pass.